### PR TITLE
Add missing types to type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -108,7 +108,12 @@ interface MountOptions<V extends Vue> extends ComponentOptions<V> {
 
 type ShallowOptions<V extends Vue> = MountOptions<V>
 
+interface VueTestUtilsConfigOptions {
+  stubs?: Stubs
+}
+
 export declare function createLocalVue (): typeof Vue
+export declare let config: VueTestUtilsConfigOptions
 
 export declare function mount<V extends Vue, Ctor extends VueClass<V> = VueClass<V>> (component: Ctor, options?: MountOptions<V>): Wrapper<V>
 export declare function mount<V extends Vue> (component: ComponentOptions<V>, options?: MountOptions<V>): Wrapper<V>
@@ -117,3 +122,6 @@ export declare function mount (component: FunctionalComponentOptions, options?: 
 export declare function shallow<V extends Vue, Ctor extends VueClass<V> = VueClass<V>> (component: Ctor, options?: ShallowOptions<V>): Wrapper<V>
 export declare function shallow<V extends Vue> (component: ComponentOptions<V>, options?: ShallowOptions<V>): Wrapper<V>
 export declare function shallow (component: FunctionalComponentOptions, options?: ShallowOptions<Vue>): Wrapper<Vue>
+
+export declare let TransitionStub: Component | string | true  
+export declare let TransitionGroupStub: Component | string | true 


### PR DESCRIPTION
When using typescript on a vue site that has animation, it becomes quite vital to be able to check that transitions are called. 
In order to do just that in TS too, I added the missing types.
This way I can spy on render and check that animations are run.

This is connected with the following issue:
https://github.com/vuejs/vue-test-utils/issues/88