### PR TITLE
Remove moved warning

### DIFF
--- a/build/moved-warning.js
+++ b/build/moved-warning.js
@@ -1,3 +1,0 @@
-const warning = '\nVUE-TEST-UILS WARN: vue-test-utils has moved to a scoped package. \nVUE-TEST-UILS WARN: The new repository is available @vue/test-utils \nVUE-TEST-UILS WARN: To install the new package, run npm install --save-dev @vue/test-utils \n'
-
-console.warn(warning)

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "types": "types/index.d.ts",
   "files": [
     "dist/*.js",
-    "types/index.d.ts",
-    "build/moved-warning.js"
+    "types/index.d.ts"
   ],
   "scripts": {
     "build": "node build/build.js",
@@ -17,7 +16,6 @@
     "docs:deploy": "build/update-docs.sh",
     "docs:serve": "cd docs && gitbook serve",
     "flow": "flow check",
-    "install": "node build/moved-warning",
     "lint": "eslint --ext js,vue src test flow build --ignore-path .gitignore",
     "lint:docs": "eslint --ext js,vue,md docs --ignore-path .gitignore",
     "lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
This PR is related to #347.

You have to run `npm deprecate vue-test-utils "\nVUE-TEST-UILS WARN: vue-test-utils has moved to a scoped package. \nVUE-TEST-UILS WARN: The new repository is available @vue/test-utils \nVUE-TEST-UILS WARN: To install the new package, run npm install --save-dev @vue/test-utils \n"` after publishing the new version on npm

See also: https://docs.npmjs.com/cli/deprecate 

(Since I haven't tested, I may be wrong...)