### PR TITLE
docs: add links for guides/testing-async-components.md

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 vuejs
+Copyright (c) 2017-present vuejs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -11,6 +11,7 @@
   * [Choosing a test runner](guides/choosing-a-test-runner.md)
   * [Testing SFCs with Jest](guides/testing-SFCs-with-jest.md)
   * [Testing SFCs with Mocha + webpack](guides/testing-SFCs-with-mocha-webpack.md)
+  * [Testing Asynchronous Behavior](guides/testing-async-components.md)
   * [Using with Vue Router](guides/using-with-vue-router.md)
   * [Using with Vuex](guides/using-with-vuex.md)
 * [API](api/README.md)

--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -7,6 +7,7 @@
   * [Choosing a test runner](guides/choosing-a-test-runner.md)
   * [Testing SFCs with Jest](guides/testing-SFCs-with-jest.md)
   * [Testing SFCs with Mocha + webpack](guides/testing-SFCs-with-mocha-webpack.md)
+  * [Testing Asynchronous Behavior](guides/testing-async-components.md)
   * [Using with Vue Router](guides/using-with-vue-router.md)
   * [Using with Vuex](guides/using-with-vuex.md)
 * [API](api/README.md)

--- a/docs/en/guides/README.md
+++ b/docs/en/guides/README.md
@@ -6,5 +6,6 @@
 * [Choosing a test runner](./choosing-a-test-runner.md)
 * [Testing SFCs with Jest](./testing-SFCs-with-jest.md)
 * [Testing SFCs with Mocha + webpack](./testing-SFCs-with-mocha-webpack.md)
+* [Testing Asynchronous Behavior](testing-async-components.md)
 * [Using with Vue Router](./using-with-vue-router.md)
 * [Using with Vuex](./using-with-vuex.md)


### PR DESCRIPTION
This adds the links for `guides/testing-async-components.md`.