### PR TITLE
Allow additional arguments in use

### DIFF
--- a/src/create-local-vue.js
+++ b/src/create-local-vue.js
@@ -33,7 +33,6 @@ function createLocalVue (): Component {
   instance.use = (plugin, ...rest) => {
     plugin.installed = false
     plugin.install.installed = false
-
     use.call(instance, plugin, ...rest)
   }
   return instance

--- a/src/create-local-vue.js
+++ b/src/create-local-vue.js
@@ -30,10 +30,11 @@ function createLocalVue (): Component {
 
   // compat for vue-router < 2.7.1 where it does not allow multiple installs
   const use = instance.use
-  instance.use = (plugin) => {
+  instance.use = (plugin, ...rest) => {
     plugin.installed = false
     plugin.install.installed = false
-    use.call(instance, plugin)
+
+    use.call(instance, plugin, ...rest)
   }
   return instance
 }

--- a/test/unit/specs/create-local-vue.spec.js
+++ b/test/unit/specs/create-local-vue.spec.js
@@ -104,7 +104,6 @@ describe('createLocalVue', () => {
         expect(options).to.equal(pluginOptions)
       }
     }
-
     localVue.use(plugin, pluginOptions)
   })
 })

--- a/test/unit/specs/create-local-vue.spec.js
+++ b/test/unit/specs/create-local-vue.spec.js
@@ -95,4 +95,16 @@ describe('createLocalVue', () => {
     const freshWrapper = mount(Component)
     expect(typeof freshWrapper.vm.$route).to.equal('undefined')
   })
+
+  it('use can take additional arguments', () => {
+    const localVue = createLocalVue()
+    const pluginOptions = { foo: 'bar' }
+    const plugin = {
+      install: function (_Vue, options) {
+        expect(options).to.equal(pluginOptions)
+      }
+    }
+
+    localVue.use(plugin, pluginOptions)
+  })
 })


### PR DESCRIPTION
As mentioned in the Plugins guide [1], `Vue.use` allows for additional arguments [2] to be passed alongside the plugin. This PR modifies the `use` function in `create-local-vue` to pass these additional arguments in the `instance.use` call.

The plugins guide seems to imply that additional options should be passed via a single object, but there doesn't seem to be a requirement for this, so I wrote this to just use rest parameters and spread syntax.

[1] - https://vuejs.org/v2/guide/plugins.html#Using-a-Plugin
[2] - https://github.com/vuejs/vue/blob/049f3171a9d2e97f62c209a4b78a71ec9dae810f/src/core/global-api/use.js#L13-L19