### PR TITLE
Update shallow documentation

### DIFF
--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -26,9 +26,13 @@ Passes context to functional component. Can only be used with functional compone
 Example:
 
 ```js
+import Foo from './Foo.vue'
+import Bar from './Bar.vue'
+
 const wrapper = mount(Component, {
   context: {
-    props: { show: true }
+    props: { show: true },
+    children: [Foo, Bar]
   }
 })
 

--- a/docs/en/api/shallow.md
+++ b/docs/en/api/shallow.md
@@ -6,13 +6,13 @@
   - `{Object} options`
     - `{boolean} attachToDocument`
     - `{Object} context`
+      - `{Array<Component|Object>|Component} children`
     - `{Object} slots`
         - `{Array<Componet|Object>|Component|String} default`
         - `{Array<Componet|Object>|Component|String} named`
     - `{Object} mocks`
     - `{Object|Array<string>} stubs`
     - `{boolean} clone`
-    - `{Object} children`
     - `{Vue} localVue`
 
 - **Returns:** `{Wrapper}`


### PR DESCRIPTION
Update shallow documentation to depict the children array
that context can include.

Proposed documentation update in https://github.com/vuejs/vue-test-utils/issues/132