### PR TITLE
Improve find() and findAll()

### DIFF
--- a/test/resources/components/component-increase.vue
+++ b/test/resources/components/component-increase.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <button class="click" @click="clickHandler" id="button" />
+  </div>
+</template>
+
+<script>
+  export default{
+    name: 'component-increase',
+    data () {
+      return {
+        count: 0
+      }
+    },
+    methods: {
+      clickHandler (event) {
+        this.count += 1
+      }
+    }
+  }
+</script>

--- a/test/resources/components/component-with-child-increase.vue
+++ b/test/resources/components/component-with-child-increase.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <span id="span">
+      <child-component ref="child"/>
+      <div>foo</div>
+    </span>
+  </div>
+</template>
+
+<script>
+  import ChildComponent from './component-increase.vue'
+
+  export default{
+    name: 'component-with-child',
+    components: {
+      ChildComponent
+    }
+  }
+</script>

--- a/test/unit/specs/mount/Wrapper/find.spec.js
+++ b/test/unit/specs/mount/Wrapper/find.spec.js
@@ -2,11 +2,13 @@ import { compileToFunctions } from 'vue-template-compiler'
 import mount from '~src/mount'
 import createLocalVue from '~src/create-local-vue'
 import ComponentWithChild from '~resources/components/component-with-child.vue'
+import ComponentWithChildIncrease from '~resources/components/component-with-child-increase.vue'
 import ComponentWithoutName from '~resources/components/component-without-name.vue'
 import ComponentWithSlots from '~resources/components/component-with-slots.vue'
 import ComponentWithVFor from '~resources/components/component-with-v-for.vue'
 import Component from '~resources/components/component.vue'
 import Wrapper from '~src/wrappers/wrapper'
