### PR TITLE
fix #63 isEmpty on element with empty slot

### DIFF
--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -248,7 +248,7 @@ export default class Wrapper implements BaseWrapper {
    * Checks if node is empty
    */
   isEmpty (): boolean {
-    return this.vnode.children === undefined
+    return this.vnode.children === undefined || this.vnode.children.length === 0
   }
 
   /**

--- a/test/unit/specs/mount/Wrapper/isEmpty.spec.js
+++ b/test/unit/specs/mount/Wrapper/isEmpty.spec.js
@@ -9,6 +9,13 @@ describe('isEmpty', () => {
     expect(wrapper.isEmpty()).to.equal(true)
   })
 
+  it('returns true contains empty slot', () => {
+    const compiled = compileToFunctions('<div><slot></slot></div>')
+    const wrapper = mount(compiled)
+
+    expect(wrapper.isEmpty()).to.equal(true)
+  })
+
   it('returns false if node contains other nodes', () => {
     const compiled = compileToFunctions('<div><p /></div>')
     const wrapper = mount(compiled)


### PR DESCRIPTION
closes #63

Mounting element with slot with no content sets vnode children to [], which makes isEmpty return false (currently checks only for undefined). This duplicates behaviour in [Avoriaz](https://github.com/eddyerburgh/avoriaz/pull/128).