### PR TITLE
Add workaround for IE in trigger

### DIFF
--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -512,10 +512,18 @@ export default class Wrapper implements BaseWrapper {
 
     const event = type.split('.')
 
-    const eventObject = new window.Event(event[0], {
-      bubbles: true,
-      cancelable: true
-    })
+    let eventObject
+
+    // Fallback for IE10,11 - https://stackoverflow.com/questions/26596123
+    if (typeof (window.Event) === 'function') {
+      eventObject = new window.Event(event[0], {
+        bubbles: true,
+        cancelable: true
+      })
+    } else {
+      eventObject = document.createEvent('Event')
+      eventObject.initEvent(event[0], true, true)
+    }
 
     if (options && options.preventDefault) {
       eventObject.preventDefault()


### PR DESCRIPTION
Addresses #208. Reran tests locally and they all passed (there are some linter failures but not in the code changed here). I built and manually verified this fix allows events to trigger in IE.