### PR TITLE
fix: link to docs, #76

### DIFF
--- a/src/mount.js
+++ b/src/mount.js
@@ -15,7 +15,7 @@ export default function mount (component: Component, options: Options = {}): Vue
     throwError(
       'window is undefined, vue-test-utils needs to be run in a browser environment.\n' +
       'You can run the tests in node using jsdom + jsdom-global.\n' +
-      'See https://vue-test-utils.vuejs.org/en/guides/general-tips.html for more details.'
+      'See https://vue-test-utils.vuejs.org/en/guides/common-tips.html for more details.'
     )
   }
 


### PR DESCRIPTION
This PR fixe a link to docs.
Existing URL was throwing 404.

Correct URL should be -
https://vue-test-utils.vuejs.org/en/guides/common-tips.html

May be we should setup a test to traverse such links in code and make sure they respond in 200.

Ref #76 