### PR TITLE
fix: find ref childComponent should be VueWrapper #267

### DIFF
--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -244,6 +244,9 @@ export default class Wrapper implements BaseWrapper {
       if (!this.isVueComponent) {
         throwError('$ref selectors can only be used on Vue component wrappers')
       }
+      if (this.vm && this.vm.$refs && selector.ref in this.vm.$refs && this.vm.$refs[selector.ref] instanceof Vue) {
+        return new VueWrapper(this.vm.$refs[selector.ref], this.options)
+      }
       const nodes = findVNodesByRef(this.vnode, selector.ref)
       if (nodes.length === 0) {
         return new ErrorWrapper(`ref="${selector.ref}"`)
@@ -277,6 +280,9 @@ export default class Wrapper implements BaseWrapper {
     if (selectorType === selectorTypes.OPTIONS_OBJECT) {
       if (!this.isVueComponent) {
         throwError('$ref selectors can only be used on Vue component wrappers')
+      }
+      if (this.vm && this.vm.$refs && selector.ref in this.vm.$refs && this.vm.$refs[selector.ref] instanceof Vue) {
+        return new WrapperArray([new VueWrapper(this.vm.$refs[selector.ref], this.options)])
       }
       const nodes = findVNodesByRef(this.vnode, selector.ref)
       return new WrapperArray(nodes.map(node => new Wrapper(node, this.update, this.options)))

--- a/test/unit/specs/mount/Wrapper/find.spec.js
+++ b/test/unit/specs/mount/Wrapper/find.spec.js
@@ -6,6 +6,7 @@ import ComponentWithoutName from '~resources/components/component-without-name.v
 import ComponentWithSlots from '~resources/components/component-with-slots.vue'
 import ComponentWithVFor from '~resources/components/component-with-v-for.vue'
 import Component from '~resources/components/component.vue'
+import VueWrapper from '~src/wrappers/vue-wrapper'
 import Wrapper from '~src/wrappers/wrapper'
 import ErrorWrapper from '~src/wrappers/error-wrapper'
 
@@ -172,7 +173,7 @@ describe('find', () => {
 
   it('returns Wrapper of Vue Components matching the ref in options object', () => {
     const wrapper = mount(ComponentWithChild)
-    expect(wrapper.find({ ref: 'child' })).to.be.instanceOf(Wrapper)
+    expect(wrapper.find({ ref: 'child' })).to.be.instanceOf(VueWrapper)
   })
 
   it('throws an error when ref selector is called on a wrapper that is not a Vue component', () => {


### PR DESCRIPTION
Fix for #267

Adjusted wrappers/wrapper.js:
- find, findAll now check vm.$refs for a directly referenced Vue component, then return a VueWrapper
- else standard vnode check is executed, returning Wrapper

Adjusted test mount/Wrapper/find.spec.js:
- test with ChildComponent ref now tests agains VueWrapper

All tests pass, though I'm not sure if using $refs directly is ok (as it isn't used in other find-ref variants, instead going for vnodes...)