### PR TITLE
Improve the "using-with-vue-router" docs

### DIFF
--- a/docs/en/guides/using-with-vue-router.md
+++ b/docs/en/guides/using-with-vue-router.md
@@ -7,9 +7,10 @@ You should never install Vue Router on the Vue base constructor in tests. Instal
 To avoid this, we can create a localVue, and install Vue Router on that.
 
 ```js
+import { shallow, createLocalVue } from 'vue-test-utils'
 import VueRouter from 'vue-router'
-const localVue = createLocalVue()
 
+const localVue = createLocalVue()
 localVue.use(VueRouter)
 
 shallow(Component, {
@@ -21,11 +22,13 @@ shallow(Component, {
 
 When you install Vue Router, the `router-link` and `router-view` components are registered. This means we can use them anywhere in our application without needing to import them.
 
-When we run tests, we need to make these vue-router components available to the component we're mounting. There are two methods to do this.
+When we run tests, we need to make these Vue Router components available to the component we're mounting. There are two methods to do this.
 
 ### Using stubs
 
 ```js
+import { shallow } from 'vue-test-utils'
+
 shallow(Component, {
   stubs: ['router-link', 'router-view']
 })
@@ -34,9 +37,10 @@ shallow(Component, {
 ### Installing Vue Router with localVue
 
 ```js
+import { shallow, createLocalVue } from 'vue-test-utils'
 import VueRouter from 'vue-router'
-const localVue = createLocalVue()
 
+const localVue = createLocalVue()
 localVue.use(VueRouter)
 
 shallow(Component, {
@@ -49,6 +53,8 @@ shallow(Component, {
 Sometimes you want to test that a component does something with parameters from the `$route` and `$router` objects. To do that, you can pass custom mocks to the Vue instance.
 
 ```js
+import { shallow } from 'vue-test-utils'
+
 const $route = {
   path: '/some/path'
 }
@@ -59,7 +65,7 @@ const wrapper = shallow(Component, {
   }
 })
 
-wrapper.vm.$router // /some/path
+wrapper.vm.$route.path // /some/path
 ```
 
 ## Common gotchas
@@ -68,4 +74,4 @@ Installing Vue Router adds `$route` and `$router` as read-only properties on Vue
 
 This means any future tests that try to mock `$route` or `$router` will fail.
 
-To avoid this, never install Vue Router when you're running tests.
+To avoid this, never install Vue Router globally when you're running tests; use a localVue as detailed above.


### PR DESCRIPTION
This patch makes the documentation around using with Vue Router a
little more verbose by explicitly importing the modules used in the
examples.