### PR TITLE
Correct typos

### DIFF
--- a/docs/en/api/mount.md
+++ b/docs/en/api/mount.md
@@ -151,8 +151,8 @@ import Faz from './Faz.vue'
 describe('Foo', () => {
   it('renders a div', () => {
     const wrapper = mount(Foo, {
-      stub: {
-        Bar: '<div class="stubbed />',
+      stubs: {
+        Bar: '<div class="stubbed" />',
         BarFoo: true,
         FooBar: Faz
       }


### PR DESCRIPTION
Lost quite some time while learning how to use this library due to following the example on this page which had a typo (`stub` versus `stubs`). Correcting to save other the same fate.