### PR TITLE
Add checks for wrapper.element

### DIFF
--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -77,7 +77,8 @@ export default class Wrapper implements BaseWrapper {
       throwError('wrapper.hasClass() must be passed a string')
     }
 
-    return this.element.className.split(' ').indexOf(className) !== -1
+    return !!(this.element &&
+    this.element.className.split(' ').indexOf(className) !== -1)
   }
 
   /**

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -312,6 +312,10 @@ export default class Wrapper implements BaseWrapper {
    * Return text of wrapper element
    */
   text (): string {
+    if (!this.element) {
+      throwError('cannot call wrapper.text() on a wrapper without an element')
+    }
+
     return this.element.textContent
   }
 

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -217,7 +217,10 @@ export default class Wrapper implements BaseWrapper {
       }
       return vmCtorMatchesName(this.vm, selector.name)
     }
-    return this.element.getAttribute && this.element.matches(selector)
+
+    return !!(this.element &&
+    this.element.getAttribute &&
+    this.element.matches(selector))
   }
 
   /**

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -66,7 +66,7 @@ export default class Wrapper implements BaseWrapper {
       throwError('wrapper.hasAttribute() must be passed value as a string')
     }
 
-    return this.element && this.element.getAttribute(attribute) === value
+    return !!(this.element && this.element.getAttribute(attribute) === value)
   }
 
   /**

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -327,6 +327,10 @@ export default class Wrapper implements BaseWrapper {
       throwError('wrapper.trigger() must be passed a string')
     }
 
+    if (!this.element) {
+      throwError('cannot call wrapper.trigger() on a wrapper without an element')
+    }
+
     const modifiers = {
       enter: 13,
       tab: 9,

--- a/test/unit/specs/mount/Wrapper/hasAttribute.spec.js
+++ b/test/unit/specs/mount/Wrapper/hasAttribute.spec.js
@@ -16,6 +16,13 @@ describe('hasAttribute', () => {
     expect(wrapper.hasAttribute('attribute', 'value')).to.equal(false)
   })
 
+  it('returns false if wrapper element is null', () => {
+    const compiled = compileToFunctions('<div />')
+    const wrapper = mount(compiled)
+    wrapper.element = null
+    expect(wrapper.hasAttribute('attribute', 'value')).to.equal(false)
+  })
+
   it('throws an error if attribute is not a string', () => {
     const compiled = compileToFunctions('<div />')
     const wrapper = mount(compiled)

--- a/test/unit/specs/mount/Wrapper/hasClass.spec.js
+++ b/test/unit/specs/mount/Wrapper/hasClass.spec.js
@@ -14,6 +14,19 @@ describe('hasClass', () => {
     expect(wrapper.hasClass('not-class-name')).to.equal(false)
   })
 
+  it('returns false if wrapper includes class name in string, but not as a seperate class', () => {
+    const compiled = compileToFunctions('<div class="class-name-together"/>')
+    const wrapper = mount(compiled)
+    expect(wrapper.hasClass('class-name')).to.equal(false)
+  })
+
+  it('returns false if wrapper does not have an element', () => {
+    const compiled = compileToFunctions('<div />')
+    const wrapper = mount(compiled)
+    wrapper.element = null
+    expect(wrapper.hasClass('not-class-name')).to.equal(false)
+  })
+
   it('throws an error if selector is not a string', () => {
     const compiled = compileToFunctions('<div />')
     const wrapper = mount(compiled)

--- a/test/unit/specs/mount/Wrapper/is.spec.js
+++ b/test/unit/specs/mount/Wrapper/is.spec.js
@@ -22,6 +22,12 @@ describe('is', () => {
     expect(wrapper.is('#div')).to.equal(true)
   })
 
+  it('returns false if wrapper does not contain element', () => {
+    const wrapper = mount(ComponentWithChild)
+    wrapper.element = null
+    expect(wrapper.is('a')).to.equal(false)
+  })
+
   it('returns true if root node matches Vue Component selector', () => {
     const wrapper = mount(ComponentWithChild)
     const component = wrapper.findAll(Component).at(0)

--- a/test/unit/specs/mount/Wrapper/text.spec.js
+++ b/test/unit/specs/mount/Wrapper/text.spec.js
@@ -10,7 +10,7 @@ describe('text', () => {
     expect(wrapper.text()).to.equal(text)
   })
 
-  it('throws error if wrapper does not contain eleemnt', () => {
+  it('throws error if wrapper does not contain elememnt', () => {
     const compiled = compileToFunctions(`<div />`)
     const wrapper = mount(compiled)
     wrapper.element = null

--- a/test/unit/specs/mount/Wrapper/text.spec.js
+++ b/test/unit/specs/mount/Wrapper/text.spec.js
@@ -9,4 +9,13 @@ describe('text', () => {
 
     expect(wrapper.text()).to.equal(text)
   })
+
+  it('throws error if wrapper does not contain eleemnt', () => {
+    const compiled = compileToFunctions(`<div />`)
+    const wrapper = mount(compiled)
+    wrapper.element = null
+    const fn = () => wrapper.text()
+    const message = '[vue-test-utils]: cannot call wrapper.text() on a wrapper without an element'
+    expect(fn).to.throw().with.property('message', message)
+  })
 })

--- a/test/unit/specs/mount/Wrapper/trigger.spec.js
+++ b/test/unit/specs/mount/Wrapper/trigger.spec.js
@@ -74,6 +74,14 @@ describe('trigger', () => {
     expect(info.calledWith(true)).to.equal(true)
   })
 
+  it('throws error if wrapper does not contain eleemnt', () => {
+    const wrapper = mount({ render: () => {} })
+    wrapper.element = null
+    const fn = () => wrapper.trigger('click')
+    const message = '[vue-test-utils]: cannot call wrapper.trigger() on a wrapper without an element'
+    expect(fn).to.throw().with.property('message', message)
+  })
+
   it('throws an error if type is not a string', () => {
     const wrapper = mount(ComponentWithEvents)
     const invalidSelectors = [


### PR DESCRIPTION
Some functions throw unexpected errors it the wrapper doesn't contain an element.

This PR handles null elements by throwing an error or returning false