### PR TITLE
Fix typo

### DIFF
--- a/docs/en/api/mount.md
+++ b/docs/en/api/mount.md
@@ -123,7 +123,7 @@ describe('Foo', () => {
   it('renders a div', () => {
     const wrapper = mount(Foo, {
       stubs: {
-        Bar: '<div class="stubbed />',
+        Bar: '<div class="stubbed" />',
         BarFoo: true,
         FooBar: Faz
       }

--- a/docs/en/api/mount.md
+++ b/docs/en/api/mount.md
@@ -122,7 +122,7 @@ import Faz from './Faz.vue'
 describe('Foo', () => {
   it('renders a div', () => {
     const wrapper = mount(Foo, {
-      stub: {
+      stubs: {
         Bar: '<div class="stubbed />',
         BarFoo: true,
         FooBar: Faz


### PR DESCRIPTION
It should be `stubs` instead of `stub`.

(vue-test-utils are awesome by the way :heart:)