### PR TITLE
refactor: change method hasClass to use classList.contains method

### DIFF
--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -77,8 +77,7 @@ export default class Wrapper implements BaseWrapper {
       throwError('wrapper.hasClass() must be passed a string')
     }
 
-    return !!(this.element &&
-    this.element.className.split(' ').indexOf(className) !== -1)
+    return !!(this.element && this.element.classList.contains(className))
   }
 
   /**


### PR DESCRIPTION
I experienced error:

    undefined is not an object (evaluating 'this.element.className.split')

when running 'hasClass' test on PhantomJS . This change fix that problem.