### PR TITLE
Set _error on vm before we rethrow it in error handler in order to ca…

### DIFF
--- a/src/lib/error-handler.js
+++ b/src/lib/error-handler.js
@@ -1,19 +1,18 @@
-function errorMessage (msg, info) {
+function errorMessage (message, info) {
   if (info) {
-    return `${msg} : additional info ${info}`
+    return `${message} : additional info ${info}`
   }
 
-  return msg
+  return message
 }
 
-export default function errorHandler (err, _vm, info) {
-  if ((typeof err === 'object') && err.message) {
-    if (info) {
-      err.message = errorMessage(err.message, info)
-    }
+export default function errorHandler (errorOrString, vm, info) {
+  const error = (typeof errorOrString === 'object')
+    ? errorOrString
+    : new Error(errorOrString)
 
-    throw err
-  }
+  error.message = errorMessage(error.message, info)
+  vm._error = error
 
-  throw new Error(errorMessage(err, info))
+  throw error
 }

--- a/src/mount.js
+++ b/src/mount.js
@@ -25,5 +25,9 @@ export default function mount (component: Component, options: Options = {}): Vue
     vm.$mount()
   }
 
+  if (vm._error) {
+    throw (vm._error)
+  }
+
   return new VueWrapper(vm, { attachedToDocument: !!options.attachToDocument })
 }

--- a/test/unit/specs/lib/error-handler.spec.js
+++ b/test/unit/specs/lib/error-handler.spec.js
@@ -4,9 +4,8 @@ describe('errorHandler', () => {
   const errorString = 'errorString'
   const info = 'additional info provided by vue'
   const errorObject = new Error(errorString)
-
   it('when error object: rethrows error', () => {
-    expect(() => errorHandler(errorObject)).to.throw().with.property('message', errorString)
+    expect(() => errorHandler(errorObject, {})).to.throw().with.property('message', errorString)
   })
 
   it('when error object: rethrown error contains vue info when provided', () => {
@@ -17,8 +16,15 @@ describe('errorHandler', () => {
     })
   })
 
+  it('when error object: sets vm_error to the error that is thrown', () => {
+    const vm = {}
+    expect(() => errorHandler(errorObject, vm, info)).to.throw().that.satisfies(function (err) {
+      return err === vm._error
+    })
+  })
+
   it('when error string: throws error with string', () => {
-    expect(() => errorHandler(errorString)).to.throw().with.property('message', errorString)
+    expect(() => errorHandler(errorString, {})).to.throw().with.property('message', errorString)
   })
 
   it('throws error with string and appends info when provided', () => {
@@ -26,6 +32,14 @@ describe('errorHandler', () => {
       const errorMessage = err.message
 
       return errorMessage.includes(errorString) && errorMessage.includes(info)
+    })
+  })
+
+  it('when error string: sets vm_error to the error that is thrown', () => {
+    const vm = {}
+
+    expect(() => errorHandler(errorObject, vm, info)).to.throw().that.satisfies(function (err) {
+      return err === vm._error
     })
   })
 })

--- a/test/unit/specs/mount.spec.js
+++ b/test/unit/specs/mount.spec.js
@@ -143,13 +143,14 @@ describe('mount', () => {
     expect(wrapper.vm.$options.listeners).to.equal(undefined)
   })
 
-  it.skip('throws an error when the component fails to mount', () => {
+  it('propagates errors when they are thrown', () => {
     const TestComponent = {
       template: '<div></div>',
       mounted: function () {
         throw new Error('Error in mounted')
       }
     }
+
     const fn = () => mount(TestComponent)
     expect(fn).to.throw()
   })

--- a/test/unit/specs/shallow.spec.js
+++ b/test/unit/specs/shallow.spec.js
@@ -75,7 +75,7 @@ describe('shallow', () => {
     expect(info.called).to.equal(false)
   })
 
-  it.skip('throws an error when the component fails to mount', () => {
+  it('throws an error when the component fails to mount', () => {
     expect(() => shallow({
       template: '<div></div>',
       mounted: function () {


### PR DESCRIPTION
…tch instances where global error handler will log instead of throw

Patches mount to throw if vm._error is set.  Handles cases where we are not inBrowser and console is defined. 
https://github.com/vuejs/vue/blob/015a31890250e93564959de97372be7bd6195f62/dist/vue.js#L1682-L1703

Follow up to #154 
