### PR TITLE
docs: fix mount and shallow usage description

### DIFF
--- a/docs/en/api/mount.md
+++ b/docs/en/api/mount.md
@@ -13,9 +13,7 @@ See [options](options.md)
 
 - **Usage:**
 
-Returns [`Wrapper`](wrapper/README.md) of first DOM node or Vue component matching selector.
-
-Use any valid [selector](selectors.md).
+Creates a [`Wrapper`](wrapper/README.md) that contains the mounted and rendered Vue component.
 
 **Without options:**
 

--- a/docs/en/api/shallow.md
+++ b/docs/en/api/shallow.md
@@ -22,11 +22,7 @@ See [options](./options.md)
 
 - **Usage:**
 
-Returns [`Wrapper`](./wrapper/README.md) of first DOM node or Vue component matching selector.
-
-Stubs all child components.
-
-Use any valid [selector](./selectors.md).
+Like [`mount`](mount.md), it creates a [`Wrapper`](wrapper/README.md) that contains the mounted and rendered Vue component, but with stubbed child components.
 
 **Without options:**
 


### PR DESCRIPTION
It looks like the usage description for `mount` and `shallow` was changed here: https://github.com/vuejs/vue-test-utils/commit/7931f7ce74309bd855af38d9ea905cfa516e5980

I used the original description to create a new one that fits the new structure.

This fixes vuejs/vue-test-utils/issues/338