### PR TITLE
Add vue-test-utils.vuejs.org CNAME

### DIFF
--- a/docs/assets/CNAME
+++ b/docs/assets/CNAME
@@ -1,0 +1,1 @@
+vue-test-utils.vuejs.org


### PR DESCRIPTION
This file is needed to deploy to `vue-test-utils.vuejs.org` - the DNS is already set up.