+import VueWrapper from '~src/wrappers/vue-wrapper'
 import ErrorWrapper from '~src/wrappers/error-wrapper'
 
 describe('find', () => {
@@ -171,17 +173,16 @@ describe('find', () => {
   })
 
   it('returns Wrapper of Vue Components matching the ref in options object', () => {
-    const wrapper = mount(ComponentWithChild)
-    expect(wrapper.find({ ref: 'child' })).to.be.instanceOf(Wrapper)
-  })
-
-  it('throws an error when ref selector is called on a wrapper that is not a Vue component', () => {
-    const compiled = compileToFunctions('<div><a href="/"></a></div>')
-    const wrapper = mount(compiled)
-    const a = wrapper.find('a')
-    const message = '[vue-test-utils]: $ref selectors can only be used on Vue component wrappers'
-    const fn = () => a.find({ ref: 'foo' })
-    expect(fn).to.throw().with.property('message', message)
+    const wrapper = mount(ComponentWithChildIncrease)
+    const child1 = wrapper.find({ ref: 'child' })
+    expect(child1.vm.count).to.equal(0)
+    wrapper.find('#button').trigger('click')
+    expect(child1).to.be.instanceOf(VueWrapper)
+    expect(child1.vm.count).to.equal(1)
+    wrapper.find('#span').find({ ref: 'child' })
+    const child2 = wrapper.find({ ref: 'child' })
+    expect(child2).to.be.instanceOf(VueWrapper)
+    expect(child2.vm.count).to.equal(1)
   })
 
   it('returns Wrapper matching ref selector in options object passed if nested in a transition', () => {

--- a/test/unit/specs/mount/Wrapper/findAll.spec.js
+++ b/test/unit/specs/mount/Wrapper/findAll.spec.js
@@ -6,7 +6,10 @@ import ComponentWithoutName from '~resources/components/component-without-name.v
 import ComponentWithSlots from '~resources/components/component-with-slots.vue'
 import ComponentWithVFor from '~resources/components/component-with-v-for.vue'
 import Component from '~resources/components/component.vue'
+import ComponentWithChildIncrease from '~resources/components/component-with-child-increase.vue'
 import WrapperArray from '~src/wrappers/wrapper-array'
+import Wrapper from '~src/wrappers/wrapper'
+import VueWrapper from '~src/wrappers/vue-wrapper'
 
 describe('findAll', () => {
   it('returns an WrapperArray of elements matching tag selector passed', () => {
@@ -191,15 +194,6 @@ describe('findAll', () => {
     expect(fooArr.length).to.equal(1)
   })
 
-  it('throws an error when ref selector is called on a wrapper that is not a Vue component', () => {
-    const compiled = compileToFunctions('<div><a href="/"></a></div>')
-    const wrapper = mount(compiled)
-    const a = wrapper.find('a')
-    const message = '[vue-test-utils]: $ref selectors can only be used on Vue component wrappers'
-    const fn = () => a.findAll({ ref: 'foo' })
-    expect(fn).to.throw().with.property('message', message)
-  })
-
   it('returns an array of Wrapper of elements matching the ref in options object if they are nested in a transition', () => {
     const compiled = compileToFunctions('<transition><div ref="foo" /></transition>')
     const wrapper = mount(compiled)
@@ -233,5 +227,23 @@ describe('findAll', () => {
       const fn = () => wrapper.findAll(invalidSelector)
       expect(fn).to.throw().with.property('message', message)
     })
+  })
+
+  it('returns VueWrapper and Wrapper', () => {
+    const wrapper = mount(ComponentWithChildIncrease)
+    const wrappers = wrapper.findAll('div')
+    expect(wrappers.length).to.equal(3)
+    expect(wrappers.at(0)).to.be.an.instanceOf(VueWrapper)
+    expect(wrappers.at(1)).to.be.an.instanceOf(VueWrapper)
+    expect(wrappers.at(2)).to.be.not.an.instanceOf(VueWrapper)
+    expect(wrappers.at(2)).to.be.an.instanceOf(Wrapper)
+  })
+
+  it('is used with ref by Wrapper', () => {
+    const wrapper = mount(ComponentWithChildIncrease)
+    const span = wrapper.find('span')
+    const wrappers = span.findAll({ ref: 'child' })
+    expect(wrappers.length).to.equal(1)
+    expect(wrappers.at(0)).to.be.an.instanceOf(VueWrapper)
   })
 })

--- a/test/unit/specs/mount/Wrapper/text.spec.js
+++ b/test/unit/specs/mount/Wrapper/text.spec.js
@@ -1,4 +1,5 @@
 import { compileToFunctions } from 'vue-template-compiler'
+import ComponentWithChildIncrease from '~resources/components/component-with-child-increase.vue'
 import mount from '~src/mount'
 
 describe('text', () => {
@@ -20,12 +21,12 @@ describe('text', () => {
 
     expect(wrapper.text()).to.equal(text)
   })
-  152
+
   it('throws error if wrapper does not contain element', () => {
-    const wrapper = mount({ render: (h) => h('div') })
-    const div = wrapper.find('div')
-    div.element = null
-    const fn = () => div.text()
+    const wrapper = mount(ComponentWithChildIncrease)
+    const span = wrapper.find('#span')
+    span.element = null
+    const fn = () => span.text()
     const message = '[vue-test-utils]: cannot call wrapper.text() on a wrapper without an element'
     expect(fn).to.throw().with.property('message', message)
   })

--- a/test/unit/specs/mount/Wrapper/trigger.spec.js
+++ b/test/unit/specs/mount/Wrapper/trigger.spec.js
@@ -1,5 +1,6 @@
 import mount from '~src/mount'
 import ComponentWithEvents from '~resources/components/component-with-events.vue'
+import ComponentWithChildIncrease from '~resources/components/component-with-child-increase.vue'
 
 describe('trigger', () => {
   let info
@@ -104,10 +105,10 @@ describe('trigger', () => {
   })
 
   it('throws error if wrapper does not contain element', () => {
-    const wrapper = mount({ render: (h) => h('div') })
-    const div = wrapper.find('div')
-    div.element = null
-    const fn = () => div.trigger('click')
+    const wrapper = mount(ComponentWithChildIncrease)
+    const span = wrapper.find('#span')
+    span.element = null
+    const fn = () => span.trigger('click')
     const message = '[vue-test-utils]: cannot call wrapper.trigger() on a wrapper without an element'
     expect(fn).to.throw().with.property('message', message)
   })


### PR DESCRIPTION
This makes the following changes.

Wrapper can use `ref`.
If the element is binding Vue instance, it always returns VueWrapper.
If the element is not binding Vue instance, it always returns Wrapper.