### PR TITLE
Improve passing text to slots

### DIFF
--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -64,12 +64,12 @@ expect(wrapper.find('div')).toBe(true)
 #### Passing text
 
 You can pass text to `slots`.  
-There is two limitations to this.
+There are two limitations to this.
 
 This does not support PhantomJS.  
 Please use [Puppeteer](ihttps://github.com/karma-runner/karma-chrome-launcher#headless-chromium-with-puppeteer).
 
-The text works below.
+This works for the text below.
 
 ```js
 const wrapper1 = mount(ComponentWithSlots, { slots: { default: '1{{ foo }}2' }})

--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -64,28 +64,10 @@ expect(wrapper.find('div')).toBe(true)
 #### Passing text
 
 You can pass text to `slots`.  
-There are two limitations to this.
+There is a limitation to this.
 
 This does not support PhantomJS.  
 Please use [Puppeteer](https://github.com/karma-runner/karma-chrome-launcher#headless-chromium-with-puppeteer).
-
-This works for the text below.
-
-```js
-const wrapper1 = mount(ComponentWithSlots, { slots: { default: '1{{ foo }}2' }})
-const wrapper2 = mount(ComponentWithSlots, { slots: { default: '<p>1</p>{{ foo }}<p>2</p>' }})
-const wrapper3 = mount(ComponentWithSlots, { slots: { default: '<p>1</p>{{ foo }}' }})
-const wrapper4 = mount(ComponentWithSlots, { slots: { default: '123' }})
-const wrapper5 = mount(ComponentWithSlots, { slots: { default: '1<p>2</p>{{ foo }}3' }})
-```
-
-This does not work for the text below.  
-When there are some elements, `{{ }}` is required.
-
-```js
-const wrapper1 = mount(ComponentWithSlots, { slots: { default: '<p>1</p><p>2</p>' }})
-const wrapper2 = mount(ComponentWithSlots, { slots: { default: '1<p>2</p>3' }})
-```
 
 ### `stubs`
 

--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -64,7 +64,9 @@ expect(wrapper.find('div')).toBe(true)
 #### Passing text
 
 You can pass text to `slots`.  
-There is a limitation to this.
+There is two limitations to this.
+
+This does not support PhantomJS.
 
 The text works below.
 

--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -61,26 +61,6 @@ const wrapper = shallow(Component, {
 expect(wrapper.find('div')).toBe(true)
 ```
 
-#### Passing text
-
-You can pass text to `slots`.  
-There are two limitations to this.
-
-This works with Vue 2.2+.
-
-This works for the text below.
-
-```js
-const wrapper = mount(ComponentWithSlots, { slots: { default: 'foobar' }})
-```
-
-This does not work for the text below.
-
-```js
-const wrapper1 = mount(ComponentWithSlots, { slots: { default: 'foo<span>bar</span>' }})
-const wrapper2 = mount(FooComponent, { slots: { default: 'foo {{ bar }}' }})
-```
-
 ### `stubs`
 
 - type: `{ [name: string]: Component | boolean } | Array<string>`

--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -61,6 +61,29 @@ const wrapper = shallow(Component, {
 expect(wrapper.find('div')).toBe(true)
 ```
 
+#### Passing text
+
+You can pass text to `slots`.  
+There is a limitation to this.
+
+The text works below.
+
+```js
+const wrapper1 = mount(ComponentWithSlots, { slots: { default: '1{{ foo }}2' }})
+const wrapper2 = mount(ComponentWithSlots, { slots: { default: '<p>1</p>{{ foo }}<p>2</p>' }})
+const wrapper3 = mount(ComponentWithSlots, { slots: { default: '<p>1</p>{{ foo }}' }})
+const wrapper4 = mount(ComponentWithSlots, { slots: { default: '123' }})
+const wrapper5 = mount(ComponentWithSlots, { slots: { default: '1<p>2</p>{{ foo }}3' }})
+```
+
+This does not work for the text below.  
+When there are some elements, `{{ }}` is required.
+
+```js
+const wrapper1 = mount(ComponentWithSlots, { slots: { default: '<p>1</p><p>2</p>' }})
+const wrapper2 = mount(ComponentWithSlots, { slots: { default: '1<p>2</p>3' }})
+```
+
 ### `stubs`
 
 - type: `{ [name: string]: Component | boolean } | Array<string>`

--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -66,7 +66,8 @@ expect(wrapper.find('div')).toBe(true)
 You can pass text to `slots`.  
 There is two limitations to this.
 
-This does not support PhantomJS.
+This does not support PhantomJS.  
+Please use [Puppeteer](ihttps://github.com/karma-runner/karma-chrome-launcher#headless-chromium-with-puppeteer).
 
 The text works below.
 

--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -67,7 +67,7 @@ You can pass text to `slots`.
 There are two limitations to this.
 
 This does not support PhantomJS.  
-Please use [Puppeteer](ihttps://github.com/karma-runner/karma-chrome-launcher#headless-chromium-with-puppeteer).
+Please use [Puppeteer](https://github.com/karma-runner/karma-chrome-launcher#headless-chromium-with-puppeteer).
 
 This works for the text below.
 

--- a/src/lib/add-slots.js
+++ b/src/lib/add-slots.js
@@ -22,7 +22,7 @@ function addSlotToVm (vm: Component, slotName: string, slotValue: Component | st
     if (_slotValue[0] === '<' && _slotValue[_slotValue.length - 1] === '>' && document.body.childElementCount === 1) {
       elem = vm.$createElement(compileToFunctions(slotValue))
     } else {
-      const compiledResult = compileToFunctions(`<div>${slotValue}</div>`)
+      const compiledResult = compileToFunctions(`<div>${slotValue}{{ }}</div>`)
       const _staticRenderFns = vm._renderProxy.$options.staticRenderFns
       vm._renderProxy.$options.staticRenderFns = compiledResult.staticRenderFns
       elem = compiledResult.render.call(vm._renderProxy, vm.$createElement).children

--- a/src/lib/add-slots.js
+++ b/src/lib/add-slots.js
@@ -13,6 +13,9 @@ function addSlotToVm (vm: Component, slotName: string, slotValue: Component | st
     if (!compileToFunctions) {
       throwError('vueTemplateCompiler is undefined, you must pass components explicitly if vue-template-compiler is undefined')
     }
+    if (window.navigator.userAgent.match(/PhantomJS/i)) {
+      throwError('option.slots does not support PhantomJS. Please use Puppeteer')
+    }
     const domParser = new window.DOMParser()
     const document = domParser.parseFromString(slotValue, 'text/html')
     const _slotValue = slotValue.trim()

--- a/src/lib/add-slots.js
+++ b/src/lib/add-slots.js
@@ -14,7 +14,7 @@ function addSlotToVm (vm: Component, slotName: string, slotValue: Component | st
       throwError('vueTemplateCompiler is undefined, you must pass components explicitly if vue-template-compiler is undefined')
     }
     if (window.navigator.userAgent.match(/PhantomJS/i)) {
-      throwError('option.slots does not support PhantomJS. Please use Puppeteer')
+      throwError('option.slots does not support strings PhantomJS. Please use Puppeteer, or pass a component')
     }
     const domParser = new window.DOMParser()
     const document = domParser.parseFromString(slotValue, 'text/html')

--- a/src/lib/add-slots.js
+++ b/src/lib/add-slots.js
@@ -14,7 +14,7 @@ function addSlotToVm (vm: Component, slotName: string, slotValue: Component | st
       throwError('vueTemplateCompiler is undefined, you must pass components explicitly if vue-template-compiler is undefined')
     }
     if (window.navigator.userAgent.match(/PhantomJS/i)) {
-      throwError('option.slots does not support strings PhantomJS. Please use Puppeteer, or pass a component')
+      throwError('option.slots does not support strings in PhantomJS. Please use Puppeteer, or pass a component')
     }
     const domParser = new window.DOMParser()
     const document = domParser.parseFromString(slotValue, 'text/html')

--- a/src/lib/add-slots.js
+++ b/src/lib/add-slots.js
@@ -31,10 +31,18 @@ function addSlotToVm (vm: Component, slotName: string, slotValue: Component | st
   } else {
     elem = vm.$createElement(slotValue)
   }
-  if (Array.isArray(vm.$slots[slotName])) {
-    vm.$slots[slotName].push(elem)
+  if (Array.isArray(elem)) {
+    if (Array.isArray(vm.$slots[slotName])) {
+      vm.$slots[slotName] = [...vm.$slots[slotName], ...elem]
+    } else {
+      vm.$slots[slotName] = [...elem]
+    }
   } else {
-    vm.$slots[slotName] = [elem]
+    if (Array.isArray(vm.$slots[slotName])) {
+      vm.$slots[slotName].push(elem)
+    } else {
+      vm.$slots[slotName] = [elem]
+    }
   }
 }
 

--- a/src/lib/create-instance.js
+++ b/src/lib/create-instance.js
@@ -13,6 +13,7 @@ import createLocalVue from '../create-local-vue'
 import extractOptions from '../options/extract-options'
 import deleteMountingOptions from '../options/delete-mounting-options'
 import createFunctionalComponent from './create-functional-component'
+import cloneDeep from 'lodash/cloneDeep'
 
 export default function createConstructor (
   component: Component,
@@ -57,6 +58,9 @@ export default function createConstructor (
 
   addAttrs(vm, mountingOptions.attrs)
   addListeners(vm, mountingOptions.listeners)
+
+  vm.$_mountingOptionsSlots = mountingOptions.slots
+  vm.$_originalSlots = cloneDeep(vm.$slots)
 
   if (mountingOptions.slots) {
     addSlots(vm, mountingOptions.slots)

--- a/src/wrappers/vue-wrapper.js
+++ b/src/wrappers/vue-wrapper.js
@@ -1,9 +1,19 @@
 // @flow
 
 import Wrapper from './wrapper'
+import addSlots from '../lib/add-slots'
+import cloneDeep from 'lodash/cloneDeep'
 
 function update () {
-  this._update(this._render())
+  // the only component made by mount()
+  if (this.$_originalSlots) {
+    this.$slots = cloneDeep(this.$_originalSlots)
+  }
+  if (this.$_mountingOptionsSlots) {
+    addSlots(this, this.$_mountingOptionsSlots)
+  }
+  const vnodes = this._render()
+  this._update(vnodes)
   this.$children.forEach(child => update.call(child))
 }
 

--- a/test/resources/components/component-with-slots.vue
+++ b/test/resources/components/component-with-slots.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <div class="container" @keydown="change">
     <header>
       <slot name="header"></slot>
     </header>
@@ -18,6 +18,11 @@
     data () {
       return {
         'foo': 'bar'
+      }
+    },
+    methods: {
+      change () {
+        this.foo = 'BAR'
       }
     }
   }

--- a/test/resources/components/component-with-slots.vue
+++ b/test/resources/components/component-with-slots.vue
@@ -14,6 +14,11 @@
 
 <script>
   export default {
-    name: 'component-with-slots'
+    name: 'component-with-slots',
+    data () {
+      return {
+        'foo': 'bar'
+      }
+    }
   }
 </script>

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -2,7 +2,6 @@ import { compileToFunctions } from 'vue-template-compiler'
 import { mount } from '~vue-test-utils'
 import Component from '~resources/components/component.vue'
 import ComponentWithSlots from '~resources/components/component-with-slots.vue'
-import { vueVersion } from '~resources/test-utils'
 
 describe('mount.slots', () => {
   it('mounts component with default slot if passed component in slot object', () => {
@@ -27,14 +26,12 @@ describe('mount.slots', () => {
   })
 
   it('mounts component with default slot if passed string in slot object', () => {
-    if (vueVersion >= 2.2) {
-      const wrapper = mount(ComponentWithSlots, { slots: { default: 'foo' }})
-      expect(wrapper.find('main').text()).to.equal('foo')
-    } else {
-      const message = '[vue-test-utils]: vue-test-utils support for passing text to slots at vue@2.2+'
-      const fn = () => mount(ComponentWithSlots, { slots: { default: 'foo' }})
-      expect(fn).to.throw().with.property('message', message)
-    }
+    const wrapper1 = mount(ComponentWithSlots, { slots: { default: 'foo<span>123</span>{{ foo }}' }})
+    expect(wrapper1.find('main').html()).to.equal('<main>foo<span>123</span>bar</main>')
+    const wrapper2 = mount(ComponentWithSlots, { slots: { default: '<p>1</p>{{ foo }}' }})
+    expect(wrapper2.find('main').html()).to.equal('<main><p>1</p>bar</main>')
+    const wrapper3 = mount(ComponentWithSlots, { slots: { default: '<p>1</p>{{ foo }}<p></p>' }})
+    expect(wrapper3.find('main').html()).to.equal('<main><p>1</p>bar<p></p></main>')
   })
 
   it('throws error if passed string in default slot object and vue-template-compiler is undefined', () => {
@@ -59,14 +56,8 @@ describe('mount.slots', () => {
   })
 
   it('mounts component with default slot if passed string in slot text array object', () => {
-    if (vueVersion >= 2.2) {
-      const wrapper = mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})
-      expect(wrapper.find('main').text()).to.equal('foobar')
-    } else {
-      const message = '[vue-test-utils]: vue-test-utils support for passing text to slots at vue@2.2+'
-      const fn = () => mount(ComponentWithSlots, { slots: { default: ['foo', 'bar'] }})
-      expect(fn).to.throw().with.property('message', message)
-    }
+    const wrapper = mount(ComponentWithSlots, { slots: { default: ['{{ foo }}<span>1</span>', 'bar'] }})
+    expect(wrapper.find('main').html()).to.equal('<main>bar<span>1</span>bar</main>')
   })
 
   it('throws error if passed string in default slot array vue-template-compiler is undefined', () => {

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -12,9 +12,7 @@ describe('mount.slots', () => {
 
   afterEach(() => {
     if (!window.navigator.userAgent.match(/Chrome/i)) {
-      /* eslint-disable */
-      window = _window 
-      /* eslint-enable */
+      window = _window // eslint-disable-line no-native-reassign
     }
   })
 
@@ -43,9 +41,7 @@ describe('mount.slots', () => {
     if (window.navigator.userAgent.match(/Chrome/i)) {
       return
     }
-    /* eslint-disable */
-    window = { navigator: { userAgent:'PhantomJS' } }
-    /* eslint-enable */
+    window = { navigator: { userAgent: 'PhantomJS' }} // eslint-disable-line no-native-reassign
     const message = '[vue-test-utils]: option.slots does not support PhantomJS. Please use Puppeteer'
     const fn = () => mount(ComponentWithSlots, { slots: { default: 'foo' }})
     expect(fn).to.throw().with.property('message', message)

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -60,6 +60,10 @@ describe('mount.slots', () => {
     expect(wrapper5.find('main').html()).to.equal('<main>1bar2</main>')
     wrapper5.trigger('keydown')
     expect(wrapper5.find('main').html()).to.equal('<main>1BAR2</main>')
+    const wrapper6 = mount(ComponentWithSlots, { slots: { default: '<p>1</p><p>2</p>' }})
+    expect(wrapper6.find('main').html()).to.equal('<main><p>1</p><p>2</p></main>')
+    const wrapper7 = mount(ComponentWithSlots, { slots: { default: '1<p>2</p>3' }})
+    expect(wrapper7.find('main').html()).to.equal('<main>1<p>2</p>3</main>')
   })
 
   it('throws error if passed string in default slot object and vue-template-compiler is undefined', () => {

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -58,6 +58,8 @@ describe('mount.slots', () => {
     expect(wrapper4.find('main').html()).to.equal('<main>123</main>')
     const wrapper5 = mount(ComponentWithSlots, { slots: { default: '1{{ foo }}2' }})
     expect(wrapper5.find('main').html()).to.equal('<main>1bar2</main>')
+    wrapper5.trigger('keydown')
+    expect(wrapper5.find('main').html()).to.equal('<main>1BAR2</main>')
   })
 
   it('throws error if passed string in default slot object and vue-template-compiler is undefined', () => {

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -28,10 +28,14 @@ describe('mount.slots', () => {
   it('mounts component with default slot if passed string in slot object', () => {
     const wrapper1 = mount(ComponentWithSlots, { slots: { default: 'foo<span>123</span>{{ foo }}' }})
     expect(wrapper1.find('main').html()).to.equal('<main>foo<span>123</span>bar</main>')
-    const wrapper2 = mount(ComponentWithSlots, { slots: { default: '<p>1</p>{{ foo }}' }})
-    expect(wrapper2.find('main').html()).to.equal('<main><p>1</p>bar</main>')
-    const wrapper3 = mount(ComponentWithSlots, { slots: { default: '<p>1</p>{{ foo }}<p></p>' }})
-    expect(wrapper3.find('main').html()).to.equal('<main><p>1</p>bar<p></p></main>')
+    const wrapper2 = mount(ComponentWithSlots, { slots: { default: '<p>1</p>{{ foo }}2' }})
+    expect(wrapper2.find('main').html()).to.equal('<main><p>1</p>bar2</main>')
+    const wrapper3 = mount(ComponentWithSlots, { slots: { default: '<p>1</p>{{ foo }}<p>2</p>' }})
+    expect(wrapper3.find('main').html()).to.equal('<main><p>1</p>bar<p>2</p></main>')
+    const wrapper4 = mount(ComponentWithSlots, { slots: { default: '123' }})
+    expect(wrapper4.find('main').html()).to.equal('<main>123</main>')
+    const wrapper5 = mount(ComponentWithSlots, { slots: { default: '1{{ foo }}2' }})
+    expect(wrapper5.find('main').html()).to.equal('<main>1bar2</main>')
   })
 
   it('throws error if passed string in default slot object and vue-template-compiler is undefined', () => {

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -4,6 +4,18 @@ import Component from '~resources/components/component.vue'
 import ComponentWithSlots from '~resources/components/component-with-slots.vue'
 
 describe('mount.slots', () => {
+  let _window
+
+  beforeEach(() => {
+    _window = window
+  })
+
+  afterEach(() => {
+    /* eslint-disable */
+    window = _window 
+    /* eslint-enable */
+  })
+
   it('mounts component with default slot if passed component in slot object', () => {
     const wrapper = mount(ComponentWithSlots, { slots: { default: Component }})
     expect(wrapper.contains(Component)).to.equal(true)
@@ -23,6 +35,15 @@ describe('mount.slots', () => {
   it('mounts component with default slot if passed string in slot object', () => {
     const wrapper = mount(ComponentWithSlots, { slots: { default: '<span />' }})
     expect(wrapper.contains('span')).to.equal(true)
+  })
+
+  it('throws error if the UserAgent is PhantomJS when passed string is in slot object', () => {
+    /* eslint-disable */
+    window = { navigator: { userAgent:'PhantomJS' } }
+    /* eslint-enable */
+    const message = '[vue-test-utils]: option.slots does not support PhantomJS. Please use Puppeteer'
+    const fn = () => mount(ComponentWithSlots, { slots: { default: 'foo' }})
+    expect(fn).to.throw().with.property('message', message)
   })
 
   it('mounts component with default slot if passed string in slot object', () => {

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -42,7 +42,7 @@ describe('mount.slots', () => {
       return
     }
     window = { navigator: { userAgent: 'PhantomJS' }} // eslint-disable-line no-native-reassign
-    const message = '[vue-test-utils]: option.slots does not support PhantomJS. Please use Puppeteer'
+    const message = '[vue-test-utils]: option.slots does not support strings PhantomJS. Please use Puppeteer, or pass a component'
     const fn = () => mount(ComponentWithSlots, { slots: { default: 'foo' }})
     expect(fn).to.throw().with.property('message', message)
   })

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -11,9 +11,11 @@ describe('mount.slots', () => {
   })
 
   afterEach(() => {
-    /* eslint-disable */
-    window = _window 
-    /* eslint-enable */
+    if (!window.navigator.userAgent.match(/Chrome/i)) {
+      /* eslint-disable */
+      window = _window 
+      /* eslint-enable */
+    }
   })
 
   it('mounts component with default slot if passed component in slot object', () => {
@@ -38,6 +40,9 @@ describe('mount.slots', () => {
   })
 
   it('throws error if the UserAgent is PhantomJS when passed string is in slot object', () => {
+    if (window.navigator.userAgent.match(/Chrome/i)) {
+      return
+    }
     /* eslint-disable */
     window = { navigator: { userAgent:'PhantomJS' } }
     /* eslint-enable */

--- a/test/unit/specs/mount/options/slots.spec.js
+++ b/test/unit/specs/mount/options/slots.spec.js
@@ -42,7 +42,7 @@ describe('mount.slots', () => {
       return
     }
     window = { navigator: { userAgent: 'PhantomJS' }} // eslint-disable-line no-native-reassign
-    const message = '[vue-test-utils]: option.slots does not support strings PhantomJS. Please use Puppeteer, or pass a component'
+    const message = '[vue-test-utils]: option.slots does not support strings in PhantomJS. Please use Puppeteer, or pass a component'
     const fn = () => mount(ComponentWithSlots, { slots: { default: 'foo' }})
     expect(fn).to.throw().with.property('message', message)
   })


### PR DESCRIPTION
This is related to #244 .

The text works below.

```js
const wrapper1 = mount(ComponentWithSlots, { slots: { default: '1{{ foo }}2' )
const wrapper2 = mount(ComponentWithSlots, { slots: { default: '<p>1</p>{{ foo }}<p>2</p>' )
const wrapper3 = mount(ComponentWithSlots, { slots: { default: '<p>1</p>{{ foo }}' )
const wrapper4 = mount(ComponentWithSlots, { slots: { default: '123' )
const wrapper5 = mount(ComponentWithSlots, { slots: { default: '1<p>2</p>{{ foo }}3' )
const wrapper6 = mount(ComponentWithSlots, { slots: { default: '<p>1</p><p>2</p>' }})
const wrapper7 = mount(ComponentWithSlots, { slots: { default: '1<p>2</p>3' }})
```
