### PR TITLE
Added support for CSS modules in hasClass

### DIFF
--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -98,15 +98,15 @@ export default class Wrapper implements BaseWrapper {
    * Asserts wrapper has a class name
    */
   hasClass (className: string) {
-    let targetClass = className;
+    let targetClass = className
 
     if (typeof targetClass !== 'string') {
       throwError('wrapper.hasClass() must be passed a string')
     }
 
-    // if $style is available and has a matching target, use that instead. 
-    if (this.vm && this.vm.$style && this.vm.$style[targetClass]) { 
-      targetClass = this.vm.$style[targetClass];
+    // if $style is available and has a matching target, use that instead.
+    if (this.vm && this.vm.$style && this.vm.$style[targetClass]) {
+      targetClass = this.vm.$style[targetClass]
     }
 
     return !!(this.element && this.element.classList.contains(targetClass))

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -98,16 +98,18 @@ export default class Wrapper implements BaseWrapper {
    * Asserts wrapper has a class name
    */
   hasClass (className: string) {
-    if (typeof className !== 'string') {
+    let targetClass = className;
+
+    if (typeof targetClass !== 'string') {
       throwError('wrapper.hasClass() must be passed a string')
     }
 
-    // if $style is available and has a matching className, use that instead. 
-    if (this.vm && this.vm.$style && this.vm.$style[className]) { 
-      className = this.vm.$style[className] 
+    // if $style is available and has a matching target, use that instead. 
+    if (this.vm && this.vm.$style && this.vm.$style[targetClass]) { 
+      targetClass = this.vm.$style[targetClass];
     }
 
-    return !!(this.element && this.element.classList.contains(className))
+    return !!(this.element && this.element.classList.contains(targetClass))
   }
 
   /**

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -102,6 +102,11 @@ export default class Wrapper implements BaseWrapper {
       throwError('wrapper.hasClass() must be passed a string')
     }
 
+    // if $style is available and has a matching className, use that instead. 
+    if (this.vm && this.vm.$style && this.vm.$style[className]) { 
+      className = this.vm.$style[className] 
+    }
+
     return !!(this.element && this.element.classList.contains(className))
   }
 

--- a/test/resources/components/component-with-css-modules.vue
+++ b/test/resources/components/component-with-css-modules.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="color-red"></div>
+    <div :class="$style['color-red']"></div>
 </template>
 
 <style module>

--- a/test/resources/components/component-with-css-modules.vue
+++ b/test/resources/components/component-with-css-modules.vue
@@ -1,0 +1,15 @@
+<template>
+    <div class="color-red"></div>
+</template>
+
+<style module>
+    .color-red {
+        color: red;
+    }
+</style>
+
+<script>
+    export default{
+      name: 'component-with-css-modules'
+    }
+</script>

--- a/test/unit/specs/mount/Wrapper/hasClass.spec.js
+++ b/test/unit/specs/mount/Wrapper/hasClass.spec.js
@@ -1,3 +1,4 @@
+import ComponentWithCssModules from '~resources/components/component-with-css-modules.vue'
 import { compileToFunctions } from 'vue-template-compiler'
 import mount from '~src/mount'
 
@@ -38,5 +39,11 @@ describe('hasClass', () => {
       const fn = () => wrapper.hasClass(invalidSelector)
       expect(fn).to.throw().with.property('message', message)
     })
+  })
+
+  it('returns true when element contains class name mapped in css modules', () => {
+    const wrapper = mount(ComponentWithCssModules)
+
+    expect(wrapper.hasClass('color-red')).to.equal(true)
   })
 })


### PR DESCRIPTION
Checks the className against $style where available.

- Allows for checking classes that were converted with css modules without needing to know what it was converted to.
- Only works when $style exists on the vm and a mapping is available for the target class.

> **DISCLAIMER**: Not a fan of defining a function argument but it's the cleanest solution.