### PR TITLE
feat(types): add typescript declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "0.1.0",
   "description": "Utilities for testing Vue components.",
   "main": "dist/vue-test-utils.js",
+  "types": "types/index.d.ts",
   "files": [
     "src",
-    "dist/*.js"
+    "dist/*.js",
+    "types/index.d.ts"
   ],
   "scripts": {
     "build": "node build/build.js",
@@ -16,10 +18,11 @@
     "lint:docs": "eslint --ext js,vue,md docs --ignore-path .gitignore",
     "lint:fix": "npm run lint -- --fix",
     "postinstall": "node build/install-hooks.js",
-    "test": "npm run lint && npm run lint:docs && npm run flow && npm run test:unit && npm run test:integration && npm run test:integration:karma",
+    "test": "npm run lint && npm run lint:docs && npm run flow && npm run test:types && npm run test:unit && npm run test:integration && npm run test:integration:karma",
     "test:integration": "cross-env BABEL_ENV=test mocha-webpack --webpack-config build/webpack.test.config.js test/integration/specs --recursive --require test/integration/setup/mocha.setup.js",
     "test:integration:karma": "cross-env BABEL_ENV=test TARGET=browser karma start test/integration/setup/karma.conf.js --single-run",
     "test:unit": "cross-env BABEL_ENV=test mocha-webpack --webpack-config build/webpack.test.config.js test/unit/specs --recursive --require test/unit/setup/mocha.setup.js",
+    "test:types": "tsc -p types",
     "release": "bash build/release.sh",
     "release:note": "node build/gen-release-note.js"
   },
@@ -72,6 +75,7 @@
     "shelljs": "^0.7.8",
     "sinon": "^2.3.2",
     "sinon-chai": "^2.10.0",
