### PR TITLE
Emit api

### DIFF
--- a/docs/en/api/wrapper/emitted.md
+++ b/docs/en/api/wrapper/emitted.md
@@ -31,3 +31,16 @@ expect(wrapper.emitted().foo.length).toBe(2)
 // assert event payload
 expect(wrapper.emitted().foo[1]).toEqual([123])
 ```
+
+You can also write the as follows:
+
+```js
+// assert event has been emitted
+expect(wrapper.emitted('foo')).toBeTruthy()
+
+// assert event count
+expect(wrapper.emitted('foo').length).toBe(2)
+
+// assert event payload
+expect(wrapper.emitted('foo')[1]).toEqual([123])
+```

--- a/docs/ja/api/wrapper/emitted.md
+++ b/docs/ja/api/wrapper/emitted.md
@@ -31,3 +31,16 @@ expect(wrapper.emitted().foo.length).toBe(2)
 // イベントのペイロードを検証します
 expect(wrapper.emitted().foo[1]).toEqual([123])
 ```
+
+別の構文があります。
+
+```js
+// イベントが発行されたか検証します
+expect(wrapper.emitted('foo')).toBeTruthy()
+
+// イベントの数を検証します
+expect(wrapper.emitted('foo').length).toBe(2)
+
+// イベントのペイロードを検証します
+expect(wrapper.emitted('foo')[1]).toEqual([123])
+```

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -59,6 +59,7 @@ export default class Wrapper implements BaseWrapper {
     if (!this._emitted && !this.vm) {
       throwError('wrapper.emitted() can only be called on a Vue instance')
     }
+    console.log('here', this._emitted)
     return this._emitted
   }
 

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -55,11 +55,14 @@ export default class Wrapper implements BaseWrapper {
   /**
    * Returns an object containing custom events emitted by the Wrapper vm
    */
-  emitted () {
+  emitted (event: string) {
     if (!this._emitted && !this.vm) {
       throwError('wrapper.emitted() can only be called on a Vue instance')
     }
-    console.log('here', this._emitted)
+    if (event) {
+      console.log(`event is ${event}`)
+      return this._emitted[event]
+    }
     return this._emitted
   }
 

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -60,7 +60,6 @@ export default class Wrapper implements BaseWrapper {
       throwError('wrapper.emitted() can only be called on a Vue instance')
     }
     if (event) {
-      console.log(`event is ${event}`)
       return this._emitted[event]
     }
     return this._emitted

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -55,7 +55,7 @@ export default class Wrapper implements BaseWrapper {
   /**
    * Returns an object containing custom events emitted by the Wrapper vm
    */
-  emitted (event: string) {
+  emitted (event: ?string) {
     if (!this._emitted && !this.vm) {
       throwError('wrapper.emitted() can only be called on a Vue instance')
     }

--- a/test/unit/specs/mount/Wrapper/emitted.spec.js
+++ b/test/unit/specs/mount/Wrapper/emitted.spec.js
@@ -9,7 +9,6 @@ describe('emitted', () => {
     wrapper.vm.$emit('foo', 1, 2, 3)
     const evt = wrapper.emitted('foo')
 
-    console.log('evt', evt)
     expect(wrapper.emitted().foo).to.exist
     expect(wrapper.emitted().foo.length).to.equal(1)
     expect(wrapper.emitted().foo[0]).to.eql([])

--- a/test/unit/specs/mount/Wrapper/emitted.spec.js
+++ b/test/unit/specs/mount/Wrapper/emitted.spec.js
@@ -6,7 +6,10 @@ describe('emitted', () => {
       render: h => h('div')
     })
 
-    wrapper.vm.$emit('foo')
+    wrapper.vm.$emit('foo', 1, 2, 3)
+    const evt = wrapper.emitted('foo')
+
+    console.log('evt', evt)
     expect(wrapper.emitted().foo).to.exist
     expect(wrapper.emitted().foo.length).to.equal(1)
     expect(wrapper.emitted().foo[0]).to.eql([])

--- a/test/unit/specs/mount/Wrapper/emitted.spec.js
+++ b/test/unit/specs/mount/Wrapper/emitted.spec.js
@@ -1,17 +1,15 @@
 import mount from '~src/mount'
 
 describe('emitted', () => {
-  it.only('captures emitted events', () => {
+  it.only('captures emitted events with a different api', () => {
     const wrapper = mount({
       render: h => h('div')
     })
 
     wrapper.vm.$emit('foo')
-    console.log('2' ,wrapper.emitted('foo'))
-    console.log('1',wrapper.emitted('foo')['foo'])
-    expect(wrapper.emitted('foo')).to.exist
-    expect(wrapper.emitted('foo').length).to.equal(1)
-    expect(wrapper.emitted('foo')[0]).to.eql([])
+    expect(wrapper.emitted().foo).to.exist
+    expect(wrapper.emitted().foo.length).to.equal(1)
+    expect(wrapper.emitted().foo[0]).to.eql([])
   })
 
   it('captures emitted events', () => {

--- a/test/unit/specs/mount/Wrapper/emitted.spec.js
+++ b/test/unit/specs/mount/Wrapper/emitted.spec.js
@@ -1,17 +1,26 @@
 import mount from '~src/mount'
 
 describe('emitted', () => {
-  it.only('captures emitted events with a different api', () => {
+  it('captures emitted events with a different api', () => {
     const wrapper = mount({
       render: h => h('div')
     })
 
-    wrapper.vm.$emit('foo', 1, 2, 3)
-    const evt = wrapper.emitted('foo')
+    wrapper.vm.$emit('foo')
+    expect(wrapper.emitted('foo')).to.exist
+    expect(wrapper.emitted('foo').length).to.equal(1)
+    expect(wrapper.emitted('foo')[0]).to.eql([])
 
-    expect(wrapper.emitted().foo).to.exist
-    expect(wrapper.emitted().foo.length).to.equal(1)
-    expect(wrapper.emitted().foo[0]).to.eql([])
+    expect(wrapper.emitted('bar')).not.to.exist
+    wrapper.vm.$emit('bar', 1, 2, 3)
+    expect(wrapper.emitted('bar')).to.exist
+    expect(wrapper.emitted('bar').length).to.equal(1)
+    expect(wrapper.emitted('bar')[0]).to.eql([1, 2, 3])
+
+    wrapper.vm.$emit('foo', 2, 3, 4)
+    expect(wrapper.emitted('foo')).to.exist
+    expect(wrapper.emitted('foo').length).to.equal(2)
+    expect(wrapper.emitted('foo')[1]).to.eql([2, 3, 4])
   })
 
   it('captures emitted events', () => {

--- a/test/unit/specs/mount/Wrapper/emitted.spec.js
+++ b/test/unit/specs/mount/Wrapper/emitted.spec.js
@@ -1,6 +1,19 @@
 import mount from '~src/mount'
 
 describe('emitted', () => {
+  it.only('captures emitted events', () => {
+    const wrapper = mount({
+      render: h => h('div')
+    })
+
+    wrapper.vm.$emit('foo')
+    console.log('2' ,wrapper.emitted('foo'))
+    console.log('1',wrapper.emitted('foo')['foo'])
+    expect(wrapper.emitted('foo')).to.exist
+    expect(wrapper.emitted('foo').length).to.equal(1)
+    expect(wrapper.emitted('foo')[0]).to.eql([])
+  })
+
   it('captures emitted events', () => {
     const wrapper = mount({
       render: h => h('div')

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -70,7 +70,7 @@ interface Wrapper<V extends Vue> extends BaseWrapper {
   text (): string
   name (): string
 
-  emitted (): { [name: string]: Array<Array<any>> }
+  emitted (string? event): { [name: string]: Array<Array<any>> }
   emittedByOrder (): Array<{ name: string, args: Array<any> }>
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -76,6 +76,7 @@ interface Wrapper<V extends Vue> extends BaseWrapper {
 
 interface WrapperArray<V extends Vue> extends BaseWrapper {
   readonly length: number
+  readonly wrappers: Array<Wrapper<V>>
 
   at (index: number): Wrapper<V>
 }


### PR DESCRIPTION
Add an alternative syntax for `wrapper.emitted()`.

Also updated docs to include new syntax (ja and en).