### PR TITLE
Hotfix: Fix error being thrown with `Vue.extend` when functional

### DIFF
--- a/src/lib/create-instance.js
+++ b/src/lib/create-instance.js
@@ -27,7 +27,7 @@ export default function createConstructor (
     addMocks(mountingOptions.mocks, vue)
   }
 
-  if (component.functional) {
+  if ((component.options && component.options.functional) || component.functional) {
     component = createFunctionalComponent(component, mountingOptions)
   } else if (mountingOptions.context) {
     throwError(

--- a/test/unit/specs/mount/options/context.spec.js
+++ b/test/unit/specs/mount/options/context.spec.js
@@ -1,7 +1,8 @@
+import Vue from 'vue'
 import { mount } from '~vue-test-utils'
 import { vueVersion } from '~resources/test-utils'
 
-describe('context', () => {
+describe.only('context', () => {
   it('mounts functional component when passed context object', () => {
     if (vueVersion <= 2.2) {
       console.log('WARN: no current way to test functional component is component in v2.1.x')
@@ -32,6 +33,16 @@ describe('context', () => {
     const message = '[vue-test-utils]: mount.context can only be used when mounting a functional component'
     const fn = () => mount(Component, { context })
     expect(fn).to.throw().with.property('message', message)
+  })
+
+  it('does not throw error if functional component with Vue.extend', () => {
+    const Component = Vue.extend({
+      functional: true,
+      render: h => h('div')
+    })
+    const context = {}
+    const fn = () => mount(Component, { context })
+    expect(fn).not.to.throw()
   })
 
   it('throws error if context option is not an object', () => {

--- a/test/unit/specs/mount/options/context.spec.js
+++ b/test/unit/specs/mount/options/context.spec.js
@@ -2,7 +2,7 @@ import Vue from 'vue'
 import { mount } from '~vue-test-utils'
 import { vueVersion } from '~resources/test-utils'
 
-describe.only('context', () => {
+describe('context', () => {
   it('mounts functional component when passed context object', () => {
     if (vueVersion <= 2.2) {
       console.log('WARN: no current way to test functional component is component in v2.1.x')


### PR DESCRIPTION
If using `functional` component with `Vue.extend` an error is thrown,
this is avoided by checking the options object