### PR TITLE
test: add sourcemap

### DIFF
--- a/build/config/rollup-options-test.js
+++ b/build/config/rollup-options-test.js
@@ -3,6 +3,7 @@ const resolve = require('path').resolve
 module.exports = [
   {
     dest: resolve('dist/vue-test-utils.js'),
-    format: 'cjs'
+    format: 'cjs',
+    sourceMap: 'inline'
   }
 ]


### PR DESCRIPTION
This adds a sourcemap of test build.
This is related to #379 .