### PR TITLE
refactor(types): remove 2nd type parameter of find/findAll to allow type inference

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -67,13 +67,13 @@ interface Wrapper<V extends Vue> extends BaseWrapper {
   readonly element: HTMLElement
   readonly options: WrapperOptions
 
-  find<R extends Vue, Ctor extends VueClass<R> = VueClass<R>> (selector: Ctor): Wrapper<R>
+  find<R extends Vue> (selector: VueClass<R>): Wrapper<R>
   find<R extends Vue> (selector: ComponentOptions<R>): Wrapper<R>
   find (selector: FunctionalComponentOptions): Wrapper<Vue>
   find (selector: string): Wrapper<Vue>
   find (selector: RefSelector): Wrapper<Vue>
 
-  findAll<R extends Vue, Ctor extends VueClass<R> = VueClass<R>> (selector: Ctor): WrapperArray<R>
+  findAll<R extends Vue> (selector: VueClass<R>): WrapperArray<R>
   findAll<R extends Vue> (selector: ComponentOptions<R>): WrapperArray<R>
   findAll (selector: FunctionalComponentOptions): WrapperArray<Vue>
   findAll (selector: string): WrapperArray<Vue>

--- a/types/test/mount.ts
+++ b/types/test/mount.ts
@@ -9,7 +9,7 @@ import { normalOptions, functionalOptions, Normal, ClassComponent } from './reso
 const normalWrapper = mount(normalOptions)
 const normalFoo: string = normalWrapper.vm.foo
 
-const classWrapper = mount<ClassComponent>(ClassComponent)
+const classWrapper = mount(ClassComponent)
 const classFoo: string = classWrapper.vm.bar
 
 const functinalWrapper = mount(functionalOptions)
@@ -22,7 +22,7 @@ localVue.use(Vuex)
 
 const store = new Vuex.Store({})
 
-mount<ClassComponent>(ClassComponent, {
+mount(ClassComponent, {
   attachToDocument: true,
   localVue,
   mocks: {
@@ -57,7 +57,7 @@ mount(functionalOptions, {
 /**
  * MountOptions should receive Vue's component options
  */
-mount<ClassComponent>(ClassComponent, {
+mount(ClassComponent, {
   propsData: {
     test: 'test'
   },

--- a/types/test/shallow.ts
+++ b/types/test/shallow.ts
@@ -9,7 +9,7 @@ import { normalOptions, functionalOptions, Normal, ClassComponent } from './reso
 const normalWrapper = shallow(normalOptions)
 const normalFoo: string = normalWrapper.vm.foo
 
-const classWrapper = shallow<ClassComponent>(ClassComponent)
+const classWrapper = shallow(ClassComponent)
 const classFoo: string = classWrapper.vm.bar
 
 const functinalWrapper = shallow(functionalOptions)
@@ -22,7 +22,7 @@ localVue.use(Vuex)
 
 const store = new Vuex.Store({})
 
-shallow<ClassComponent>(ClassComponent, {
+shallow(ClassComponent, {
   attachToDocument: true,
   localVue,
   mocks: {
@@ -51,7 +51,7 @@ shallow(functionalOptions, {
 /**
  * ShallowOptions should receive Vue's component options
  */
-shallow<ClassComponent>(ClassComponent, {
+shallow(ClassComponent, {
   propsData: {
     test: 'test'
   },

--- a/types/test/wrapper.ts
+++ b/types/test/wrapper.ts
@@ -4,7 +4,7 @@ import { normalOptions, functionalOptions, Normal, ClassComponent } from './reso
 /**
  * Tests for BaseWrapper API
  */
-let wrapper = mount<Normal>(normalOptions)
+let wrapper = mount(normalOptions)
 
 let bool: boolean = wrapper.contains('.foo')
 bool = wrapper.contains(normalOptions)
@@ -51,12 +51,12 @@ bool = wrapper.options.attachedToDocument
 let found = wrapper.find('.foo')
 found = wrapper.find(normalOptions)
 found = wrapper.find(functionalOptions)
-found = wrapper.find<ClassComponent>(ClassComponent)
+found = wrapper.find(ClassComponent)
 
 let array = wrapper.findAll('.bar')
 array = wrapper.findAll(normalOptions)
 array = wrapper.findAll(functionalOptions)
-array = wrapper.findAll<ClassComponent>(ClassComponent)
+array = wrapper.findAll(ClassComponent)
 
 let str: string = wrapper.html()
 str = wrapper.text()


### PR DESCRIPTION
I noticed that we don't need the 2nd type parameter of `find`/`findAll`. So we can remove it so that it allows type inference of component type when we pass a component constructor as same as passing a component options object.