### PR TITLE
typo fix "docs/zh-cn/guides/using-with-vuex.md"

### DIFF
--- a/docs/zh-cn/guides/using-with-vuex.md
+++ b/docs/zh-cn/guides/using-with-vuex.md
@@ -1,4 +1,4 @@
-# 配合 Vuex 实用
+# 配合 Vuex 使用
 
 在本教程中，我们将会看到如何用 `vue-test-utils` 测试组件中的 Vuex。
 


### PR DESCRIPTION
typo fixed with line 1: "实用" => "使用"