### PR TITLE
Docs: Remove Chai references from examples 

### DIFF
--- a/docs/en/api/createLocalVue.md
+++ b/docs/en/api/createLocalVue.md
@@ -11,7 +11,6 @@ Use it with `options.localVue`:
 
 ```js
 import { createLocalVue, shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const localVue = createLocalVue()

--- a/docs/en/api/mount.md
+++ b/docs/en/api/mount.md
@@ -19,7 +19,6 @@ Creates a [`Wrapper`](wrapper/README.md) that contains the mounted and rendered 
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -34,7 +33,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -53,7 +51,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -69,7 +66,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import FooBar from './FooBar.vue'
@@ -92,7 +88,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -112,7 +107,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import Faz from './Faz.vue'

--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -193,5 +193,5 @@ const options = {
   }
 }
 const wrapper = mount(Component, options)
-expect(wrapper.text()).to.equal('aBC')
+expect(wrapper.text()).toBe('aBC')
 ```

--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -45,7 +45,6 @@ Provide an object of slot contents to the component. The key corresponds to the 
 Example:
 
 ```js
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 
@@ -102,8 +101,6 @@ Add additional properties to the instance. Useful for mocking global injections.
 Example:
 
 ```js
-import { expect } from 'chai'
-
 const $route = { path: 'http://www.example-path.com' }
 const wrapper = shallow(Component, {
   mocks: {
@@ -124,7 +121,6 @@ Example:
 ```js
 import { createLocalVue, mount } from '@vue/test-utils'
 import VueRouter from 'vue-router'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const localVue = createLocalVue()

--- a/docs/en/api/renderToString.md
+++ b/docs/en/api/renderToString.md
@@ -29,7 +29,6 @@ Renders a component to HTML.
 
 ```js
 import { renderToString } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {

--- a/docs/en/api/renderToString.md
+++ b/docs/en/api/renderToString.md
@@ -43,7 +43,6 @@ describe('Foo', () => {
 
 ```js
 import { renderToString } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -62,7 +61,6 @@ describe('Foo', () => {
 
 ```js
 import { renderToString } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import FooBar from './FooBar.vue'
@@ -85,7 +83,6 @@ describe('Foo', () => {
 
 ```js
 import { renderToString } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {

--- a/docs/en/api/selectors.md
+++ b/docs/en/api/selectors.md
@@ -33,7 +33,6 @@ export default {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = shallow(Foo)

--- a/docs/en/api/shallow.md
+++ b/docs/en/api/shallow.md
@@ -28,7 +28,6 @@ Like [`mount`](mount.md), it creates a [`Wrapper`](wrapper/README.md) that conta
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -43,7 +42,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -62,7 +60,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -79,7 +76,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import FooBar from './FooBar.vue'
@@ -102,7 +98,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {

--- a/docs/en/api/wrapper-array/at.md
+++ b/docs/en/api/wrapper-array/at.md
@@ -11,7 +11,6 @@ Returns `Wrapper` at `index` passed. Uses zero based numbering (i.e. first item 
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = shallow(Foo)

--- a/docs/en/api/wrapper-array/contains.md
+++ b/docs/en/api/wrapper-array/contains.md
@@ -13,7 +13,6 @@ Use any valid [selector](../selectors.md).
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/en/api/wrapper-array/destroy.md
+++ b/docs/en/api/wrapper-array/destroy.md
@@ -6,7 +6,6 @@ Destroys each Vue `Wrapper` in `WrapperArray`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper-array/is.md
+++ b/docs/en/api/wrapper-array/is.md
@@ -11,7 +11,6 @@ Assert every `Wrapper` in `WrapperArray` DOM node or `vm` matches [selector](../
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper-array/isEmpty.md
+++ b/docs/en/api/wrapper-array/isEmpty.md
@@ -8,7 +8,6 @@ Assert every `Wrapper` in `WrapperArray` does not contain child node.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper-array/isVisible.md
+++ b/docs/en/api/wrapper-array/isVisible.md
@@ -12,7 +12,6 @@ This can be used to assert that a component is hidden by `v-show`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper-array/isVueInstance.md
+++ b/docs/en/api/wrapper-array/isVueInstance.md
@@ -8,7 +8,6 @@ Assert every `Wrapper` in `WrapperArray` is Vue instance.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/en/api/wrapper-array/setData.md
+++ b/docs/en/api/wrapper-array/setData.md
@@ -11,7 +11,6 @@ Sets `Wrapper` `vm` data and forces update on each `Wrapper` in `WrapperArray`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/en/api/wrapper-array/setMethods.md
+++ b/docs/en/api/wrapper-array/setMethods.md
@@ -11,7 +11,6 @@ Sets `Wrapper` `vm` methods and forces update on each `Wrapper` in `WrapperArray
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'

--- a/docs/en/api/wrapper-array/setProps.md
+++ b/docs/en/api/wrapper-array/setProps.md
@@ -11,7 +11,6 @@ Sets `Wrapper` `vm` props and forces update on each `Wrapper` in `WrapperArray`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/en/api/wrapper-array/trigger.md
+++ b/docs/en/api/wrapper-array/trigger.md
@@ -11,7 +11,6 @@ Triggers an event on every `Wrapper` in the `WrapperArray` DOM node.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 

--- a/docs/en/api/wrapper-array/update.md
+++ b/docs/en/api/wrapper-array/update.md
@@ -8,7 +8,6 @@ If called on a Vue component wrapper array, it will force each Vue component to 
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper/attributes.md
+++ b/docs/en/api/wrapper/attributes.md
@@ -8,7 +8,6 @@ Returns `Wrapper` DOM node attribute object.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper/classes.md
+++ b/docs/en/api/wrapper/classes.md
@@ -10,7 +10,6 @@ Returns Array of class names.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper/contains.md
+++ b/docs/en/api/wrapper/contains.md
@@ -11,7 +11,6 @@ Assert `Wrapper` contains an element or component matching [selector](../selecto
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/en/api/wrapper/destroy.md
+++ b/docs/en/api/wrapper/destroy.md
@@ -6,7 +6,6 @@ Destroys a Vue component instance.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 
 const spy = sinon.stub()

--- a/docs/en/api/wrapper/destroy.md
+++ b/docs/en/api/wrapper/destroy.md
@@ -15,5 +15,5 @@ mount({
     spy()
   }
 }).destroy()
-expect(spy.calledOnce).to.equal(true)
+expect(spy.calledOnce).toEqual(true)
 ```

--- a/docs/en/api/wrapper/destroy.md
+++ b/docs/en/api/wrapper/destroy.md
@@ -15,5 +15,5 @@ mount({
     spy()
   }
 }).destroy()
-expect(spy.calledOnce).toEqual(true)
+expect(spy.calledOnce).toBe(true)
 ```

--- a/docs/en/api/wrapper/emitted.md
+++ b/docs/en/api/wrapper/emitted.md
@@ -8,7 +8,6 @@ Return an object containing custom events emitted by the `Wrapper` `vm`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 
 const wrapper = mount(Component)
 

--- a/docs/en/api/wrapper/emittedByOrder.md
+++ b/docs/en/api/wrapper/emittedByOrder.md
@@ -8,7 +8,6 @@ Return an Array containing custom events emitted by the `Wrapper` `vm`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 
 const wrapper = mount(Component)
 

--- a/docs/en/api/wrapper/exists.md
+++ b/docs/en/api/wrapper/exists.md
@@ -10,7 +10,6 @@ Returns false if called on an empty `Wrapper` or `WrapperArray`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper/find.md
+++ b/docs/en/api/wrapper/find.md
@@ -13,7 +13,6 @@ Use any valid [selector](../selectors.md).
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/en/api/wrapper/findAll.md
+++ b/docs/en/api/wrapper/findAll.md
@@ -13,7 +13,6 @@ Use any valid [selector](../selectors.md).
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/en/api/wrapper/html.md
+++ b/docs/en/api/wrapper/html.md
@@ -8,7 +8,6 @@ Returns HTML of `Wrapper` DOM node as a string.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper/is.md
+++ b/docs/en/api/wrapper/is.md
@@ -11,7 +11,6 @@ Assert `Wrapper` DOM node or `vm` matches [selector](../selectors.md).
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper/isEmpty.md
+++ b/docs/en/api/wrapper/isEmpty.md
@@ -8,7 +8,6 @@ Assert `Wrapper` does not contain child node.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper/isVisible.md
+++ b/docs/en/api/wrapper/isVisible.md
@@ -12,7 +12,6 @@ This can be used to assert that a component is hidden by `v-show`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper/isVueInstance.md
+++ b/docs/en/api/wrapper/isVueInstance.md
@@ -8,7 +8,6 @@ Assert `Wrapper` is Vue instance.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper/name.md
+++ b/docs/en/api/wrapper/name.md
@@ -8,7 +8,6 @@ Returns component name if `Wrapper` contains a Vue instance, or the tag name of 
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper/props.md
+++ b/docs/en/api/wrapper/props.md
@@ -10,7 +10,6 @@ Return `Wrapper` `vm` props object.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo, {

--- a/docs/en/api/wrapper/setData.md
+++ b/docs/en/api/wrapper/setData.md
@@ -11,7 +11,6 @@ Sets `Wrapper` `vm` data and forces update.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper/setMethods.md
+++ b/docs/en/api/wrapper/setMethods.md
@@ -11,7 +11,6 @@ Sets `Wrapper` `vm` methods and forces update.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 

--- a/docs/en/api/wrapper/setProps.md
+++ b/docs/en/api/wrapper/setProps.md
@@ -15,7 +15,7 @@ import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)
 wrapper.setProps({ foo: 'bar' })
-expect(wrapper.vm.foo).toEqual('bar')
+expect(wrapper.vm.foo).toBe('bar')
 ```
 
 You can also pass a `propsData` object, which will initialize the Vue instance with passed values.
@@ -42,5 +42,5 @@ const wrapper = mount(Foo, {
   }
 })
 
-expect(wrapper.vm.foo).toEqual('bar')
+expect(wrapper.vm.foo).toBe('bar')
 ```

--- a/docs/en/api/wrapper/setProps.md
+++ b/docs/en/api/wrapper/setProps.md
@@ -34,7 +34,6 @@ export default {
 
 ``` js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo, {
@@ -43,5 +42,5 @@ const wrapper = mount(Foo, {
   }
 })
 
-expect(wrapper.vm.foo).to.equal('bar')
+expect(wrapper.vm.foo).toEqual('bar')
 ```

--- a/docs/en/api/wrapper/setProps.md
+++ b/docs/en/api/wrapper/setProps.md
@@ -11,12 +11,11 @@ Sets `Wrapper` `vm` props and forces update.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)
 wrapper.setProps({ foo: 'bar' })
-expect(wrapper.vm.foo).to.equal('bar')
+expect(wrapper.vm.foo).toEqual('bar')
 ```
 
 You can also pass a `propsData` object, which will initialize the Vue instance with passed values.

--- a/docs/en/api/wrapper/text.md
+++ b/docs/en/api/wrapper/text.md
@@ -8,7 +8,6 @@ Returns text content of `Wrapper`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/api/wrapper/trigger.md
+++ b/docs/en/api/wrapper/trigger.md
@@ -12,7 +12,6 @@ Triggers an event on the `Wrapper` DOM node.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo'
 

--- a/docs/en/api/wrapper/update.md
+++ b/docs/en/api/wrapper/update.md
@@ -8,7 +8,6 @@ If called on a `Wrapper` containing a `vm`, it will force the `Wrapper` `vm` to 
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/en/guides/common-tips.md
+++ b/docs/en/guides/common-tips.md
@@ -46,8 +46,6 @@ wrapper.vm.$emit('foo', 123)
 You can then make assertions based on these data:
 
 ``` js
-import { expect } from 'chai'
-
 // assert event has been emitted
 expect(wrapper.emitted().foo).toBeTruthy()
 

--- a/docs/en/guides/dom-events.md
+++ b/docs/en/guides/dom-events.md
@@ -151,27 +151,27 @@ import { mount } from '@vue/test-utils'
 describe('Key event tests', () => {
   it('Quantity is zero by default', () => {
     const wrapper = mount(QuantityComponent)
-    expect(wrapper.vm.quantity).to.equal(0)
+    expect(wrapper.vm.quantity).toBe(0)
   })
 
   it('Cursor up sets quantity to 1', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.trigger('keydown.up')
-    expect(wrapper.vm.quantity).to.equal(1)
+    expect(wrapper.vm.quantity).toBe(1)
   })
 
   it('Cursor down reduce quantity by 1', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.vm.quantity = 5
     wrapper.trigger('keydown.down')
-    expect(wrapper.vm.quantity).to.equal(4)
+    expect(wrapper.vm.quantity).toBe(4)
   })
 
   it('Escape sets quantity to 0', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.vm.quantity = 5
     wrapper.trigger('keydown.esc')
-    expect(wrapper.vm.quantity).to.equal(0)
+    expect(wrapper.vm.quantity).toBe(0)
   })
 
   it('Magic character "a" sets quantity to 13', () => {
@@ -179,7 +179,7 @@ describe('Key event tests', () => {
     wrapper.trigger('keydown', {
       which: 65
     })
-    expect(wrapper.vm.quantity).to.equal(13)
+    expect(wrapper.vm.quantity).toBe(13)
   })
 })
 

--- a/docs/en/guides/testing-async-components.md
+++ b/docs/en/guides/testing-async-components.md
@@ -52,7 +52,7 @@ test('Foo', () => {
   it('fetches async when a button is clicked', () => {
     const wrapper = shallow(Foo)
     wrapper.find('button').trigger('click')
-    expect(wrapper.vm.value).toEqual('value')
+    expect(wrapper.vm.value).toBe('value')
   })
 })
 ```
@@ -65,7 +65,7 @@ test('Foo', () => {
     const wrapper = shallow(Foo)
     wrapper.find('button').trigger('click')
     wrapper.vm.$nextTick(() => {
-      expect(wrapper.vm.value).toEqual('value')
+      expect(wrapper.vm.value).toBe('value')
       done()
     })
   })
@@ -89,7 +89,7 @@ test('Foo', () => {
     const wrapper = shallow(Foo)
     wrapper.find('button').trigger('click')
     await flushPromises()
-    expect(wrapper.vm.value).toEqual('value')
+    expect(wrapper.vm.value).toBe('value')
   })
 })
 ```

--- a/docs/fr/api/createLocalVue.md
+++ b/docs/fr/api/createLocalVue.md
@@ -11,7 +11,6 @@ Use it with `options.localVue`:
 
 ```js
 import { createLocalVue, shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const localVue = createLocalVue()

--- a/docs/fr/api/mount.md
+++ b/docs/fr/api/mount.md
@@ -21,7 +21,6 @@ Use any valid [selector](selectors.md).
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -36,7 +35,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -55,7 +53,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -71,7 +68,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import FooBar from './FooBar.vue'
@@ -94,7 +90,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -114,7 +109,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import Faz from './Faz.vue'

--- a/docs/fr/api/options.md
+++ b/docs/fr/api/options.md
@@ -43,7 +43,6 @@ Provide an object of slot contents to the component. The key corresponds to the 
 Example:
 
 ```js
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 
@@ -91,8 +90,6 @@ Add additional properties to the instance. Useful for mocking global injections.
 Example:
 
 ```js
-import { expect } from 'chai'
-
 const $route = { path: 'http://www.example-path.com' }
 const wrapper = shallow(Component, {
   mocks: {
@@ -113,7 +110,6 @@ Example:
 ```js
 import { createLocalVue, mount } from '@vue/test-utils'
 import VueRouter from 'vue-router'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const localVue = createLocalVue()

--- a/docs/fr/api/selectors.md
+++ b/docs/fr/api/selectors.md
@@ -35,7 +35,6 @@ export default {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = shallow(Foo)

--- a/docs/fr/api/shallow.md
+++ b/docs/fr/api/shallow.md
@@ -32,7 +32,6 @@ Use any valid [selector](./selectors.md).
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -47,7 +46,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -66,7 +64,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -83,7 +80,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import FooBar from './FooBar.vue'
@@ -106,7 +102,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {

--- a/docs/fr/api/wrapper-array/at.md
+++ b/docs/fr/api/wrapper-array/at.md
@@ -11,7 +11,6 @@
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = shallow(Foo)

--- a/docs/fr/api/wrapper-array/contains.md
+++ b/docs/fr/api/wrapper-array/contains.md
@@ -13,7 +13,6 @@ Use any valid [selector](../selectors.md).
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/fr/api/wrapper-array/destroy.md
+++ b/docs/fr/api/wrapper-array/destroy.md
@@ -6,7 +6,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper-array/hasAttribute.md
+++ b/docs/fr/api/wrapper-array/hasAttribute.md
@@ -12,7 +12,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper-array/hasClass.md
+++ b/docs/fr/api/wrapper-array/hasClass.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper-array/hasProp.md
+++ b/docs/fr/api/wrapper-array/hasProp.md
@@ -14,7 +14,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/fr/api/wrapper-array/hasStyle.md
+++ b/docs/fr/api/wrapper-array/hasStyle.md
@@ -15,7 +15,6 @@ Returns `true` if `Wrapper` DOM node has `style` matching `value`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper-array/is.md
+++ b/docs/fr/api/wrapper-array/is.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper-array/isEmpty.md
+++ b/docs/fr/api/wrapper-array/isEmpty.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper-array/isVueInstance.md
+++ b/docs/fr/api/wrapper-array/isVueInstance.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/fr/api/wrapper-array/setData.md
+++ b/docs/fr/api/wrapper-array/setData.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/fr/api/wrapper-array/setMethods.md
+++ b/docs/fr/api/wrapper-array/setMethods.md
@@ -12,7 +12,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'

--- a/docs/fr/api/wrapper-array/setProps.md
+++ b/docs/fr/api/wrapper-array/setProps.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/fr/api/wrapper-array/trigger.md
+++ b/docs/fr/api/wrapper-array/trigger.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 

--- a/docs/fr/api/wrapper-array/update.md
+++ b/docs/fr/api/wrapper-array/update.md
@@ -8,7 +8,6 @@ If called on a Vue component wrapper array, it will force each Vue component to 
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper/contains.md
+++ b/docs/fr/api/wrapper/contains.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/fr/api/wrapper/destroy.md
+++ b/docs/fr/api/wrapper/destroy.md
@@ -6,7 +6,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 
 const spy = sinon.stub()
@@ -16,5 +15,5 @@ mount({
     spy()
   }
 }).destroy()
-expect(spy.calledOnce).to.equal(true)
+expect(spy.calledOnce).toBe(true)
 ```

--- a/docs/fr/api/wrapper/emitted.md
+++ b/docs/fr/api/wrapper/emitted.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 
 const wrapper = mount(Component)
 

--- a/docs/fr/api/wrapper/emittedByOrder.md
+++ b/docs/fr/api/wrapper/emittedByOrder.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 
 const wrapper = mount(Component)
 

--- a/docs/fr/api/wrapper/exists.md
+++ b/docs/fr/api/wrapper/exists.md
@@ -10,7 +10,6 @@ Returns false if called on an empty `Wrapper` or `WrapperArray`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper/find.md
+++ b/docs/fr/api/wrapper/find.md
@@ -13,7 +13,6 @@ Use any valid [selector](../selectors.md).
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/fr/api/wrapper/findAll.md
+++ b/docs/fr/api/wrapper/findAll.md
@@ -13,7 +13,6 @@ Use any valid [selector](../selectors.md).
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/fr/api/wrapper/hasAttribute.md
+++ b/docs/fr/api/wrapper/hasAttribute.md
@@ -14,7 +14,6 @@ Returns `true` if `Wrapper` DOM node contains attribute with matching value.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)
@@ -27,7 +26,6 @@ You could get the attribute from the `Wrapper.element` to have a value based ass
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper/hasClass.md
+++ b/docs/fr/api/wrapper/hasClass.md
@@ -13,7 +13,6 @@ Returns `true` if `Wrapper` DOM node contains the class.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper/hasProp.md
+++ b/docs/fr/api/wrapper/hasProp.md
@@ -17,7 +17,6 @@ Returns `true` if `Wrapper` `vm` has `prop` matching `value`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper/hasStyle.md
+++ b/docs/fr/api/wrapper/hasStyle.md
@@ -16,7 +16,6 @@ Returns `true` if `Wrapper` DOM node has `style` matching `value`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper/html.md
+++ b/docs/fr/api/wrapper/html.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper/is.md
+++ b/docs/fr/api/wrapper/is.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper/isEmpty.md
+++ b/docs/fr/api/wrapper/isEmpty.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper/isVueInstance.md
+++ b/docs/fr/api/wrapper/isVueInstance.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper/name.md
+++ b/docs/fr/api/wrapper/name.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper/setData.md
+++ b/docs/fr/api/wrapper/setData.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper/setMethods.md
+++ b/docs/fr/api/wrapper/setMethods.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 

--- a/docs/fr/api/wrapper/setProps.md
+++ b/docs/fr/api/wrapper/setProps.md
@@ -11,12 +11,11 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)
 wrapper.setProps({ foo: 'bar' })
-expect(wrapper.vm.foo).to.equal('bar')
+expect(wrapper.vm.foo).toBe('bar')
 ```
 
 You can also pass a `propsData` object, which will initialize the Vue instance with passed values.
@@ -35,7 +34,6 @@ export default {
 
 ``` js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo, {
@@ -44,5 +42,5 @@ const wrapper = mount(Foo, {
   }
 })
 
-expect(wrapper.vm.foo).to.equal('bar')
+expect(wrapper.vm.foo).toBe('bar')
 ```

--- a/docs/fr/api/wrapper/text.md
+++ b/docs/fr/api/wrapper/text.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/api/wrapper/trigger.md
+++ b/docs/fr/api/wrapper/trigger.md
@@ -13,7 +13,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo'
 

--- a/docs/fr/api/wrapper/update.md
+++ b/docs/fr/api/wrapper/update.md
@@ -8,7 +8,6 @@ If called on a `Wrapper` containing a `vm`, it will force the `Wrapper` `vm` to 
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/fr/guides/common-tips.md
+++ b/docs/fr/guides/common-tips.md
@@ -45,8 +45,6 @@ wrapper.vm.$emit('foo', 123)
 
 Vous pouvez ensuite réaliser des assertions sur ces données :
 ``` js
-import { expect } from 'chai'
-
 // asserte que l'évènement est bien émit
 expect(wrapper.emitted().foo).toBeTruthy()
 

--- a/docs/fr/guides/dom-events.md
+++ b/docs/fr/guides/dom-events.md
@@ -150,27 +150,27 @@ import { mount } from '@vue/test-utils'
 describe('Tests événement clavier', () => {
   it('La quantité est zéro par défaut', () => {
     const wrapper = mount(QuantityComponent)
-    expect(wrapper.vm.quantity).to.equal(0)
+    expect(wrapper.vm.quantity).toBe(0)
   })
 
   it('La flèche du haut positionne la quantité à 1', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.trigger('keydown.up')
-    expect(wrapper.vm.quantity).to.equal(1)
+    expect(wrapper.vm.quantity).toBe(1)
   })
 
   it('La flèche du bas réduit la quantité de 1', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.vm.quantity = 5
     wrapper.trigger('keydown.down')
-    expect(wrapper.vm.quantity).to.equal(4)
+    expect(wrapper.vm.quantity).toBe(4)
   })
 
   it('La touche Échap positionne la quantité à 0', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.vm.quantity = 5
     wrapper.trigger('keydown.esc')
-    expect(wrapper.vm.quantity).to.equal(0)
+    expect(wrapper.vm.quantity).toBe(0)
   })
 
   it('Le caractère magique `a` positionne la quantité à 13', () => {
@@ -178,7 +178,7 @@ describe('Tests événement clavier', () => {
     wrapper.trigger('keydown', {
       which: 65
     })
-    expect(wrapper.vm.quantity).to.equal(13)
+    expect(wrapper.vm.quantity).toBe(13)
   })
 })
 

--- a/docs/ja/api/createLocalVue.md
+++ b/docs/ja/api/createLocalVue.md
@@ -11,7 +11,6 @@
 
 ```js
 import { createLocalVue, shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const localVue = createLocalVue()

--- a/docs/ja/api/mount.md
+++ b/docs/ja/api/mount.md
@@ -19,7 +19,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -33,7 +32,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -52,7 +50,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -68,7 +65,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import FooBar from './FooBar.vue'
@@ -91,7 +87,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -111,7 +106,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import Faz from './Faz.vue'

--- a/docs/ja/api/options.md
+++ b/docs/ja/api/options.md
@@ -41,7 +41,6 @@ expect(wrapper.is(Component)).toBe(true)
 例:
 
 ```js
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 
@@ -95,8 +94,6 @@ shallow(Component, {
 例:
 
 ```js
-import { expect } from 'chai'
-
 const $route = { path: 'http://www.example-path.com' }
 const wrapper = shallow(Component, {
   mocks: {
@@ -117,7 +114,6 @@ expect(wrapper.vm.$route.path).toBe($route.path)
 ```js
 import { createLocalVue, mount } from '@vue/test-utils'
 import VueRouter from 'vue-router'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const localVue = createLocalVue()
@@ -190,5 +186,5 @@ const options = {
   }
 }
 const wrapper = mount(Component, options)
-expect(wrapper.text()).to.equal('aBC')
+expect(wrapper.text()).toBe('aBC')
 ```

--- a/docs/ja/api/selectors.md
+++ b/docs/ja/api/selectors.md
@@ -33,7 +33,6 @@ export default{
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = shallow(Foo)

--- a/docs/ja/api/shallow.md
+++ b/docs/ja/api/shallow.md
@@ -29,7 +29,6 @@
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -44,7 +43,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -63,7 +61,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -80,7 +77,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import FooBar from './FooBar.vue'
@@ -103,7 +99,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {

--- a/docs/ja/api/wrapper-array/at.md
+++ b/docs/ja/api/wrapper-array/at.md
@@ -11,7 +11,6 @@
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = shallow(Foo)

--- a/docs/ja/api/wrapper-array/contains.md
+++ b/docs/ja/api/wrapper-array/contains.md
@@ -13,7 +13,6 @@
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/ja/api/wrapper-array/destroy.md
+++ b/docs/ja/api/wrapper-array/destroy.md
@@ -6,7 +6,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper-array/is.md
+++ b/docs/ja/api/wrapper-array/is.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper-array/isEmpty.md
+++ b/docs/ja/api/wrapper-array/isEmpty.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper-array/isVisible.md
+++ b/docs/ja/api/wrapper-array/isVisible.md
@@ -12,7 +12,6 @@ style が `display: none` か `visibility: hidden` の親要素を持つ `Wrappe
 
 ```js
 import { mount } from 'vue-test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper-array/isVueInstance.md
+++ b/docs/ja/api/wrapper-array/isVueInstance.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/ja/api/wrapper-array/setData.md
+++ b/docs/ja/api/wrapper-array/setData.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/ja/api/wrapper-array/setMethods.md
+++ b/docs/ja/api/wrapper-array/setMethods.md
@@ -12,7 +12,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'

--- a/docs/ja/api/wrapper-array/setProps.md
+++ b/docs/ja/api/wrapper-array/setProps.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/ja/api/wrapper-array/trigger.md
+++ b/docs/ja/api/wrapper-array/trigger.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 

--- a/docs/ja/api/wrapper-array/update.md
+++ b/docs/ja/api/wrapper-array/update.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper/attributes.md
+++ b/docs/ja/api/wrapper/attributes.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper/classes.md
+++ b/docs/ja/api/wrapper/classes.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper/contains.md
+++ b/docs/ja/api/wrapper/contains.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/ja/api/wrapper/destroy.md
+++ b/docs/ja/api/wrapper/destroy.md
@@ -6,7 +6,6 @@ Vue コンポーネントインスタンスを破棄します。
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 
 const spy = sinon.stub()
@@ -16,5 +15,5 @@ mount({
     spy()
   }
 }).destroy()
-expect(spy.calledOnce).to.equal(true)
+expect(spy.calledOnce).toBe(true)
 ```

--- a/docs/ja/api/wrapper/emitted.md
+++ b/docs/ja/api/wrapper/emitted.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 
 const wrapper = mount(Component)
 
@@ -29,7 +28,7 @@ expect(wrapper.emitted().foo).toBeTruthy()
 expect(wrapper.emitted().foo.length).toBe(2)
 
 // イベントのペイロードを検証します
-expect(wrapper.emitted().foo[1]).toEqual([123])
+expect(wrapper.emitted().foo[1]).toBe([123])
 ```
 
 別の構文があります。

--- a/docs/ja/api/wrapper/emittedByOrder.md
+++ b/docs/ja/api/wrapper/emittedByOrder.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 
 const wrapper = mount(Component)
 

--- a/docs/ja/api/wrapper/exists.md
+++ b/docs/ja/api/wrapper/exists.md
@@ -10,7 +10,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper/find.md
+++ b/docs/ja/api/wrapper/find.md
@@ -13,7 +13,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/ja/api/wrapper/findAll.md
+++ b/docs/ja/api/wrapper/findAll.md
@@ -13,7 +13,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/ja/api/wrapper/html.md
+++ b/docs/ja/api/wrapper/html.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper/is.md
+++ b/docs/ja/api/wrapper/is.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper/isEmpty.md
+++ b/docs/ja/api/wrapper/isEmpty.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper/isVisible.md
+++ b/docs/ja/api/wrapper/isVisible.md
@@ -12,7 +12,6 @@ style が `display: none` か `visibility: hidden` の親要素がある場合�
 
 ```js
 import { mount } from 'vue-test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper/isVueInstance.md
+++ b/docs/ja/api/wrapper/isVueInstance.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper/name.md
+++ b/docs/ja/api/wrapper/name.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper/setData.md
+++ b/docs/ja/api/wrapper/setData.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper/setMethods.md
+++ b/docs/ja/api/wrapper/setMethods.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 

--- a/docs/ja/api/wrapper/setProps.md
+++ b/docs/ja/api/wrapper/setProps.md
@@ -12,12 +12,11 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)
 wrapper.setProps({ foo: 'bar' })
-expect(wrapper.vm.foo).to.equal('bar')
+expect(wrapper.vm.foo).toBe('bar')
 ```
 
 渡された値で Vue インスタンス を初期化する `propsData` オブジェクトを渡すことができます。
@@ -36,7 +35,6 @@ export default {
 
 ``` js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo, {
@@ -45,5 +43,5 @@ const wrapper = mount(Foo, {
   }
 })
 
-expect(wrapper.vm.foo).to.equal('bar')
+expect(wrapper.vm.foo).toBe('bar')
 ```

--- a/docs/ja/api/wrapper/text.md
+++ b/docs/ja/api/wrapper/text.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/api/wrapper/trigger.md
+++ b/docs/ja/api/wrapper/trigger.md
@@ -12,7 +12,6 @@ Triggerは `options` オブジェクト形式で行います。`options` オブ�
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo'
 

--- a/docs/ja/api/wrapper/update.md
+++ b/docs/ja/api/wrapper/update.md
@@ -8,7 +8,6 @@ Vue コンポーネントを強制的に再描画します。
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ja/guides/common-tips.md
+++ b/docs/ja/guides/common-tips.md
@@ -46,8 +46,6 @@ wrapper.emitted()は次のオブジェクトを返します:
 次に、これらのデータに基づいて検証することもできます。
 
 ``` js
-import { expect } from 'chai'
-
 // イベントが発行されたか検証する
 expect(wrapper.emitted().foo).toBeTruthy()
 

--- a/docs/ja/guides/dom-events.md
+++ b/docs/ja/guides/dom-events.md
@@ -151,27 +151,27 @@ import { mount } from '@vue/test-utils'
 describe('Key event tests', () => {
   it('Quantity is zero by default', () => {
     const wrapper = mount(QuantityComponent)
-    expect(wrapper.vm.quantity).to.equal(0)
+    expect(wrapper.vm.quantity).toBe(0)
   })
 
   it('Cursor up sets quantity to 1', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.trigger('keydown.up')
-    expect(wrapper.vm.quantity).to.equal(1)
+    expect(wrapper.vm.quantity).toBe(1)
   })
 
   it('Cursor down reduce quantity by 1', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.vm.quantity = 5
     wrapper.trigger('keydown.down')
-    expect(wrapper.vm.quantity).to.equal(4)
+    expect(wrapper.vm.quantity).toBe(4)
   })
 
   it('Escape sets quantity to 0', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.vm.quantity = 5
     wrapper.trigger('keydown.esc')
-    expect(wrapper.vm.quantity).to.equal(0)
+    expect(wrapper.vm.quantity).toBe(0)
   })
 
   it('Magic character "a" sets quantity to 13', () => {
@@ -179,7 +179,7 @@ describe('Key event tests', () => {
     wrapper.trigger('keydown', {
       which: 65
     })
-    expect(wrapper.vm.quantity).to.equal(13)
+    expect(wrapper.vm.quantity).toBe(13)
   })
 })
 

--- a/docs/ja/guides/testing-async-components.md
+++ b/docs/ja/guides/testing-async-components.md
@@ -52,7 +52,7 @@ test('Foo', () => {
   it('fetches async when a button is clicked', () => {
     const wrapper = shallow(Foo)
     wrapper.find('button').trigger('click')
-    expect(wrapper.vm.value).toEqual('value')
+    expect(wrapper.vm.value).toBe('value')
   })
 })
 ```
@@ -65,7 +65,7 @@ test('Foo', () => {
     const wrapper = shallow(Foo)
     wrapper.find('button').trigger('click')
     wrapper.vm.$nextTick(() => {
-      expect(wrapper.vm.value).toEqual('value')
+      expect(wrapper.vm.value).toBe('value')
       done()
     })
   })
@@ -89,7 +89,7 @@ test('Foo', () => {
     const wrapper = shallow(Foo)
     wrapper.find('button').trigger('click')
     await flushPromises()
-    expect(wrapper.vm.value).toEqual('value')
+    expect(wrapper.vm.value).toBe('value')
   })
 })
 ```

--- a/docs/kr/api/createLocalVue.md
+++ b/docs/kr/api/createLocalVue.md
@@ -11,7 +11,6 @@
 
 ```js
 import { createLocalVue, shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const localVue = createLocalVue()

--- a/docs/kr/api/mount.md
+++ b/docs/kr/api/mount.md
@@ -21,7 +21,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -35,7 +34,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -54,7 +52,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -70,7 +67,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import FooBar from './FooBar.vue'
@@ -93,7 +89,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -113,7 +108,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import Faz from './Faz.vue'

--- a/docs/kr/api/options.md
+++ b/docs/kr/api/options.md
@@ -42,7 +42,6 @@ expect(wrapper.is(Component)).toBe(true)
 예:
 
 ```js
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 
@@ -90,8 +89,6 @@ shallow(Component, {
 예:
 
 ```js
-import { expect } from 'chai'
-
 const $route = { path: 'http://www.example-path.com' }
 const wrapper = shallow(Component, {
   mocks: {
@@ -112,7 +109,6 @@ localVue는 [createLocalVue](./createLocalVue.md)에 의해 생성된 Vue의 로
 ```js
 import { createLocalVue, mount } from '@vue/test-utils'
 import VueRouter from 'vue-router'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const localVue = createLocalVue()

--- a/docs/kr/api/selectors.md
+++ b/docs/kr/api/selectors.md
@@ -35,7 +35,6 @@ export default{
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = shallow(Foo)

--- a/docs/kr/api/shallow.md
+++ b/docs/kr/api/shallow.md
@@ -32,7 +32,6 @@
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -47,7 +46,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -66,7 +64,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -83,7 +80,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import FooBar from './FooBar.vue'
@@ -106,7 +102,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {

--- a/docs/kr/api/wrapper-array/at.md
+++ b/docs/kr/api/wrapper-array/at.md
@@ -11,7 +11,6 @@
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = shallow(Foo)

--- a/docs/kr/api/wrapper-array/contains.md
+++ b/docs/kr/api/wrapper-array/contains.md
@@ -13,7 +13,6 @@
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/kr/api/wrapper-array/destroy.md
+++ b/docs/kr/api/wrapper-array/destroy.md
@@ -6,7 +6,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper-array/hasAttribute.md
+++ b/docs/kr/api/wrapper-array/hasAttribute.md
@@ -12,7 +12,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper-array/hasClass.md
+++ b/docs/kr/api/wrapper-array/hasClass.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper-array/hasProp.md
+++ b/docs/kr/api/wrapper-array/hasProp.md
@@ -14,7 +14,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/kr/api/wrapper-array/hasStyle.md
+++ b/docs/kr/api/wrapper-array/hasStyle.md
@@ -16,7 +16,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper-array/is.md
+++ b/docs/kr/api/wrapper-array/is.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper-array/isEmpty.md
+++ b/docs/kr/api/wrapper-array/isEmpty.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper-array/isVueInstance.md
+++ b/docs/kr/api/wrapper-array/isVueInstance.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/kr/api/wrapper-array/setData.md
+++ b/docs/kr/api/wrapper-array/setData.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/kr/api/wrapper-array/setMethods.md
+++ b/docs/kr/api/wrapper-array/setMethods.md
@@ -12,7 +12,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'

--- a/docs/kr/api/wrapper-array/setProps.md
+++ b/docs/kr/api/wrapper-array/setProps.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/kr/api/wrapper-array/trigger.md
+++ b/docs/kr/api/wrapper-array/trigger.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 

--- a/docs/kr/api/wrapper-array/update.md
+++ b/docs/kr/api/wrapper-array/update.md
@@ -9,7 +9,6 @@ Vue 컴포넌트 래퍼 배열에서 호출되면 각 Vue 컴포넌트가 강제
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper/contains.md
+++ b/docs/kr/api/wrapper/contains.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/kr/api/wrapper/destroy.md
+++ b/docs/kr/api/wrapper/destroy.md
@@ -6,7 +6,6 @@ Vue 컴포넌트 인스턴스를 파괴합니다.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 
 const spy = sinon.stub()
@@ -16,5 +15,5 @@ mount({
     spy()
   }
 }).destroy()
-expect(spy.calledOnce).to.equal(true)
+expect(spy.calledOnce).toBe(true)
 ```

--- a/docs/kr/api/wrapper/emitted.md
+++ b/docs/kr/api/wrapper/emitted.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 
 const wrapper = mount(Component)
 

--- a/docs/kr/api/wrapper/emittedByOrder.md
+++ b/docs/kr/api/wrapper/emittedByOrder.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 
 const wrapper = mount(Component)
 

--- a/docs/kr/api/wrapper/exists.md
+++ b/docs/kr/api/wrapper/exists.md
@@ -10,7 +10,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper/find.md
+++ b/docs/kr/api/wrapper/find.md
@@ -13,7 +13,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/kr/api/wrapper/findAll.md
+++ b/docs/kr/api/wrapper/findAll.md
@@ -13,7 +13,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/kr/api/wrapper/hasAttribute.md
+++ b/docs/kr/api/wrapper/hasAttribute.md
@@ -14,7 +14,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)
@@ -27,7 +26,6 @@ expect(wrapper.hasAttribute('id', 'foo')).toBe(true)
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper/hasClass.md
+++ b/docs/kr/api/wrapper/hasClass.md
@@ -13,7 +13,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper/hasProp.md
+++ b/docs/kr/api/wrapper/hasProp.md
@@ -16,7 +16,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper/hasStyle.md
+++ b/docs/kr/api/wrapper/hasStyle.md
@@ -16,7 +16,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper/html.md
+++ b/docs/kr/api/wrapper/html.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper/is.md
+++ b/docs/kr/api/wrapper/is.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper/isEmpty.md
+++ b/docs/kr/api/wrapper/isEmpty.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper/isVueInstance.md
+++ b/docs/kr/api/wrapper/isVueInstance.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper/name.md
+++ b/docs/kr/api/wrapper/name.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper/setData.md
+++ b/docs/kr/api/wrapper/setData.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper/setMethods.md
+++ b/docs/kr/api/wrapper/setMethods.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 

--- a/docs/kr/api/wrapper/setProps.md
+++ b/docs/kr/api/wrapper/setProps.md
@@ -11,12 +11,11 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)
 wrapper.setProps({ foo: 'bar' })
-expect(wrapper.vm.foo).to.equal('bar')
+expect(wrapper.vm.foo).toBe('bar')
 ```
 
 전달받은 값으로 Vue 인스턴스를 초기화하는 `propsData` 객체를 전달할 수 있습니다.
@@ -35,7 +34,6 @@ export default {
 
 ``` js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo, {
@@ -44,5 +42,5 @@ const wrapper = mount(Foo, {
   }
 })
 
-expect(wrapper.vm.foo).to.equal('bar')
+expect(wrapper.vm.foo).toBe('bar')
 ```

--- a/docs/kr/api/wrapper/text.md
+++ b/docs/kr/api/wrapper/text.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/api/wrapper/trigger.md
+++ b/docs/kr/api/wrapper/trigger.md
@@ -12,7 +12,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo'
 

--- a/docs/kr/api/wrapper/update.md
+++ b/docs/kr/api/wrapper/update.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/kr/guides/common-tips.md
+++ b/docs/kr/guides/common-tips.md
@@ -46,8 +46,6 @@ wrapper.emitted() 는 다음 객체를 반환합니다.
 그런 다음 위 데이터 기반으로 검증할 수 있습니다.
 
 ``` js
-import { expect } from 'chai'
-
 // 방출된 이벤트 검증
 expect(wrapper.emitted().foo).toBeTruthy()
 

--- a/docs/kr/guides/dom-events.md
+++ b/docs/kr/guides/dom-events.md
@@ -149,27 +149,27 @@ import { mount } from '@vue/test-utils'
 describe('Key event tests', () => {
   it('Quantity is zero by default', () => {
     const wrapper = mount(QuantityComponent)
-    expect(wrapper.vm.quantity).to.equal(0)
+    expect(wrapper.vm.quantity).toBe(0)
   })
 
   it('Cursor up sets quantity to 1', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.trigger('keydown.up')
-    expect(wrapper.vm.quantity).to.equal(1)
+    expect(wrapper.vm.quantity).toBe(1)
   })
 
   it('Cursor down reduce quantity by 1', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.vm.quantity = 5
     wrapper.trigger('keydown.down')
-    expect(wrapper.vm.quantity).to.equal(4)
+    expect(wrapper.vm.quantity).toBe(4)
   })
 
   it('Escape sets quantity to 0', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.vm.quantity = 5
     wrapper.trigger('keydown.esc')
-    expect(wrapper.vm.quantity).to.equal(0)
+    expect(wrapper.vm.quantity).toBe(0)
   })
 
   it('Magic character "a" sets quantity to 13', () => {
@@ -177,7 +177,7 @@ describe('Key event tests', () => {
     wrapper.trigger('keydown', {
       which: 65
     })
-    expect(wrapper.vm.quantity).to.equal(13)
+    expect(wrapper.vm.quantity).toBe(13)
   })
 })
 

--- a/docs/pt-br/api/createLocalVue.md
+++ b/docs/pt-br/api/createLocalVue.md
@@ -11,7 +11,6 @@ Usando com o `options.localVue`
 
 ```js
 import { createLocalVue, shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const localVue = createLocalVue()

--- a/docs/pt-br/api/mount.md
+++ b/docs/pt-br/api/mount.md
@@ -21,7 +21,6 @@ Use qualquer [seletor](selectors.md) válido.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -36,7 +35,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -55,7 +53,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -72,7 +69,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import FooBar from './FooBar.vue'
@@ -95,7 +91,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -115,7 +110,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import Faz from './Faz.vue'

--- a/docs/pt-br/api/options.md
+++ b/docs/pt-br/api/options.md
@@ -42,7 +42,6 @@ Forneça um objeto do slot para o componente. A chave corresponde ao nome do slo
 Exemplo:
 
 ```js
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 
@@ -90,7 +89,6 @@ Adiciona uma propriedade adicional à instância. Ótimo para simular injeções
 Exemplo:
 
 ```js
-import { expect } from 'chai'
 
 const $route = { path: 'http://www.meusite.com.br' }
 const wrapper = shallow(Component, {
@@ -112,7 +110,6 @@ Exemplo:
 ```js
 import { createLocalVue, mount } from '@vue/test-utils'
 import VueRouter from 'vue-router'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const localVue = createLocalVue()

--- a/docs/pt-br/api/selectors.md
+++ b/docs/pt-br/api/selectors.md
@@ -35,7 +35,6 @@ export default{
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = shallow(Foo)

--- a/docs/pt-br/api/shallow.md
+++ b/docs/pt-br/api/shallow.md
@@ -32,7 +32,6 @@ Use qualquer [seletor](selectors.md) válido.
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -47,7 +46,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -66,7 +64,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -83,7 +80,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import FooBar from './FooBar.vue'
@@ -106,7 +102,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {

--- a/docs/pt-br/api/wrapper-array/at.md
+++ b/docs/pt-br/api/wrapper-array/at.md
@@ -11,7 +11,6 @@ Retorna o wrapper correspondente ao `indice` passado. Use números para correspo
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = shallow(Foo)

--- a/docs/pt-br/api/wrapper-array/contains.md
+++ b/docs/pt-br/api/wrapper-array/contains.md
@@ -13,7 +13,6 @@ Use qualquer [seletor](../selectors.md) válido.
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/pt-br/api/wrapper-array/destroy.md
+++ b/docs/pt-br/api/wrapper-array/destroy.md
@@ -6,7 +6,6 @@ Destroí a instância do Vue da cada um dos wrappers do Array.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper-array/hasAttribute.md
+++ b/docs/pt-br/api/wrapper-array/hasAttribute.md
@@ -12,7 +12,6 @@ Verifica se algum wrapper do Array tem o `atributo` com `value` correspondente n
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper-array/hasClass.md
+++ b/docs/pt-br/api/wrapper-array/hasClass.md
@@ -11,7 +11,6 @@ Verifica se algum wrapper do Array contém uma classe com o nome `className` no 
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper-array/hasProp.md
+++ b/docs/pt-br/api/wrapper-array/hasProp.md
@@ -14,7 +14,6 @@ Verifica se algum wrapper do Array possui a `propriedade` com o `value` no `vm`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/pt-br/api/wrapper-array/hasStyle.md
+++ b/docs/pt-br/api/wrapper-array/hasStyle.md
@@ -16,7 +16,6 @@ Retorna `true` se o wrapper contém o `style` com o `value`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper-array/is.md
+++ b/docs/pt-br/api/wrapper-array/is.md
@@ -11,7 +11,6 @@ Verifica se algum wrapper do Array possui o [seletor](../selectors.md) no seu `v
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper-array/isEmpty.md
+++ b/docs/pt-br/api/wrapper-array/isEmpty.md
@@ -8,7 +8,6 @@ Verifica se algum wrapper do Array não tem um elemento filho.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper-array/isVueInstance.md
+++ b/docs/pt-br/api/wrapper-array/isVueInstance.md
@@ -8,7 +8,6 @@ Verifica se algum wrapper do Array é uma instância do Vue.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/pt-br/api/wrapper-array/setData.md
+++ b/docs/pt-br/api/wrapper-array/setData.md
@@ -11,7 +11,6 @@ Define os dados e força a atualização de cada wrapper presente no Array.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/pt-br/api/wrapper-array/setMethods.md
+++ b/docs/pt-br/api/wrapper-array/setMethods.md
@@ -11,7 +11,6 @@ Define os métodos do componente e força sua atualização para cada wrapper no
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'

--- a/docs/pt-br/api/wrapper-array/setProps.md
+++ b/docs/pt-br/api/wrapper-array/setProps.md
@@ -11,7 +11,6 @@ Define as `propriedades` do componente e força sua atualização para cada wrap
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/pt-br/api/wrapper-array/trigger.md
+++ b/docs/pt-br/api/wrapper-array/trigger.md
@@ -11,7 +11,6 @@ Aciona um evento no elemeto do DOM de cada wrapper no Array.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 

--- a/docs/pt-br/api/wrapper-array/update.md
+++ b/docs/pt-br/api/wrapper-array/update.md
@@ -8,7 +8,6 @@ Se for chamado a partir de um componente Vue, força a atualização de cada com
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper/contains.md
+++ b/docs/pt-br/api/wrapper/contains.md
@@ -11,7 +11,6 @@ Verifica se o wrapper contém um elemento ou componente com o [seletor](../selec
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/pt-br/api/wrapper/destroy.md
+++ b/docs/pt-br/api/wrapper/destroy.md
@@ -6,7 +6,6 @@ Destrói a instância do componente Vue.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 
 const spy = sinon.stub()
@@ -18,5 +17,5 @@ mount({
   }
 }).destroy()
 
-expect(spy.calledOnce).to.equal(true)
+expect(spy.calledOnce).toBe(true)
 ```

--- a/docs/pt-br/api/wrapper/emitted.md
+++ b/docs/pt-br/api/wrapper/emitted.md
@@ -8,7 +8,6 @@ Retorna um objeto contendo os eventos cutomizados emitidos pelo `vm` do wrapper.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 
 const wrapper = mount(Componente)
 

--- a/docs/pt-br/api/wrapper/emittedByOrder.md
+++ b/docs/pt-br/api/wrapper/emittedByOrder.md
@@ -8,7 +8,6 @@ Retorna um Array contendo os eventos customizados emitidos pelo `vm` do wrapper.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 
 const wrapper = mount(Component)
 

--- a/docs/pt-br/api/wrapper/exists.md
+++ b/docs/pt-br/api/wrapper/exists.md
@@ -10,7 +10,6 @@ Retorna `false` se chamado com um `Wrapper` ou `WrapperArray` vazio.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper/find.md
+++ b/docs/pt-br/api/wrapper/find.md
@@ -13,7 +13,6 @@ Use qualquer [seletor](../selectors.md) válido.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/pt-br/api/wrapper/findAll.md
+++ b/docs/pt-br/api/wrapper/findAll.md
@@ -13,7 +13,6 @@ Use qualquer [seletor](../selectors.md) válido.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/pt-br/api/wrapper/hasAttribute.md
+++ b/docs/pt-br/api/wrapper/hasAttribute.md
@@ -14,7 +14,6 @@ Retorna `true` se o wrapper contém o atributo.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 // Exemplo <div class="foo">...</div>
@@ -28,7 +27,6 @@ Você poderia obter o atributo do `Wrapper.element` para então verificar basead
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper/hasClass.md
+++ b/docs/pt-br/api/wrapper/hasClass.md
@@ -13,7 +13,6 @@ Retorna `true` se o wrapper contém a classe.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper/hasProp.md
+++ b/docs/pt-br/api/wrapper/hasProp.md
@@ -16,7 +16,6 @@ Retorna `true` se o `vm` do wrapper tem a `propriedade` com o `value` passado.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper/hasStyle.md
+++ b/docs/pt-br/api/wrapper/hasStyle.md
@@ -16,7 +16,6 @@ Retorna `true` se o wrapper possui um `style` com o `value`.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper/html.md
+++ b/docs/pt-br/api/wrapper/html.md
@@ -8,7 +8,6 @@ Retorna o HTML do elemento do wrapper como uma String.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper/is.md
+++ b/docs/pt-br/api/wrapper/is.md
@@ -11,7 +11,6 @@ Verifica se o `vm` do wrapper possui o [seletor](../selectors.md) informado.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper/isEmpty.md
+++ b/docs/pt-br/api/wrapper/isEmpty.md
@@ -8,7 +8,6 @@ Verifica se o wrapper não contem elementos filhos.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper/isVueInstance.md
+++ b/docs/pt-br/api/wrapper/isVueInstance.md
@@ -8,7 +8,6 @@ Verifica se o wrapper é uma intância do Vue.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper/name.md
+++ b/docs/pt-br/api/wrapper/name.md
@@ -8,7 +8,6 @@ Retorna o nome do componente se o wrapper for uma instância do Vue, ou então o
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper/setData.md
+++ b/docs/pt-br/api/wrapper/setData.md
@@ -11,7 +11,6 @@ Define os dados do `vm` do wrapper e força a sua atualização.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper/setMethods.md
+++ b/docs/pt-br/api/wrapper/setMethods.md
@@ -11,7 +11,6 @@ Define os métodos do `vm` do wrapper e força sua atualização.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 

--- a/docs/pt-br/api/wrapper/setProps.md
+++ b/docs/pt-br/api/wrapper/setProps.md
@@ -11,12 +11,11 @@ Define as propriedades do `vm` do wrapper e força sua atualização.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)
 wrapper.setProps({ foo: 'bar' })
-expect(wrapper.vm.foo).to.equal('bar')
+expect(wrapper.vm.foo).toBe('bar')
 ```
 
 Além disso, você pode passar o objeto `propsData`, que irá inicializar a instância do Vue com os valores passados.
@@ -35,7 +34,6 @@ export default {
 
 ``` js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo, {
@@ -44,5 +42,5 @@ const wrapper = mount(Foo, {
   }
 })
 
-expect(wrapper.vm.foo).to.equal('bar')
+expect(wrapper.vm.foo).toBe('bar')
 ```

--- a/docs/pt-br/api/wrapper/text.md
+++ b/docs/pt-br/api/wrapper/text.md
@@ -8,7 +8,6 @@ Retorna o texto contido no wrapper.
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/api/wrapper/trigger.md
+++ b/docs/pt-br/api/wrapper/trigger.md
@@ -12,7 +12,6 @@ O método `trigger` usa o objeto opicional `options`, essas opções serão adic
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo'
 

--- a/docs/pt-br/api/wrapper/update.md
+++ b/docs/pt-br/api/wrapper/update.md
@@ -8,7 +8,6 @@ Se você chamar esse método em um wrapper que contém `vm`, ele forçará o `vm
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/pt-br/guides/common-tips.md
+++ b/docs/pt-br/guides/common-tips.md
@@ -47,8 +47,6 @@ wrapper.emitted() retorna o objeto a seguir:
 Então você pode criar asserções baseadas nesses dados:
 
 ``` js
-import { expect } from 'chai'
-
 // verifica se o evento 'foo' foi emitido
 expect(wrapper.emitted().foo).toBeTruthy()
 

--- a/docs/pt-br/guides/dom-events.md
+++ b/docs/pt-br/guides/dom-events.md
@@ -149,27 +149,27 @@ import { mount } from '@vue/test-utils'
 describe('Testes de eventos de tecla', () => {
   it('Contador é zero por padrão', () => {
     const wrapper = mount(ContadorComponente)
-    expect(wrapper.vm.contador).to.equal(0)
+    expect(wrapper.vm.contador).toBe(0)
   })
 
   it('Tecla para cima incrementa contador para um', () => {
     const wrapper = mount(ContadorComponente)
     wrapper.trigger('keydown.up')
-    expect(wrapper.vm.contador).to.equal(1)
+    expect(wrapper.vm.contador).toBe(1)
   })
 
   it('Tecla para baixo decrementa contador para quatro', () => {
     const wrapper = mount(ContadorComponente)
     wrapper.vm.contador = 5
     wrapper.trigger('keydown.down')
-    expect(wrapper.vm.contador).to.equal(4)
+    expect(wrapper.vm.contador).toBe(4)
   })
 
   it('Tecla esc volta o contador para zero', () => {
     const wrapper = mount(ContadorComponente)
     wrapper.vm.contador = 5
     wrapper.trigger('keydown.esc')
-    expect(wrapper.vm.contador).to.equal(0)
+    expect(wrapper.vm.contador).toBe(0)
   })
 
   it('Tecla A define o contador para 13', () => {
@@ -177,7 +177,7 @@ describe('Testes de eventos de tecla', () => {
     wrapper.trigger('keydown', {
       which: 65
     })
-    expect(wrapper.vm.contador).to.equal(13)
+    expect(wrapper.vm.contador).toBe(13)
   })
 })
 

--- a/docs/ru/api/createLocalVue.md
+++ b/docs/ru/api/createLocalVue.md
@@ -11,7 +11,6 @@
 
 ```js
 import { createLocalVue, shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const localVue = createLocalVue()

--- a/docs/ru/api/mount.md
+++ b/docs/ru/api/mount.md
@@ -19,7 +19,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -34,7 +33,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -53,7 +51,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -70,7 +67,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import FooBar from './FooBar.vue'
@@ -93,7 +89,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -113,7 +108,6 @@ describe('Foo', () => {
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import Faz from './Faz.vue'

--- a/docs/ru/api/options.md
+++ b/docs/ru/api/options.md
@@ -45,7 +45,6 @@ expect(wrapper.is(Component)).toBe(true)
 Пример:
 
 ```js
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 
@@ -102,8 +101,6 @@ shallow(Component, {
 Пример:
 
 ```js
-import { expect } from 'chai'
-
 const $route = { path: 'http://www.example-path.com' }
 const wrapper = shallow(Component, {
   mocks: {
@@ -124,7 +121,6 @@ expect(wrapper.vm.$route.path).toBe($route.path)
 ```js
 import { createLocalVue, mount } from '@vue/test-utils'
 import VueRouter from 'vue-router'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const localVue = createLocalVue()
@@ -197,5 +193,5 @@ const options = {
   }
 }
 const wrapper = mount(Component, options)
-expect(wrapper.text()).to.equal('aBC')
+expect(wrapper.text()).toBe('aBC')
 ```

--- a/docs/ru/api/selectors.md
+++ b/docs/ru/api/selectors.md
@@ -33,7 +33,6 @@ export default {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = shallow(Foo)

--- a/docs/ru/api/shallow.md
+++ b/docs/ru/api/shallow.md
@@ -28,7 +28,6 @@
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -43,7 +42,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -62,7 +60,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {
@@ -79,7 +76,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 import FooBar from './FooBar.vue'
@@ -102,7 +98,6 @@ describe('Foo', () => {
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 describe('Foo', () => {

--- a/docs/ru/api/wrapper-array/at.md
+++ b/docs/ru/api/wrapper-array/at.md
@@ -11,7 +11,6 @@
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = shallow(Foo)

--- a/docs/ru/api/wrapper-array/contains.md
+++ b/docs/ru/api/wrapper-array/contains.md
@@ -13,7 +13,6 @@
 
 ```js
 import { shallow } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/ru/api/wrapper-array/destroy.md
+++ b/docs/ru/api/wrapper-array/destroy.md
@@ -6,7 +6,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper-array/hasStyle.md
+++ b/docs/ru/api/wrapper-array/hasStyle.md
@@ -16,7 +16,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper-array/is.md
+++ b/docs/ru/api/wrapper-array/is.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper-array/isEmpty.md
+++ b/docs/ru/api/wrapper-array/isEmpty.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper-array/isVueInstance.md
+++ b/docs/ru/api/wrapper-array/isVueInstance.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/ru/api/wrapper-array/setData.md
+++ b/docs/ru/api/wrapper-array/setData.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/ru/api/wrapper-array/setMethods.md
+++ b/docs/ru/api/wrapper-array/setMethods.md
@@ -12,7 +12,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'

--- a/docs/ru/api/wrapper-array/setProps.md
+++ b/docs/ru/api/wrapper-array/setProps.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/ru/api/wrapper-array/trigger.md
+++ b/docs/ru/api/wrapper-array/trigger.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 

--- a/docs/ru/api/wrapper-array/update.md
+++ b/docs/ru/api/wrapper-array/update.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper/attributes.md
+++ b/docs/ru/api/wrapper/attributes.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper/classes.md
+++ b/docs/ru/api/wrapper/classes.md
@@ -10,7 +10,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper/contains.md
+++ b/docs/ru/api/wrapper/contains.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/ru/api/wrapper/destroy.md
+++ b/docs/ru/api/wrapper/destroy.md
@@ -6,7 +6,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 
 const spy = sinon.stub()
@@ -16,5 +15,5 @@ mount({
     spy()
   }
 }).destroy()
-expect(spy.calledOnce).to.equal(true)
+expect(spy.calledOnce).toBe(true)
 ```

--- a/docs/ru/api/wrapper/emitted.md
+++ b/docs/ru/api/wrapper/emitted.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 
 const wrapper = mount(Component)
 

--- a/docs/ru/api/wrapper/emittedByOrder.md
+++ b/docs/ru/api/wrapper/emittedByOrder.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 
 const wrapper = mount(Component)
 

--- a/docs/ru/api/wrapper/exists.md
+++ b/docs/ru/api/wrapper/exists.md
@@ -10,7 +10,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper/find.md
+++ b/docs/ru/api/wrapper/find.md
@@ -13,7 +13,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/ru/api/wrapper/findAll.md
+++ b/docs/ru/api/wrapper/findAll.md
@@ -13,7 +13,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 

--- a/docs/ru/api/wrapper/hasStyle.md
+++ b/docs/ru/api/wrapper/hasStyle.md
@@ -16,7 +16,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper/html.md
+++ b/docs/ru/api/wrapper/html.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper/is.md
+++ b/docs/ru/api/wrapper/is.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper/isEmpty.md
+++ b/docs/ru/api/wrapper/isEmpty.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper/isVueInstance.md
+++ b/docs/ru/api/wrapper/isVueInstance.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper/name.md
+++ b/docs/ru/api/wrapper/name.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper/props.md
+++ b/docs/ru/api/wrapper/props.md
@@ -10,7 +10,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo, {

--- a/docs/ru/api/wrapper/setData.md
+++ b/docs/ru/api/wrapper/setData.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper/setMethods.md
+++ b/docs/ru/api/wrapper/setMethods.md
@@ -11,7 +11,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 

--- a/docs/ru/api/wrapper/setProps.md
+++ b/docs/ru/api/wrapper/setProps.md
@@ -11,12 +11,11 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)
 wrapper.setProps({ foo: 'bar' })
-expect(wrapper.vm.foo).to.equal('bar')
+expect(wrapper.vm.foo).toBe('bar')
 ```
 
 Вы также можете передать объект `propsData`, который инициализирует экземпляр Vue с переданными значениями.
@@ -35,7 +34,6 @@ export default {
 
 ``` js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo, {
@@ -44,5 +42,5 @@ const wrapper = mount(Foo, {
   }
 })
 
-expect(wrapper.vm.foo).to.equal('bar')
+expect(wrapper.vm.foo).toBe('bar')
 ```

--- a/docs/ru/api/wrapper/text.md
+++ b/docs/ru/api/wrapper/text.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/api/wrapper/trigger.md
+++ b/docs/ru/api/wrapper/trigger.md
@@ -12,7 +12,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import sinon from 'sinon'
 import Foo from './Foo'
 

--- a/docs/ru/api/wrapper/update.md
+++ b/docs/ru/api/wrapper/update.md
@@ -8,7 +8,6 @@
 
 ```js
 import { mount } from '@vue/test-utils'
-import { expect } from 'chai'
 import Foo from './Foo.vue'
 
 const wrapper = mount(Foo)

--- a/docs/ru/guides/common-tips.md
+++ b/docs/ru/guides/common-tips.md
@@ -46,8 +46,6 @@ wrapper.vm.$emit('foo', 123)
 Затем вы можете добавить проверки на основе этих данных:
 
 ``` js
-import { expect } from 'chai'
-
 // проверка, что событие было вызвано
 expect(wrapper.emitted().foo).toBeTruthy()
 

--- a/docs/ru/guides/dom-events.md
+++ b/docs/ru/guides/dom-events.md
@@ -149,27 +149,27 @@ import { mount } from '@vue/test-utils'
 describe('Тестирование событий клавиш', () => {
   it('Quantity по умолчанию равно нулю', () => {
     const wrapper = mount(QuantityComponent)
-    expect(wrapper.vm.quantity).to.equal(0)
+    expect(wrapper.vm.quantity).toBe(0)
   })
 
   it('Клавиша вверх устанавливает quantity равным 1', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.trigger('keydown.up')
-    expect(wrapper.vm.quantity).to.equal(1)
+    expect(wrapper.vm.quantity).toBe(1)
   })
 
   it('Клавиша вниз уменьшает quantity на 1', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.vm.quantity = 5
     wrapper.trigger('keydown.down')
-    expect(wrapper.vm.quantity).to.equal(4)
+    expect(wrapper.vm.quantity).toBe(4)
   })
 
   it('Escape устанавливает quantity равным 0', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.vm.quantity = 5
     wrapper.trigger('keydown.esc')
-    expect(wrapper.vm.quantity).to.equal(0)
+    expect(wrapper.vm.quantity).toBe(0)
   })
 
   it('Магический символ "a" устанавливает quantity равным 13', () => {
@@ -177,7 +177,7 @@ describe('Тестирование событий клавиш', () => {
     wrapper.trigger('keydown', {
       which: 65
     })
-    expect(wrapper.vm.quantity).to.equal(13)
+    expect(wrapper.vm.quantity).toBe(13)
   })
 })
 

--- a/docs/ru/guides/testing-async-components.md
+++ b/docs/ru/guides/testing-async-components.md
@@ -52,7 +52,7 @@ test('Foo', () => {
   it('делает асинхронный запрос при нажатии кнопки', () => {
     const wrapper = shallow(Foo)
     wrapper.find('button').trigger('click')
-    expect(wrapper.vm.value).toEqual('value')
+    expect(wrapper.vm.value).toBe('value')
   })
 })
 ```
@@ -65,7 +65,7 @@ test('Foo', () => {
     const wrapper = shallow(Foo)
     wrapper.find('button').trigger('click')
     wrapper.vm.$nextTick(() => {
-      expect(wrapper.vm.value).toEqual('value')
+      expect(wrapper.vm.value).toBe('value')
       done()
     })
   })
@@ -89,7 +89,7 @@ test('Foo', () => {
     const wrapper = shallow(Foo)
     wrapper.find('button').trigger('click')
     await flushPromises()
-    expect(wrapper.vm.value).toEqual('value')
+    expect(wrapper.vm.value).toBe('value')
   })
 })
 ```


### PR DESCRIPTION
fixes #437 

Removed most of the references to Chai (sans Karma example page).  Updated the style in a few spots from Chai styling to Jest. For example:

````javascript
// Chai
expect(wrapper.value).to.equal(true)
// Jest
expect(wrapper.value).toBe(true)
````


Excluded the CN docs as there was a PR that looked like it'd conflict if I made the same changes.