### PR TITLE
Feat: add callback function to trigger method

### DIFF
--- a/docs/en/api/wrapper-array/trigger.md
+++ b/docs/en/api/wrapper-array/trigger.md
@@ -1,7 +1,8 @@
-# trigger(eventName)
+# trigger(eventName, process)
 
 - **Arguments:**
-  - `{string} eventName
+  - `{string} eventName`
+  - `{string} process` - optional callback allowing to modify event object
 
 - **Usage:**
 

--- a/docs/en/api/wrapper-array/trigger.md
+++ b/docs/en/api/wrapper-array/trigger.md
@@ -2,7 +2,7 @@
 
 - **Arguments:**
   - `{string} eventName`
-  - `{string} process` - optional callback allowing to modify event object
+  - `{Function} process` - optional callback allowing to modify event object
 
 - **Usage:**
 

--- a/docs/en/api/wrapper/trigger.md
+++ b/docs/en/api/wrapper/trigger.md
@@ -1,7 +1,8 @@
-# trigger(eventName)
+# trigger(eventName, process)
 
 - **Arguments:**
   - `{string} eventName`
+  - `{string} process` - optional callback allowing to modify event object
 
 - **Usage:**
 
@@ -13,12 +14,19 @@ import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo'
 
-const clickHandler = sinon.stub()
+const keydownHandler = sinon.stub()
 const wrapper = mount(Foo, {
-  propsData: { clickHandler }
+  propsData: { keydownHandler }
 })
 
-wrapper.trigger('click')
+const input = wrapper.find('input')
 
-expect(clickHandler.called).to.equal(true)
+// fails
+input.trigger('keydown')
+// passes
+input.trigger('keydown', (e) => {
+  e.key = 'Escape'
+})
+
+expect(keydownHandler.calledOnce).to.equal(true)
 ```

--- a/docs/en/api/wrapper/trigger.md
+++ b/docs/en/api/wrapper/trigger.md
@@ -2,7 +2,7 @@
 
 - **Arguments:**
   - `{string} eventName`
-  - `{string} process` - optional callback allowing to modify event object
+  - `{Function} process` - optional callback allowing to modify event object
 
 - **Usage:**
 

--- a/flow/wrapper.js
+++ b/flow/wrapper.js
@@ -20,7 +20,7 @@ declare interface BaseWrapper { // eslint-disable-line no-undef
     text(): string | void,
     setData(data: Object): void,
     setProps(data: Object): void,
-    trigger(type: string): void,
+    trigger(type: string, process?: Function): void,
     update(): void
 }
 

--- a/src/wrappers/wrapper-array.js
+++ b/src/wrappers/wrapper-array.js
@@ -116,10 +116,10 @@ export default class WrapperArray implements BaseWrapper {
     this.wrappers.forEach(wrapper => wrapper.setProps(props))
   }
 
-  trigger (event: string): void {
+  trigger (event: string, process?: Function): void {
     this.throwErrorIfWrappersIsEmpty('trigger')
 
-    this.wrappers.forEach(wrapper => wrapper.trigger(event))
+    this.wrappers.forEach(wrapper => wrapper.trigger(event, process))
   }
 
   update (): void {

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -276,7 +276,7 @@ export default class Wrapper implements BaseWrapper {
   /**
    * Dispatches a DOM event on wrapper
    */
-  trigger (type: string) {
+  trigger (type: string, process?: Function) {
     if (typeof type !== 'string') {
       throwError('wrapper.trigger() must be passed a string')
     }
@@ -299,6 +299,10 @@ export default class Wrapper implements BaseWrapper {
 
     if (event.length === 2) {
       eventObject.keyCode = modifiers[event[1]]
+    }
+
+    if (typeof process === 'function') {
+      process(eventObject)
     }
 
     this.element.dispatchEvent(eventObject)

--- a/test/integration/specs/mount/Wrapper/trigger.spec.js
+++ b/test/integration/specs/mount/Wrapper/trigger.spec.js
@@ -52,4 +52,19 @@ describe('trigger', () => {
       expect(fn).to.throw().with.property('message', message)
     })
   })
+
+  it('trigger with the callback function', () => {
+    const clickHandler = sinon.stub()
+    const wrapper = mount(ComponentWithEvents, {
+      propsData: { clickHandler }
+    })
+    const button = wrapper.find('.left-click')
+
+    button.trigger('mousedown')
+    button.trigger('mousedown', (e) => {
+      e.button = 0
+    })
+
+    expect(clickHandler.calledOnce).to.equal(true)
+  })
 })

--- a/test/resources/components/component-with-events.vue
+++ b/test/resources/components/component-with-events.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <button class="click" @click="clickHandler" id="button" />
-        <button class="left-click-" @mousedown="mousedownHandler" />
+        <button class="left-click" @mousedown="mousedownHandler" />
         <div @click="toggleActive" v-bind:class="{ toggle: true, active: isActive }" />
         <input class="keydown" type="text" @keydown="keydownHandler" />
         <input class="keydown-enter" type="text" @keydown.enter="keydownHandler" />

--- a/test/resources/components/component-with-events.vue
+++ b/test/resources/components/component-with-events.vue
@@ -1,6 +1,7 @@
 <template>
     <div>
         <button class="click" @click="clickHandler" id="button" />
+        <button class="left-click-" @mousedown="mousedownHandler" />
         <div @click="toggleActive" v-bind:class="{ toggle: true, active: isActive }" />
         <input class="keydown" type="text" @keydown="keydownHandler" />
         <input class="keydown-enter" type="text" @keydown.enter="keydownHandler" />
@@ -26,6 +27,11 @@
         }
       },
       methods: {
+        mousedownHandler (event) {
+          if (event.button === 0) {
+            this.clickHandler()
+          }
+        },
         toggleActive () {
           this.isActive = !this.isActive
         }


### PR DESCRIPTION
Sometimes when testing our components, default Vue event modifiers may be insufficient so we need to have a way to modify event object before it gets dispatched. 