### PR TITLE
fix: dom-events.md eslint errors

### DIFF
--- a/docs/en/guides/dom-events.md
+++ b/docs/en/guides/dom-events.md
@@ -27,7 +27,7 @@ You can run preventDefault on the event by passing `preventDefault: true` in `op
 ```js
 const wrapper = mount(MyButton)
 
-wrapper.trigger('click', {preventDefault: true})
+wrapper.trigger('click', { preventDefault: true })
 ```
 
 
@@ -35,7 +35,7 @@ wrapper.trigger('click', {preventDefault: true})
 
 **Component under test**
 
-```js
+```html
 <template>
 <div>
   <button class="yes" @click="callYes">Yes</button>
@@ -91,7 +91,7 @@ describe('Click event', () => {
 
 This component allows to increment/decrement the quantity using various keys.
 
-```js
+```html
 <template>
 <input type="text" @keydown.prevent="onKeydown" v-model="quantity" />
 </template>


### PR DESCRIPTION
Fixed eslint docs errors

## issue
```
> eslint --ext js,vue,md docs --ignore-path .gitignore

js/vue-test-utils/docs/en/guides/dom-events.md
  30:26  error  A space is required after '{'                                                                                                                                                                                                                object-curly-spacing
  30:47  error  A space is required before '}'                                                                                                                                                                                                               object-curly-spacing
  41:23  error  Parsing error: Unexpected token

  1 | <template>
  2 | <div>
> 3 |   <button class="yes" @click="callYes">Yes</button>
    |                       ^
  4 |   <button class="no" @click="callNo">No</button>
  5 | </div>
  6 | </template>
  96:20  error  Parsing error: Unexpected token

  1 | <template>
> 2 | <input type="text" @keydown.prevent="onKeydown" v-model="quantity" />
    |                    ^
  3 | </template>
  4 | <script>
  5 | const KEY_DOWN = 40

✖ 4 problems (4 errors, 0 warnings)
```