+    "typescript": "^2.4.1",
     "vue": "^2.3.3",
     "vue-loader": "^12.2.1",
     "vue-router": "^2.6.0",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,8 +53,15 @@ interface Wrapper<V extends Vue> extends BaseWrapper {
   readonly element: HTMLElement
   readonly options: WrapperOptions
 
-  find<R extends Vue> (selector: Selector): Wrapper<R>
-  findAll<R extends Vue> (selector: Selector): WrapperArray<R>
+  find<R extends Vue, Ctor extends VueClass<R> = VueClass<R>> (selector: Ctor): Wrapper<R>
+  find<R extends Vue> (selector: ComponentOptions<R>): Wrapper<R>
+  find (selector: FunctionalComponentOptions): Wrapper<Vue>
+  find (selector: string): Wrapper<Vue>
+
+  findAll<R extends Vue, Ctor extends VueClass<R> = VueClass<R>> (selector: Ctor): WrapperArray<R>
+  findAll<R extends Vue> (selector: ComponentOptions<R>): WrapperArray<R>
+  findAll (selector: FunctionalComponentOptions): WrapperArray<Vue>
+  findAll (selector: string): WrapperArray<Vue>
 
   html (): string
   text (): string

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,7 +22,7 @@ type Slots = {
  * If it is an array of string, the specified children are replaced by blank components
  */
 type Stubs = {
-  [key: string]: Component | string | boolean
+  [key: string]: Component | string | true
 } | string[]
 
 /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,17 +54,17 @@ interface Wrapper<V extends Vue> extends BaseWrapper {
   readonly options: WrapperOptions
 
   find<R extends Vue> (selector: Selector): Wrapper<R>
-  findAll (selector: Selector): WrapperArray
+  findAll<R extends Vue> (selector: Selector): WrapperArray<R>
 
   html (): string
   text (): string
   name (): string
 }
 
-interface WrapperArray extends BaseWrapper {
+interface WrapperArray<V extends Vue> extends BaseWrapper {
   readonly length: number
 
-  at<V extends Vue> (index: number): Wrapper<V>
+  at (index: number): Wrapper<V>
 }
 
 interface WrapperOptions {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,94 @@
+import Vue, { VNodeData, Component, ComponentOptions, FunctionalComponentOptions } from 'vue'
+
+/**
+ * Utility type to declare an extended Vue constructor
+ */
+type VueClass<V extends Vue> = (new (...args: any[]) => V) & typeof Vue
+
+/**
+ * Utility type for a selector
+ */
+type Selector = string | Component
+
+/**
+ * Utility type for slots
+ */
+type Slots = {
+  [key: string]: (Component | string)[] | Component | string
+}
+
+/**
+ * Utility type for stubs which can be a string of template as a shorthand
+ * If it is an array of string, the specified children are replaced by blank components
+ */
+type Stubs = {
+  [key: string]: Component | string | boolean
+} | string[]
+
+/**
+ * Base class of Wrapper and WrapperArray
+ * It has common methods on both Wrapper and WrapperArray
+ */
+interface BaseWrapper {
+  contains (selector: Selector): boolean
+  exists (): boolean
+
+  hasAttribute (attribute: string, value: string): boolean
+  hasClass (className: string): boolean
+  hasProp (prop: string, value: any): boolean
+  hasStyle (style: string, value: string): boolean
+
+  is (selector: Selector): boolean
+  isEmpty (): boolean
+  isVueInstance (): boolean
+
+  update (): void
+  setData (data: object): void
+  setProps (props: object): void
+  trigger (eventName: string, options?: object): void
+}
+
+interface Wrapper<V extends Vue> extends BaseWrapper {
+  readonly vm: V
+  readonly element: HTMLElement
+  readonly options: WrapperOptions
+
+  find<R extends Vue> (selector: Selector): Wrapper<R>
+  findAll (selector: Selector): WrapperArray
+
+  html (): string
+  text (): string
+  name (): string
+}
+
+interface WrapperArray extends BaseWrapper {
+  readonly length: number
+
+  at<V extends Vue> (index: number): Wrapper<V>
+}
+
+interface WrapperOptions {
+  attachedToDocument: boolean
+}
+
+interface MountOptions<V extends Vue> extends ComponentOptions<V> {
+  attachToDocument?: boolean
+  clone?: boolean
+  context?: VNodeData
+  localVue?: typeof Vue
+  intercept?: object
+  slots?: Slots
+  stub?: Stubs
+}
+
+type ShallowOptions<V extends Vue> = MountOptions<V>
+
+export declare function createLocalVue (): typeof Vue
+
+export declare function mount<V extends Vue, Ctor extends VueClass<V> = VueClass<V>> (component: Ctor, options?: MountOptions<V>): Wrapper<V>
+export declare function mount<V extends Vue> (component: ComponentOptions<V>, options?: MountOptions<V>): Wrapper<V>
+export declare function mount (component: FunctionalComponentOptions, options?: MountOptions<Vue>): Wrapper<Vue>
+
+export declare function shallow<V extends Vue, Ctor extends VueClass<V> = VueClass<V>> (component: Ctor, options?: ShallowOptions<V>): Wrapper<V>
+export declare function shallow<V extends Vue> (component: ComponentOptions<V>, options?: ShallowOptions<V>): Wrapper<V>
+export declare function shallow (component: FunctionalComponentOptions, options?: ShallowOptions<Vue>): Wrapper<Vue>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -85,7 +85,7 @@ interface MountOptions<V extends Vue> extends ComponentOptions<V> {
   localVue?: typeof Vue
   intercept?: object
   slots?: Slots
-  stub?: Stubs
+  stubs?: Stubs
 }
 
 type ShallowOptions<V extends Vue> = MountOptions<V>

--- a/types/test/mount.ts
+++ b/types/test/mount.ts
@@ -34,7 +34,7 @@ mount<ClassComponent>(ClassComponent, {
     foo: [normalOptions, functionalOptions],
     bar: ClassComponent
   },
-  stub: {
+  stubs: {
     foo: normalOptions,
     bar: functionalOptions,
     baz: ClassComponent,
@@ -46,7 +46,7 @@ mount(functionalOptions, {
   context: {
     props: { foo: 'test' }
   },
-  stub: ['child']
+  stubs: ['child']
 })
 
 /**

--- a/types/test/mount.ts
+++ b/types/test/mount.ts
@@ -1,0 +1,62 @@
+import Vuex from 'vuex'
+import { mount, createLocalVue } from '../'
+import { normalOptions, functionalOptions, Normal, ClassComponent } from './resources'
+
+/**
+ * Should create wrapper vm based on (function) component options or constructors
+ * The users can specify component type via the type parameter
+ */
+const normalWrapper = mount<Normal>(normalOptions)
+const normalFoo: string = normalWrapper.vm.foo
+
+const classWrapper = mount<ClassComponent>(ClassComponent)
+const classFoo: string = classWrapper.vm.bar
+
+const functinalWrapper = mount(functionalOptions)
+
+/**
+ * Test for mount options
+ */
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+const store = new Vuex.Store({})
+
+mount<ClassComponent>(ClassComponent, {
+  attachToDocument: true,
+  clone: true,
+  localVue,
+  intercept: {
+    $store: store
+  },
+  slots: {
+    default: `<div>Foo</div>`,
+    foo: [normalOptions, functionalOptions],
+    bar: ClassComponent
+  },
+  stub: {
+    foo: normalOptions,
+    bar: functionalOptions,
+    baz: ClassComponent,
+    qux: `<div>Test</div>`
+  }
+})
+
+mount(functionalOptions, {
+  context: {
+    props: { foo: 'test' }
+  },
+  stub: ['child']
+})
+
+/**
+ * MountOptions should receive Vue's component options
+ */
+mount<ClassComponent>(ClassComponent, {
+  propsData: {
+    test: 'test'
+  },
+  created () {
+    this.bar
+  }
+})

--- a/types/test/mount.ts
+++ b/types/test/mount.ts
@@ -6,7 +6,7 @@ import { normalOptions, functionalOptions, Normal, ClassComponent } from './reso
  * Should create wrapper vm based on (function) component options or constructors
  * The users can specify component type via the type parameter
  */
-const normalWrapper = mount<Normal>(normalOptions)
+const normalWrapper = mount(normalOptions)
 const normalFoo: string = normalWrapper.vm.foo
 
 const classWrapper = mount<ClassComponent>(ClassComponent)

--- a/types/test/resources.ts
+++ b/types/test/resources.ts
@@ -1,0 +1,33 @@
+import Vue, { ComponentOptions, FunctionalComponentOptions } from 'vue'
+
+/**
+ * Normal component options
+ */
+export interface Normal extends Vue {
+  foo: string
+}
+export const normalOptions: ComponentOptions<Normal> = {
+  name: 'normal',
+  data () {
+    return {
+      foo: 'bar'
+    }
+  }
+}
+
+/**
+ * Functional component options
+ */
+export const functionalOptions: FunctionalComponentOptions = {
+  functional: true,
+  render (h) {
+    return h('div')
+  }
+}
+
+/**
+ * Component constructor declared with vue-class-component etc.
+ */
+export class ClassComponent extends Vue {
+  bar = 'bar'
+}

--- a/types/test/shallow.ts
+++ b/types/test/shallow.ts
@@ -6,7 +6,7 @@ import { normalOptions, functionalOptions, Normal, ClassComponent } from './reso
  * Should create wrapper vm based on (function) component options or constructors
  * The users can specify component type via the type parameter
  */
-const normalWrapper = shallow<Normal>(normalOptions)
+const normalWrapper = shallow(normalOptions)
 const normalFoo: string = normalWrapper.vm.foo
 
 const classWrapper = shallow<ClassComponent>(ClassComponent)

--- a/types/test/shallow.ts
+++ b/types/test/shallow.ts
@@ -1,0 +1,62 @@
+import Vuex from 'vuex'
+import { shallow, createLocalVue } from '../'
+import { normalOptions, functionalOptions, Normal, ClassComponent } from './resources'
+
+/**
+ * Should create wrapper vm based on (function) component options or constructors
+ * The users can specify component type via the type parameter
+ */
+const normalWrapper = shallow<Normal>(normalOptions)
+const normalFoo: string = normalWrapper.vm.foo
+
+const classWrapper = shallow<ClassComponent>(ClassComponent)
+const classFoo: string = classWrapper.vm.bar
+
+const functinalWrapper = shallow(functionalOptions)
+
+/**
+ * Test for shallow options
+ */
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+const store = new Vuex.Store({})
+
+shallow<ClassComponent>(ClassComponent, {
+  attachToDocument: true,
+  clone: true,
+  localVue,
+  intercept: {
+    $store: store
+  },
+  slots: {
+    default: `<div>Foo</div>`,
+    foo: [normalOptions, functionalOptions],
+    baz: ClassComponent
+  },
+  stub: {
+    foo: normalOptions,
+    bar: functionalOptions,
+    baz: ClassComponent,
+    qux: `<div>Test</div>`
+  }
+})
+
+shallow(functionalOptions, {
+  context: {
+    props: { foo: 'test' }
+  },
+  stub: ['child']
+})
+
+/**
+ * ShallowOptions should receive Vue's component options
+ */
+shallow<ClassComponent>(ClassComponent, {
+  propsData: {
+    test: 'test'
+  },
+  created () {
+    this.bar
+  }
+})

--- a/types/test/shallow.ts
+++ b/types/test/shallow.ts
@@ -34,7 +34,7 @@ shallow<ClassComponent>(ClassComponent, {
     foo: [normalOptions, functionalOptions],
     baz: ClassComponent
   },
-  stub: {
+  stubs: {
     foo: normalOptions,
     bar: functionalOptions,
     baz: ClassComponent,
@@ -46,7 +46,7 @@ shallow(functionalOptions, {
   context: {
     props: { foo: 'test' }
   },
-  stub: ['child']
+  stubs: ['child']
 })
 
 /**

--- a/types/test/wrapper.ts
+++ b/types/test/wrapper.ts
@@ -39,7 +39,7 @@ let el: HTMLElement = wrapper.element
 bool = wrapper.options.attachedToDocument
 
 wrapper = wrapper.find('.foo')
-let array = wrapper.findAll('.bar')
+let array = wrapper.findAll<Normal>(normalOptions)
 
 let str: string = wrapper.html()
 str = wrapper.text()

--- a/types/test/wrapper.ts
+++ b/types/test/wrapper.ts
@@ -1,5 +1,5 @@
 import { mount } from '../'
-import { normalOptions, Normal, ClassComponent } from './resources'
+import { normalOptions, functionalOptions, Normal, ClassComponent } from './resources'
 
 /**
  * Tests for BaseWrapper API
@@ -38,8 +38,15 @@ let el: HTMLElement = wrapper.element
 
 bool = wrapper.options.attachedToDocument
 
-wrapper = wrapper.find('.foo')
-let array = wrapper.findAll<Normal>(normalOptions)
+let found = wrapper.find('.foo')
+found = wrapper.find(normalOptions)
+found = wrapper.find(functionalOptions)
+found = wrapper.find<ClassComponent>(ClassComponent)
+
+let array = wrapper.findAll('.bar')
+array = wrapper.findAll(normalOptions)
+array = wrapper.findAll(functionalOptions)
+array = wrapper.findAll<ClassComponent>(ClassComponent)
 
 let str: string = wrapper.html()
 str = wrapper.text()
@@ -49,4 +56,4 @@ str = wrapper.name()
  * Tests for WrapperArray API
  */
 let num: number = array.length
-wrapper = array.at(1)
+found = array.at(1)

--- a/types/test/wrapper.ts
+++ b/types/test/wrapper.ts
@@ -1,0 +1,52 @@
+import { mount } from '../'
+import { normalOptions, Normal, ClassComponent } from './resources'
+
+/**
+ * Tests for BaseWrapper API
+ */
+let wrapper = mount<Normal>(normalOptions)
+
+let bool: boolean = wrapper.contains('.foo')
+bool = wrapper.contains(normalOptions)
+bool = wrapper.contains(ClassComponent)
+
+bool = wrapper.exists()
+
+bool = wrapper.hasAttribute('foo', 'bar')
+bool = wrapper.hasClass('foo-class')
+bool = wrapper.hasProp('checked', true)
+bool = wrapper.hasStyle('color', 'red')
+
+bool = wrapper.is(normalOptions)
+bool = wrapper.isEmpty()
+bool = wrapper.isVueInstance()
+
+wrapper.update()
+wrapper.setData({ foo: 'bar' })
+wrapper.setProps({ checked: true })
+wrapper.trigger('mousedown.enter', {
+  preventDefault: true
+})
+
+/**
+ * Tests for Wrapper API
+ */
+wrapper.vm.foo
+wrapper.vm.$emit('event', 'arg')
+
+let el: HTMLElement = wrapper.element
+
+bool = wrapper.options.attachedToDocument
+
+wrapper = wrapper.find('.foo')
+let array = wrapper.findAll('.bar')
+
+let str: string = wrapper.html()
+str = wrapper.text()
+str = wrapper.name()
+
+/**
+ * Tests for WrapperArray API
+ */
+let num: number = array.length
+wrapper = array.at(1)

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "es2015",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": [
+    "**/*.ts"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6342,6 +6342,10 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
+
 uglify-js@^2.6, uglify-js@^2.8.27:
   version "2.8.27"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.27.tgz#47787f912b0f242e5b984343be8e35e95f694c9c"


### PR DESCRIPTION
This PR adds TypeScript declarations of vue-test-utils.
I wrote these declarations by reading the current docs and implementation but not sure that the declaration is correct. So please let me know if somethings are wrong 😉 

It would be easier to confirm by seeing test files under `types/test`. They include actual usage of vue-test-utils API in TypeScript.

@HerringtonDarkholme It would be appreciated if you can review this PR 🙂 

### Directory structure

- `types/`
  - `index.d.ts` All declarations of vue-test-utils are in this file. This should be published in npm.
  - `tsconfig.json` TS compiler options are defined in this file
  - `test/` includes test files for typings

### Allow annotating type for `mount`/`shallow`

One of challenge when using vue-test-utils would be how to declare `wrapper.vm` to an actual component type. For example, if we simply declare it as `Vue`, we cannot test component properties/methods since they are not declared in `Vue`.

```ts
@Component
class SomeComponent extends Vue {
  foo = 'bar'
}

const wrapper = mount(SomeComponent)
assert(wrapper.vm.foo === 'bar') // This throws a compile error
```

To solve this, I declared `mount`/`shallow` type that can be receive a component type via generics.

```ts
@Component
class SomeComponent extends Vue {
  foo = 'bar'
}

const wrapper = mount<SomeComponent>(SomeComponent)
assert(wrapper.vm.foo === 'bar') // This passes compiler type checking

const anyWrapper = mount<any>(SomeComponent) // We can use `any` type if we don't have appropriate type
assert(wrapper.vm.someOtherProperty === 'baz')

// Wrapper#find and Wrapper#findAll can receive a type parameter as well
const found = wrapper.find<SomeComponent>(SomeComponent)
const list = wrapper.findAll<SomeComponent>(SomeComponent)
```

### Added npm script to test typings

I've added `npm run test:types` to run the typings test. It also be included in `npm run test`.
