### PR TITLE
Add missing wrappers type def in ArrayWrapper

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -76,6 +76,7 @@ interface Wrapper<V extends Vue> extends BaseWrapper {
 
 interface WrapperArray<V extends Vue> extends BaseWrapper {
   readonly length: number
+  readonly wrappers: Array<Wrapper<V>>
 
   at (index: number): Wrapper<V>
 }


### PR DESCRIPTION
Offer missing field `wrappers` in TS type definition to access wrappers directly from a test.