### PR TITLE
fix: allow plugins to be re-installed in localVue instance (fixes #406)

### DIFF
--- a/src/create-local-vue.js
+++ b/src/create-local-vue.js
@@ -32,6 +32,7 @@ function createLocalVue (): Component {
   instance.options._base = instance
 
   // compat for vue-router < 2.7.1 where it does not allow multiple installs
+  instance._installedPlugins = []
   const use = instance.use
   instance.use = (plugin, ...rest) => {
     if (plugin.installed === true) {

--- a/src/create-local-vue.js
+++ b/src/create-local-vue.js
@@ -32,7 +32,9 @@ function createLocalVue (): Component {
   instance.options._base = instance
 
   // compat for vue-router < 2.7.1 where it does not allow multiple installs
-  instance._installedPlugins = []
+  if (instance._installedPlugins && instance._installedPlugins.length) {
+    instance._installedPlugins.length = 0
+  }
   const use = instance.use
   instance.use = (plugin, ...rest) => {
     if (plugin.installed === true) {

--- a/test/specs/create-local-vue.spec.js
+++ b/test/specs/create-local-vue.spec.js
@@ -119,7 +119,9 @@ describe('createLocalVue', () => {
 
     class Plugin {}
     Plugin.install = function (_Vue) {
-      expect(_Vue._installedPlugins.indexOf(Plugin)).to.equal(-1)
+      if (_Vue._installedPlugins) {
+        expect(_Vue._installedPlugins.indexOf(Plugin)).to.equal(-1)
+      }
       installCount++
     }
 
@@ -127,7 +129,9 @@ describe('createLocalVue', () => {
     const localVue = createLocalVue()
     localVue.use(Plugin)
 
-    expect(localVue._installedPlugins.indexOf(Plugin)).to.equal(0)
+    if (localVue._installedPlugins) {
+      expect(localVue._installedPlugins.indexOf(Plugin)).to.equal(0)
+    }
     expect(installCount).to.equal(2)
   })
 

--- a/test/specs/create-local-vue.spec.js
+++ b/test/specs/create-local-vue.spec.js
@@ -1,4 +1,5 @@
 import { createLocalVue } from '~vue-test-utils'
+import Vue from 'vue'
 import Vuex from 'vuex'
 import Vuetify from 'vuetify'
 import VueRouter from 'vue-router'
@@ -111,6 +112,23 @@ describe('createLocalVue', () => {
   it('installs Vutify successfuly', () => {
     const localVue = createLocalVue()
     localVue.use(Vuetify)
+  })
+
+  it('installs plugin into local Vue regardless of previous install in Vue', () => {
+    let installCount = 0
+
+    class Plugin {}
+    Plugin.install = function (_Vue) {
+      expect(_Vue._installedPlugins.indexOf(Plugin)).to.equal(-1)
+      installCount++
+    }
+
+    Vue.use(Plugin)
+    const localVue = createLocalVue()
+    localVue.use(Plugin)
+
+    expect(localVue._installedPlugins.indexOf(Plugin)).to.equal(0)
+    expect(installCount).to.equal(2)
   })
 
   it('has an errorHandler', () => {


### PR DESCRIPTION
This fixes an issue that occurs when the global Vue object has had a plugin installed to it. 

In this scenario, installing the same plugin into the `localVue` instance created via `createLocalVue()` will mark the plugin as not installed and fails to reinstall it because of an additional check inside the `Vue.use` method.

The core source seems to be the process of cloning the original Vue object, in that plugins that are classes are of type `function` instead of type `object`, so the original objects are passed through.