### PR TITLE
Hotfix: Fix clone issue with vue.extend components

### DIFF
--- a/src/lib/create-instance.js
+++ b/src/lib/create-instance.js
@@ -42,7 +42,7 @@ export default function createConstructor (component: Component, options: Option
     compileTemplate(component)
   }
 
-  const Constructor = vue.extend(component.extend ? component.options : component)
+  const Constructor = vue.extend(component)
 
   if (options.mocks) {
     addMocks(options.mocks, Constructor)

--- a/src/mount.js
+++ b/src/mount.js
@@ -11,7 +11,7 @@ import './lib/matches-polyfill'
 Vue.config.productionTip = false
 
 export default function mount (component: Component, options: Options = {}): VueWrapper {
-  const componentToMount = options.clone === false ? component : cloneDeep(component)
+  const componentToMount = options.clone === false ? component : cloneDeep(component.extend ? component.options : component)
   // Remove cached constructor
   delete componentToMount._Ctor
 

--- a/src/shallow.js
+++ b/src/shallow.js
@@ -12,7 +12,7 @@ import type VueWrapper from './wrappers/vue-wrapper'
 
 export default function shallow (component: Component, options: Options = {}): VueWrapper {
   const vue = options.localVue || Vue
-  const clonedComponent = cloneDeep(component)
+  const clonedComponent = cloneDeep(component.extend ? component.options : component)
 
   if (clonedComponent.components) {
     stubAllComponents(clonedComponent)


### PR DESCRIPTION
- Moving the previous extend fix logic out to `mount` and `shallow`
hooks fixes cloning of component

# issue
```js
import { mount } from 'vue-test-utils'
import ContainerTest from 'container/Test.vue'

const options = {
  mocks: { $route: 'test' }
}

const wrapper = mount(ContainerTest, options)
console.log(wrapper.vm.$route) // test

const wrapper2 = mount(ContainerTest)
console.log(wrapper2.vm.$route) // test
```

# Fix
```js
import { mount } from 'vue-test-utils'
import ContainerTest from 'container/Test.vue'

const options = {
  mocks: { $route: 'test' }
}

const wrapper = mount(ContainerTest, options)
console.log(wrapper.vm.$route) // test

const wrapper2 = mount(ContainerTest)
console.log(wrapper2.vm.$route) // undefined
```