### PR TITLE
docs: fix docs/en/api/wrapper/visible.md

### DIFF
--- a/docs/en/api/wrapper/visible.md
+++ b/docs/en/api/wrapper/visible.md
@@ -1,6 +1,6 @@
 # visible()
 
-Assert `Wrapper` or `WrapperArray` is visible.
+Assert `Wrapper` is visible.
 
 Returns false if an ancestor element has `display: none` or `visibility: hidden` style.
 


### PR DESCRIPTION
I think `wrapper.visible()` targets only Wrapper.