### PR TITLE
Add attributes, classes, and props to wrapper type definitions

### DIFF
--- a/flow/wrapper.flow.js
+++ b/flow/wrapper.flow.js
@@ -24,6 +24,7 @@ declare interface BaseWrapper { // eslint-disable-line no-undef
     isEmpty(): boolean | void,
     isVueInstance(): boolean | void,
     name(): string | void,
+    props(): { [name: string]: any },
     text(): string | void,
     setData(data: Object): void,
     setComputed(computed: Object): void,

--- a/flow/wrapper.flow.js
+++ b/flow/wrapper.flow.js
@@ -7,8 +7,8 @@ declare type Selector = any
 
 declare interface BaseWrapper { // eslint-disable-line no-undef
     at(index: number): Wrapper | void,
-    attributes(): { [name: string]: string },
-    classes(): Array<string>,
+    attributes(): { [name: string]: string } | void,
+    classes(): Array<string> | void,
     contains(selector: Selector): boolean | void,
     emitted(event?: string): { [name: string]: Array<Array<any>> } | Array<Array<any>> | void,
     emittedByOrder(): Array<{ name: string; args: Array<any> }> | void,
@@ -24,7 +24,7 @@ declare interface BaseWrapper { // eslint-disable-line no-undef
     isEmpty(): boolean | void,
     isVueInstance(): boolean | void,
     name(): string | void,
-    props(): { [name: string]: any },
+    props(): { [name: string]: any } | void,
     text(): string | void,
     setData(data: Object): void,
     setComputed(computed: Object): void,

--- a/flow/wrapper.flow.js
+++ b/flow/wrapper.flow.js
@@ -7,6 +7,8 @@ declare type Selector = any
 
 declare interface BaseWrapper { // eslint-disable-line no-undef
     at(index: number): Wrapper | void,
+    attributes(): { [name: string]: string },
+    classes(): Array<string>,
     contains(selector: Selector): boolean | void,
     emitted(event?: string): { [name: string]: Array<Array<any>> } | Array<Array<any>> | void,
     emittedByOrder(): Array<{ name: string; args: Array<any> }> | void,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -42,7 +42,8 @@ interface BaseWrapper {
 
   attributes(): { [name: string]: string }
   classes(): Array<string>
-  
+  props(): { [name: string]: any }
+
   hasAttribute (attribute: string, value: string): boolean
   hasClass (className: string): boolean
   hasProp (prop: string, value: any): boolean

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,6 +40,9 @@ interface BaseWrapper {
   contains (selector: Selector): boolean
   exists (): boolean
 
+  attributes(): { [name: string]: string }
+  classes(): Array<string>
+  
   hasAttribute (attribute: string, value: string): boolean
   hasClass (className: string): boolean
   hasProp (prop: string, value: any): boolean

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,9 +40,9 @@ interface BaseWrapper {
   contains (selector: Selector): boolean
   exists (): boolean
 
-  attributes(): { [name: string]: string }
-  classes(): Array<string>
-  props(): { [name: string]: any }
+  attributes(): { [name: string]: string } | void
+  classes(): Array<string> | void
+  props(): { [name: string]: any } | void
 
   hasAttribute (attribute: string, value: string): boolean
   hasClass (className: string): boolean


### PR DESCRIPTION
I didn't see any code that automatically generates these, so I assume the type definitions have to be manually written. The types are copied from [`attributes`](https://github.com/vuejs/vue-test-utils/blob/60dde1e11fef591079795245aff5c5588c0cacf7/src/wrappers/wrapper.js#L48) and [`classes`](https://github.com/vuejs/vue-test-utils/blob/60dde1e11fef591079795245aff5c5588c0cacf7/src/wrappers/wrapper.js#L61), and [`props`](https://github.com/vuejs/vue-test-utils/blob/60dde1e11fef591079795245aff5c5588c0cacf7/src/wrappers/wrapper.js#L318).