### PR TITLE
fix: remove console.log from stubComponents

### DIFF
--- a/src/lib/stub-components.js
+++ b/src/lib/stub-components.js
@@ -127,7 +127,6 @@ function stubComponents (components: Object, stubbedComponents: Object) {
   Object.keys(components).forEach(component => {
     // Remove cached constructor
     delete components[component]._Ctor
-    console.log(components[component].name)
     if (!components[component].name) {
       components[component].name = component
     }


### PR DESCRIPTION
I'm guessing this isn't intentional, but I noticed this appearing while running tests.