### PR TITLE
Switch Actions with Getters in the Getters example

### DIFF
--- a/docs/en/guides/using-with-vuex.md
+++ b/docs/en/guides/using-with-vuex.md
@@ -137,7 +137,7 @@ import Vue from 'vue'
 import { mount } from 'vue-test-utils'
 import { expect } from 'chai'
 import Vuex from 'vuex'
-import Actions from '../../../src/components/Getters'
+import Getters from '../../../src/components/Getters'
 
 Vue.use(Vuex)
 
@@ -157,13 +157,13 @@ describe('Getters.vue', () => {
   })
 
   it('Renders state.inputValue in first p tag', () => {
-    const wrapper = mount(Actions, { store })
+    const wrapper = mount(Getters, { store })
     const p = wrapper.find('p')[0]
     expect(p.text()).to.equal(getters.inputValue())
   })
 
   it('Renders state.clicks in second p tag', () => {
-    const wrapper = mount(Actions, { store })
+    const wrapper = mount(Getters, { store })
     const p = wrapper.find('p')[1]
     expect(p.text()).to.equal(getters.clicks().toString())
   })


### PR DESCRIPTION
'Getters' makes more sense in this example than 'Actions'. Simple fix but it will prevent confusion.