### PR TITLE
fix(docs): correct docs/api links

### DIFF
--- a/docs/en/api/README.md
+++ b/docs/en/api/README.md
@@ -1,3 +1,3 @@
-## [mount](/docs/en/api/mount.md)
-## [shallow](/docs/en/api/shallow/README.md)
-## [selectors](/docs/en/api/selectors.md)
+## [mount](/api/mount.md)
+## [shallow](/api/shallow.md)
+## [selectors](/api/selectors.md)


### PR DESCRIPTION
Before this PR, the links are 404.