### PR TITLE
Propogate thrown errors by configuring error handler and attaching in…

### DIFF
--- a/src/create-local-vue.js
+++ b/src/create-local-vue.js
@@ -2,6 +2,7 @@
 
 import Vue from 'vue'
 import cloneDeep from 'lodash/cloneDeep'
+import errorHandler from './lib/error-handler'
 
 function createLocalVue (): Component {
   const instance = Vue.extend()
@@ -18,6 +19,8 @@ function createLocalVue (): Component {
 
   // config is not enumerable
   instance.config = cloneDeep(Vue.config)
+
+  instance.config.errorHandler = errorHandler
 
   // option merge strategies need to be exposed by reference
   // so that merge strats registered by plguins can work properly

--- a/src/lib/error-handler.js
+++ b/src/lib/error-handler.js
@@ -1,28 +1,19 @@
-function errorMessage(msg, info) {
+function errorMessage (msg, info) {
   if (info) {
     return `${msg} : additional info ${info}`
   }
 
-  return msg;
+  return msg
 }
 
-function setVueErrorHandler(vue) {
-  vue.config.errorHandler = errorHandler
-}
-
-function errorHandler(err, _vm, info) {
+export default function errorHandler (err, _vm, info) {
   if ((typeof err === 'object') && err.message) {
     if (info) {
-      err.message = errorMessage(err.message, info);
+      err.message = errorMessage(err.message, info)
     }
 
-    throw err;
+    throw err
   }
 
-  throw new Error(errorMessage(err, info));
-}
-
-export {
-  errorHandler,
-  setVueErrorHandler
+  throw new Error(errorMessage(err, info))
 }

--- a/src/lib/error-handler.js
+++ b/src/lib/error-handler.js
@@ -1,0 +1,28 @@
+function errorMessage(msg, info) {
+  if (info) {
+    return `${msg} : additional info ${info}`
+  }
+
+  return msg;
+}
+
+function setVueErrorHandler(vue) {
+  vue.config.errorHandler = errorHandler
+}
+
+function errorHandler(err, _vm, info) {
+  if ((typeof err === 'object') && err.message) {
+    if (info) {
+      err.message = errorMessage(err.message, info);
+    }
+
+    throw err;
+  }
+
+  throw new Error(errorMessage(err, info));
+}
+
+export {
+  errorHandler,
+  setVueErrorHandler
+}

--- a/src/mount.js
+++ b/src/mount.js
@@ -7,10 +7,10 @@ import createInstance from './lib/create-instance'
 import cloneDeep from 'lodash/cloneDeep'
 import createElement from './lib/create-element'
 import './lib/matches-polyfill'
-import { setVueErrorHandler } from './lib/error-handler'
+import errorHandler from './lib/error-handler'
 
 Vue.config.productionTip = false
-setVueErrorHandler(Vue)
+Vue.config.errorHandler = errorHandler
 
 export default function mount (component: Component, options: Options = {}): VueWrapper {
   const componentToMount = options.clone === false ? component : cloneDeep(component.extend ? component.options : component)

--- a/src/mount.js
+++ b/src/mount.js
@@ -7,8 +7,10 @@ import createInstance from './lib/create-instance'
 import cloneDeep from 'lodash/cloneDeep'
 import createElement from './lib/create-element'
 import './lib/matches-polyfill'
+import { setVueErrorHandler } from './lib/error-handler'
 
 Vue.config.productionTip = false
+setVueErrorHandler(Vue)
 
 export default function mount (component: Component, options: Options = {}): VueWrapper {
   const componentToMount = options.clone === false ? component : cloneDeep(component.extend ? component.options : component)

--- a/test/unit/specs/create-local-vue.spec.js
+++ b/test/unit/specs/create-local-vue.spec.js
@@ -113,12 +113,9 @@ describe('createLocalVue', () => {
     localVue.use(Vuetify)
   })
 
-  it('throws an error when the component fails to mount', () => {
-    expect(() => mount({
-      template: '<div></div>',
-      mounted: function () {
-        throw (new Error('Error'))
-      }
-    })).to.throw()
+  it('has an errorHandler', () => {
+    const localVue = createLocalVue()
+
+    expect(localVue.config.errorHandler).to.be.an('function')
   })
 })

--- a/test/unit/specs/create-local-vue.spec.js
+++ b/test/unit/specs/create-local-vue.spec.js
@@ -112,4 +112,13 @@ describe('createLocalVue', () => {
     const localVue = createLocalVue()
     localVue.use(Vuetify)
   })
+
+  it('throws an error when the component fails to mount', () => {
+    expect(() => mount({
+      template: '<div></div>',
+      mounted: function () {
+        throw (new Error('Error'))
+      }
+    })).to.throw()
+  })
 })

--- a/test/unit/specs/lib/error-handler.spec.js
+++ b/test/unit/specs/lib/error-handler.spec.js
@@ -1,38 +1,31 @@
-import { errorHandler } from '../../../../src/lib/error-handler'
+import errorHandler from '../../../../src/lib/error-handler'
 
 describe('errorHandler', () => {
   const errorString = 'errorString'
   const info = 'additional info provided by vue'
+  const errorObject = new Error(errorString)
 
-  describe('with Error thrown', () => {
-    const error = new Error(errorString)
+  it('when error object: rethrows error', () => {
+    expect(() => errorHandler(errorObject)).to.throw().with.property('message', errorString)
+  })
 
-    it('rethrows error', () => {
-      expect(() => errorHandler(error)).to.throw().with.property('message', errorString)
-    })
+  it('when error object: rethrown error contains vue info when provided', () => {
+    expect(() => errorHandler(errorObject, {}, info)).to.throw().that.satisfies(function (err) {
+      const errorMessage = err.message
 
-    it('rethrown error contains vue info when provided', () => {
-      expect(() => errorHandler(error, {}, info)).to.throw().that.satisfies(function(err) {
-        const errorMessage = err.message
-
-        return errorMessage.includes(errorString) && errorMessage.includes(info)
-      });
+      return errorMessage.includes(errorString) && errorMessage.includes(info)
     })
   })
 
-  describe('with not Error object thrown', () => {
-    const error = errorString
+  it('when error string: throws error with string', () => {
+    expect(() => errorHandler(errorString)).to.throw().with.property('message', errorString)
+  })
 
-    it('throws error with string', () => {
-      expect(() => errorHandler(error)).to.throw().with.property('message', errorString)
-    })
+  it('throws error with string and appends info when provided', () => {
+    expect(() => errorHandler(errorString, {}, info)).to.throw().that.satisfies(function (err) {
+      const errorMessage = err.message
 
-    it('throws error with string and appends info when provided', () => {
-      expect(() => errorHandler(error, {}, info)).to.throw().that.satisfies(function(err) {
-        const errorMessage = err.message;
-
-        return errorMessage.includes(errorString) && errorMessage.includes(info)
-      });
+      return errorMessage.includes(errorString) && errorMessage.includes(info)
     })
   })
 })

--- a/test/unit/specs/lib/error-handler.spec.js
+++ b/test/unit/specs/lib/error-handler.spec.js
@@ -1,0 +1,38 @@
+import { errorHandler } from '../../../../src/lib/error-handler'
+
+describe('errorHandler', () => {
+  const errorString = 'errorString'
+  const info = 'additional info provided by vue'
+
+  describe('with Error thrown', () => {
+    const error = new Error(errorString)
+
+    it('rethrows error', () => {
+      expect(() => errorHandler(error)).to.throw().with.property('message', errorString)
+    })
+
+    it('rethrown error contains vue info when provided', () => {
+      expect(() => errorHandler(error, {}, info)).to.throw().that.satisfies(function(err) {
+        const errorMessage = err.message
+
+        return errorMessage.includes(errorString) && errorMessage.includes(info)
+      });
+    })
+  })
+
+  describe('with not Error object thrown', () => {
+    const error = errorString
+
+    it('throws error with string', () => {
+      expect(() => errorHandler(error)).to.throw().with.property('message', errorString)
+    })
+
+    it('throws error with string and appends info when provided', () => {
+      expect(() => errorHandler(error, {}, info)).to.throw().that.satisfies(function(err) {
+        const errorMessage = err.message;
+
+        return errorMessage.includes(errorString) && errorMessage.includes(info)
+      });
+    })
+  })
+})

--- a/test/unit/specs/mount.spec.js
+++ b/test/unit/specs/mount.spec.js
@@ -85,4 +85,14 @@ describe('mount', () => {
     expect(wrapper.vm).to.be.an('object')
     expect(wrapper.html()).to.equal(`<div>foo</div>`)
   })
+
+  it('throws an error when it fails to mount', () => {
+    expect(() => mount({
+        template: '<div></div>',
+        mounted: function() {
+          throw(new Error('Error'))
+        }
+      })).to.throw();
+
+    })
 })

--- a/test/unit/specs/mount.spec.js
+++ b/test/unit/specs/mount.spec.js
@@ -86,13 +86,12 @@ describe('mount', () => {
     expect(wrapper.html()).to.equal(`<div>foo</div>`)
   })
 
-  it('throws an error when it fails to mount', () => {
+  it('throws an error when the component fails to mount', () => {
     expect(() => mount({
-        template: '<div></div>',
-        mounted: function() {
-          throw(new Error('Error'))
-        }
-      })).to.throw();
-
-    })
+      template: '<div></div>',
+      mounted: function () {
+        throw (new Error('Error'))
+      }
+    })).to.throw()
+  })
 })

--- a/test/unit/specs/shallow.spec.js
+++ b/test/unit/specs/shallow.spec.js
@@ -74,4 +74,13 @@ describe('shallow', () => {
     shallow(ComponentWithNestedChildren)
     expect(info.called).to.equal(false)
   })
+
+  it('throws an error when the component fails to mount', () => {
+    expect(() => shallow({
+      template: '<div></div>',
+      mounted: function () {
+        throw (new Error('Error'))
+      }
+    })).to.throw()
+  })
 })


### PR DESCRIPTION
… mount function resolves #147 

### High level overview

Creates an errorHandler function which we assign to Vue's config.errorHandler.  This errorHandler will be called with the error, the vm and additional info from vue.  The error handler handles
 - thrown Error objects `throw(new Error('error'))`
 - thrown string object `throw('error')`
 - appending `info` to the error message if it is provided

### Background/Justification
Currently vue-test-utils silently swallows errors that are thrown in components.  This can lead to false green test suits.  Proof of issue is in this repo pull request https://github.com/Austio/vue-test-utils-mocha-webpack-example/pull/1

