### PR TITLE
Fix example and add example using setProps

### DIFF
--- a/docs/en/api/wrapper/setProps.md
+++ b/docs/en/api/wrapper/setProps.md
@@ -19,7 +19,7 @@ wrapper.setProps({ foo: 'bar' })
 expect(wrapper.vm.foo).to.equal('bar')
 ```
 
-You can also pass a `propsData` object, which will initialize the Vue instance with passed values. This is useful if you have a component or instance that has props which are `required`.
+You can also pass a `propsData` object, which will initialize the Vue instance with passed values.
 
 ``` js
 // Foo.vue

--- a/docs/en/api/wrapper/setProps.md
+++ b/docs/en/api/wrapper/setProps.md
@@ -1,13 +1,13 @@
 # setProps(props)
 
-Sets `Wrapper` `vm` props and forces update.
-
-**Note the Wrapper must contain a Vue instance.**
-
 - **Arguments:**
   - `{Object} props`
 
-- **Example:**
+- **Usage:**
+
+Sets `Wrapper` `vm` props and forces update.
+
+**Note the Wrapper must contain a Vue instance.**
 
 ```js
 import { mount } from 'vue-test-utils'
@@ -16,5 +16,33 @@ import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)
 wrapper.setProps({ foo: 'bar' })
-expect(wrapper.props().foo).toBe('bar')
+expect(wrapper.vm.foo).to.equal('bar')
+```
+
+You can also pass a `propsData` object, which will initialize the Vue instance with passed values. This is useful if you have a component or instance that has props which are `required`.
+
+``` js
+// Foo.vue
+export default {
+  props: {
+    foo: {
+      type: String,
+      required: true
+    }
+  }
+}
+```
+
+``` js
+import { mount } from 'vue-test-utils'
+import { expect } from 'chai'
+import Foo from './Foo.vue'
+
+const wrapper = mount(Foo, {
+  propsData: {
+    foo: 'bar'
+  }
+})
+
+expect(wrapper.vm.foo).to.equal('bar')
 ```


### PR DESCRIPTION
In response to #99 

This fixes the otherwise not working example.

It also adds another example showing how to use `propsData` for a component that might have `required` props.