### PR TITLE
clarified emitted() return object in docs

### DIFF
--- a/docs/en/api/wrapper/emitted.md
+++ b/docs/en/api/wrapper/emitted.md
@@ -44,3 +44,15 @@ expect(wrapper.emitted('foo').length).toBe(2)
 // assert event payload
 expect(wrapper.emitted('foo')[1]).toEqual([123])
 ```
+
+The `.emitted()` method returns the same object every time it is called, not a new one, and so the object will update when new events are fired:
+
+```js
+const emitted = wrapper.emitted()
+
+expect(emitted.foo.length).toBe(1)
+
+// do something to make `wrapper` emit the "foo" event
+
+expect(emitted.foo.length).toBe(2)
+```


### PR DESCRIPTION
see https://github.com/vuejs/vue-test-utils/issues/236