### PR TITLE
Passing text to slots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,7 @@ _book
 .tmp
 tmp*
 
+# Vim
+*.sw[po]
+
 yarn.lock

--- a/src/lib/add-slots.js
+++ b/src/lib/add-slots.js
@@ -19,7 +19,7 @@ function addSlotToVm (vm: Component, slotName: string, slotValue: Component | st
       if ('_v' in vm) {
         elem = vm._v(slotValue)
       } else {
-        throwError('vue-test-utils support for passing text to slots at vue@2.1.5+')
+        throwError('vue-test-utils support for passing text to slots at vue@2.2+')
       }
     }
   } else {

--- a/src/lib/add-slots.js
+++ b/src/lib/add-slots.js
@@ -8,24 +8,23 @@ function isValidSlot (slot: any): boolean {
 }
 
 function addSlotToVm (vm: Component, slotName: string, slotValue: Component | string | Array<Component> | Array<string>): void {
-  if (Array.isArray(vm.$slots[slotName])) {
-    if (typeof slotValue === 'string') {
-      if (!compileToFunctions) {
-        throwError('vueTemplateCompiler is undefined, you must pass components explicitly if vue-template-compiler is undefined')
-      }
-      vm.$slots[slotName].push(vm.$createElement(compileToFunctions(slotValue)))
+  let elem
+  if (typeof slotValue === 'string') {
+    if (!compileToFunctions) {
+      throwError('vueTemplateCompiler is undefined, you must pass components explicitly if vue-template-compiler is undefined')
+    }
+    if (slotValue.trim()[0] === '<') {
+      elem = vm.$createElement(compileToFunctions(slotValue))
     } else {
-      vm.$slots[slotName].push(vm.$createElement(slotValue))
+      elem = vm._v(slotValue)
     }
   } else {
-    if (typeof slotValue === 'string') {
-      if (!compileToFunctions) {
-        throwError('vueTemplateCompiler is undefined, you must pass components explicitly if vue-template-compiler is undefined')
-      }
-      vm.$slots[slotName] = [vm.$createElement(compileToFunctions(slotValue))]
-    } else {
-      vm.$slots[slotName] = [vm.$createElement(slotValue)] // eslint-disable-line no-param-reassign
-    }
+    elem = vm.$createElement(slotValue)
+  }
+  if (Array.isArray(vm.$slots[slotName])) {
+    vm.$slots[slotName].push(elem)
+  } else {
+    vm.$slots[slotName] = [elem]
   }
 }
 

--- a/src/lib/add-slots.js
+++ b/src/lib/add-slots.js
@@ -16,7 +16,11 @@ function addSlotToVm (vm: Component, slotName: string, slotValue: Component | st
     if (slotValue.trim()[0] === '<') {
       elem = vm.$createElement(compileToFunctions(slotValue))
     } else {
-      elem = vm._v(slotValue)
+      if ('_v' in vm) {
+        elem = vm._v(slotValue)
+      } else {
+        throwError('vue-test-utils does not support for passing text to slots at your Vue.js version')
+      }
     }
   } else {
     elem = vm.$createElement(slotValue)

--- a/src/lib/add-slots.js
+++ b/src/lib/add-slots.js
@@ -19,7 +19,7 @@ function addSlotToVm (vm: Component, slotName: string, slotValue: Component | st
       if ('_v' in vm) {
         elem = vm._v(slotValue)
       } else {
-        throwError('vue-test-utils support for passing text to slots at vue@2.2+')
+        throwError('vue-test-utils support for passing text to slots at vue@2.1.5+')
       }
     }
   } else {

--- a/src/lib/add-slots.js
+++ b/src/lib/add-slots.js
@@ -1,5 +1,6 @@
 // @flow
 
+import Vue from 'vue'
 import { compileToFunctions } from 'vue-template-compiler'
 import { throwError } from './util'
 
@@ -9,6 +10,7 @@ function isValidSlot (slot: any): boolean {
 
 function addSlotToVm (vm: Component, slotName: string, slotValue: Component | string | Array<Component> | Array<string>): void {
   let elem
+  const vueVersion = Number(`${Vue.version.split('.')[0]}.${Vue.version.split('.')[1]}`)
   if (typeof slotValue === 'string') {
     if (!compileToFunctions) {
       throwError('vueTemplateCompiler is undefined, you must pass components explicitly if vue-template-compiler is undefined')
@@ -16,7 +18,7 @@ function addSlotToVm (vm: Component, slotName: string, slotValue: Component | st
     if (slotValue.trim()[0] === '<') {
       elem = vm.$createElement(compileToFunctions(slotValue))
     } else {
-      if ('_v' in vm) {
+      if (vueVersion >= 2.2) {
         elem = vm._v(slotValue)
       } else {
         throwError('vue-test-utils support for passing text to slots at vue@2.2+')

--- a/src/lib/add-slots.js
+++ b/src/lib/add-slots.js
@@ -19,7 +19,7 @@ function addSlotToVm (vm: Component, slotName: string, slotValue: Component | st
       if ('_v' in vm) {
         elem = vm._v(slotValue)
       } else {
-        throwError('vue-test-utils does not support for passing text to slots at your Vue.js version')
+        throwError('vue-test-utils support for passing text to slots at vue@2.2+')
       }
     }
   } else {

--- a/test/resources/test-utils.js
+++ b/test/resources/test-utils.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 
-export const vueVersion = parseFloat(`${Vue.version.split('.')[0]}.${Vue.version.split('.')[1]}${Vue.version.split('.')[2]}`)
+export const vueVersion = Number(`${Vue.version.split('.')[0]}.${Vue.version.split('.')[1]}`)
 
 export function injectSupported () {
   return vueVersion > 2.2

--- a/test/resources/test-utils.js
+++ b/test/resources/test-utils.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 
-export const vueVersion = Number(`${Vue.version.split('.')[0]}.${Vue.version.split('.')[1]}`)
+export const vueVersion = parseFloat(`${Vue.version.split('.')[0]}.${Vue.version.split('.')[1]}${Vue.version.split('.')[2]}`)
 
 export function injectSupported () {
   return vueVersion > 2.2

--- a/test/unit/specs/mount.spec.js
+++ b/test/unit/specs/mount.spec.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import { compileToFunctions } from 'vue-template-compiler'
 import mount from '~src/mount'
+import Component from '~resources/components/component.vue'
 import ComponentWithProps from '~resources/components/component-with-props.vue'
 import ComponentWithMixin from '~resources/components/component-with-mixin.vue'
 import createLocalVue from '~src/create-local-vue'
@@ -101,7 +102,7 @@ describe('mount', () => {
         'prop': 'val'
       },
       slots: {
-        'prop': 'val'
+        'prop': Component
       },
       localVue: createLocalVue(),
       stubs: {

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -1,5 +1,4 @@
 import { compileToFunctions } from 'vue-template-compiler'
-import Vue from 'vue'
 import mount from '~src/mount'
 import Component from '~resources/components/component.vue'
 import ComponentWithSlots from '~resources/components/component-with-slots.vue'
@@ -28,12 +27,11 @@ describe('mount.slots', () => {
   })
 
   it('mounts component with default slot if passed string in slot object', () => {
-    const vm = new Vue()
-    if (vueVersion >= 2.2) {
+    if (vueVersion >= 2.15) {
       const wrapper = mount(ComponentWithSlots, { slots: { default: 'foo' }})
       expect(wrapper.text()).to.equal('foo')
     } else {
-      const message = '[vue-test-utils]: vue-test-utils support for passing text to slots at vue@2.2+'
+      const message = '[vue-test-utils]: vue-test-utils support for passing text to slots at vue@2.1.5+'
       const fn = () => mount(ComponentWithSlots, { slots: { default: 'foo' }})
       expect(fn).to.throw().with.property('message', message)
     }
@@ -61,12 +59,11 @@ describe('mount.slots', () => {
   })
 
   it('mounts component with default slot if passed string in slot text array object', () => {
-    const vm = new Vue()
-    if (vueVersion >= 2.2) {
+    if (vueVersion >= 2.15) {
       const wrapper = mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})
       expect(wrapper.text()).to.equal('foobar')
     } else {
-      const message = '[vue-test-utils]: vue-test-utils support for passing text to slots at vue@2.2+'
+      const message = '[vue-test-utils]: vue-test-utils support for passing text to slots at vue@2.1.5+'
       const fn = () => mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})
       expect(fn).to.throw().with.property('message', message)
     }

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -27,11 +27,11 @@ describe('mount.slots', () => {
   })
 
   it('mounts component with default slot if passed string in slot object', () => {
-    if (vueVersion >= 2.15) {
+    if (vueVersion >= 2.2) {
       const wrapper = mount(ComponentWithSlots, { slots: { default: 'foo' }})
       expect(wrapper.text()).to.equal('foo')
     } else {
-      const message = '[vue-test-utils]: vue-test-utils support for passing text to slots at vue@2.1.5+'
+      const message = '[vue-test-utils]: vue-test-utils support for passing text to slots at vue@2.2+'
       const fn = () => mount(ComponentWithSlots, { slots: { default: 'foo' }})
       expect(fn).to.throw().with.property('message', message)
     }
@@ -59,11 +59,11 @@ describe('mount.slots', () => {
   })
 
   it('mounts component with default slot if passed string in slot text array object', () => {
-    if (vueVersion >= 2.15) {
+    if (vueVersion >= 2.2) {
       const wrapper = mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})
       expect(wrapper.text()).to.equal('foobar')
     } else {
-      const message = '[vue-test-utils]: vue-test-utils support for passing text to slots at vue@2.1.5+'
+      const message = '[vue-test-utils]: vue-test-utils support for passing text to slots at vue@2.2+'
       const fn = () => mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})
       expect(fn).to.throw().with.property('message', message)
     }

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -25,6 +25,11 @@ describe('mount.slots', () => {
     expect(wrapper.contains('span')).to.equal(true)
   })
 
+  it('mounts component with default slot if passed string in slot object', () => {
+    const wrapper = mount(ComponentWithSlots, { slots: { default: 'foo' }})
+    expect(wrapper.text()).to.equal('foo')
+  })
+
   it('throws error if passed string in default slot object and vue-template-compiler is undefined', () => {
     const compilerSave = require.cache[require.resolve('vue-template-compiler')].exports.compileToFunctions
     require.cache[require.resolve('vue-template-compiler')].exports.compileToFunctions = undefined
@@ -44,6 +49,11 @@ describe('mount.slots', () => {
   it('mounts component with default slot if passed string in slot array object', () => {
     const wrapper = mount(ComponentWithSlots, { slots: { default: ['<span />'] }})
     expect(wrapper.contains('span')).to.equal(true)
+  })
+
+  it('mounts component with default slot if passed string in slot text array object', () => {
+    const wrapper = mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})
+    expect(wrapper.text()).to.equal('foobar')
   })
 
   it('throws error if passed string in default slot array vue-template-compiler is undefined', () => {

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -32,7 +32,7 @@ describe('mount.slots', () => {
       const wrapper = mount(ComponentWithSlots, { slots: { default: 'foo' }})
       expect(wrapper.text()).to.equal('foo')
     } else {
-      const message = 'vue-test-utils does not support for passing text to slots at your Vue.js version'
+      const message = '[vue-test-utils]: vue-test-utils does not support for passing text to slots at your Vue.js version'
       const fn = () => mount(ComponentWithSlots, { slots: { default: 'foo' }})
       expect(fn).to.throw().with.property('message', message)
     }
@@ -65,7 +65,7 @@ describe('mount.slots', () => {
       const wrapper = mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})
       expect(wrapper.text()).to.equal('foobar')
     } else {
-      const message = 'vue-test-utils does not support for passing text to slots at your Vue.js version'
+      const message = '[vue-test-utils]: vue-test-utils does not support for passing text to slots at your Vue.js version'
       const fn = () => mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})
       expect(fn).to.throw().with.property('message', message)
     }

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -29,7 +29,7 @@ describe('mount.slots', () => {
   it('mounts component with default slot if passed string in slot object', () => {
     if (vueVersion >= 2.2) {
       const wrapper = mount(ComponentWithSlots, { slots: { default: 'foo' }})
-      expect(wrapper.text()).to.equal('foo')
+      expect(wrapper.find('main').text()).to.equal('foo')
     } else {
       const message = '[vue-test-utils]: vue-test-utils support for passing text to slots at vue@2.2+'
       const fn = () => mount(ComponentWithSlots, { slots: { default: 'foo' }})
@@ -61,7 +61,7 @@ describe('mount.slots', () => {
   it('mounts component with default slot if passed string in slot text array object', () => {
     if (vueVersion >= 2.2) {
       const wrapper = mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})
-      expect(wrapper.text()).to.equal('foobar')
+      expect(wrapper.find('main').text()).to.equal('foobar')
     } else {
       const message = '[vue-test-utils]: vue-test-utils support for passing text to slots at vue@2.2+'
       const fn = () => mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -3,6 +3,7 @@ import Vue from 'vue'
 import mount from '~src/mount'
 import Component from '~resources/components/component.vue'
 import ComponentWithSlots from '~resources/components/component-with-slots.vue'
+import { vueVersion } from '~resources/test-utils'
 
 describe('mount.slots', () => {
   it('mounts component with default slot if passed component in slot object', () => {
@@ -28,11 +29,11 @@ describe('mount.slots', () => {
 
   it('mounts component with default slot if passed string in slot object', () => {
     const vm = new Vue()
-    if ('_v' in vm) {
+    if (vueVersion >= 2.2) {
       const wrapper = mount(ComponentWithSlots, { slots: { default: 'foo' }})
       expect(wrapper.text()).to.equal('foo')
     } else {
-      const message = '[vue-test-utils]: vue-test-utils does not support for passing text to slots at your Vue.js version'
+      const message = '[vue-test-utils]: vue-test-utils support for passing text to slots at vue@2.2+'
       const fn = () => mount(ComponentWithSlots, { slots: { default: 'foo' }})
       expect(fn).to.throw().with.property('message', message)
     }
@@ -61,11 +62,11 @@ describe('mount.slots', () => {
 
   it('mounts component with default slot if passed string in slot text array object', () => {
     const vm = new Vue()
-    if ('_v' in vm) {
+    if (vueVersion >= 2.2) {
       const wrapper = mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})
       expect(wrapper.text()).to.equal('foobar')
     } else {
-      const message = '[vue-test-utils]: vue-test-utils does not support for passing text to slots at your Vue.js version'
+      const message = '[vue-test-utils]: vue-test-utils support for passing text to slots at vue@2.2+'
       const fn = () => mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})
       expect(fn).to.throw().with.property('message', message)
     }

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -1,4 +1,5 @@
 import { compileToFunctions } from 'vue-template-compiler'
+import Vue from 'vue'
 import mount from '~src/mount'
 import Component from '~resources/components/component.vue'
 import ComponentWithSlots from '~resources/components/component-with-slots.vue'
@@ -26,8 +27,15 @@ describe('mount.slots', () => {
   })
 
   it('mounts component with default slot if passed string in slot object', () => {
-    const wrapper = mount(ComponentWithSlots, { slots: { default: 'foo' }})
-    expect(wrapper.text()).to.equal('foo')
+    const vm = new Vue()
+    if ('_v' in vm) {
+      const wrapper = mount(ComponentWithSlots, { slots: { default: 'foo' }})
+      expect(wrapper.text()).to.equal('foo')
+    } else {
+      const message = 'vue-test-utils does not support for passing text to slots at your Vue.js version'
+      const fn = () => mount(ComponentWithSlots, { slots: { default: 'foo' }})
+      expect(fn).to.throw().with.property('message', message)
+    }
   })
 
   it('throws error if passed string in default slot object and vue-template-compiler is undefined', () => {
@@ -52,8 +60,15 @@ describe('mount.slots', () => {
   })
 
   it('mounts component with default slot if passed string in slot text array object', () => {
-    const wrapper = mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})
-    expect(wrapper.text()).to.equal('foobar')
+    const vm = new Vue()
+    if ('_v' in vm) {
+      const wrapper = mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})
+      expect(wrapper.text()).to.equal('foobar')
+    } else {
+      const message = 'vue-test-utils does not support for passing text to slots at your Vue.js version'
+      const fn = () => mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})
+      expect(fn).to.throw().with.property('message', message)
+    }
   })
 
   it('throws error if passed string in default slot array vue-template-compiler is undefined', () => {


### PR DESCRIPTION
This is related to #229.

This support only text as below.

```js
const wrapper = mount(ComponentWithSlots, { slots: { default: 'foobar' }})
```

This does not work for the text like one as below.

```js
const wrapper = mount(ComponentWithSlots, { slots: { default: 'foo<span>bar</span>' }})
```

```js
const wrapper = mount(FooComponent, { slots: { default: 'foo {{ bar }}' }})
```