### PR TITLE
feat: export createWrapper and add createWrapperArray functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,16 @@
 import shallow from './shallow'
 import mount from './mount'
 import createLocalVue from './create-local-vue'
+import createWrapper from './wrappers/create-wrapper'
+import createWrapperArray from './wrappers/create-wrapper-array'
 import TransitionStub from './components/TransitionStub'
 import TransitionGroupStub from './components/TransitionGroupStub'
 import config from './config'
 
 export default {
   createLocalVue,
+  createWrapper,
+  createWrapperArray,
   config,
   mount,
   shallow,

--- a/src/wrappers/create-wrapper-array.js
+++ b/src/wrappers/create-wrapper-array.js
@@ -1,0 +1,9 @@
+// @flow
+
+import WrapperArray from './wrapper-array'
+import type Wrapper from './wrapper'
+import type VueWrapper from './vue-wrapper'
+
+export default function createWrapperArray (wrappers: Array<Wrapper | VueWrapper>) {
+  return new WrapperArray(wrappers)
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import Vue, { VNodeData, ComponentOptions, FunctionalComponentOptions } from 'vue'
+import Vue, { VNode, VNodeData, ComponentOptions, FunctionalComponentOptions } from 'vue'
 
 // TODO: use core repo's Component type after https://github.com/vuejs/vue/pull/7369 is released
 export type Component =
@@ -126,6 +126,8 @@ interface VueTestUtilsConfigOptions {
 }
 
 export declare function createLocalVue (): typeof Vue
+export declare function createWrapper (node: VNode | Component, update?: Function, options?: WrapperOptions): Wrapper<Vue>
+export declare function createWrapperArray<T extends Vue> (wrappers: Array<Wrapper<T>>): WrapperArray<T>
 export declare let config: VueTestUtilsConfigOptions
 
 export declare function mount<V extends Vue> (component: VueClass<V>, options?: ThisTypedMountOptions<V>): Wrapper<V>


### PR DESCRIPTION
In some use case, it can be handy to manually create Wrapper and WrapperArray instances.

For example, you can find elements with `findAll` method, then filter them manually with `wrappers` property and Array.filter method, and finally create a new filtered WrapperArray instance.

```javascript
const wrapper = mount(SomeComponent)
const filteredSubComponents = createWrapperArray(wrapper.findAll(SubComponent).wrappers.filter(w => !!w.vm.v))
...
```

  
  