### PR TITLE
fix classes() for svg elements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "globals": {
     "wrapper": true,
     "expect": true,
-    "Element": true
+    "Element": true,
+    "SVGAnimatedString": true
   },
   "root": true,
   "plugins": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,8 +2,7 @@
   "globals": {
     "wrapper": true,
     "expect": true,
-    "Element": true,
-    "SVGAnimatedString": true
+    "Element": true
   },
   "root": true,
   "plugins": [

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -69,7 +69,12 @@ export default class Wrapper implements BaseWrapper {
    * Returns an Array containing all the classes on the element
    */
   classes (): Array<string> {
-    let classes = this.element.className ? this.element.className.split(' ') : []
+    let classes = this.element.className;
+    if (classes instanceof SVGAnimatedString) {
+      classes = this.element.getAttribute('class') || [];
+    } else {
+      classes = this.element.className ? this.element.className.split(' ') : [];
+    }
     // Handle converting cssmodules identifiers back to the original class name
     if (this.vm && this.vm.$style) {
       const cssModuleIdentifiers = {}

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -70,9 +70,8 @@ export default class Wrapper implements BaseWrapper {
    */
   classes (): Array<string> {
     // works for HTML Element and SVG Element
-    let className = this.element.getAttribute('class')
-    let classes = className ? className.split(' ') : []
-    
+    const className = this.element.getAttribute('class')
+    let classes = className ? className.split(' ') : []    
     // Handle converting cssmodules identifiers back to the original class name
     if (this.vm && this.vm.$style) {
       const cssModuleIdentifiers = {}

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -69,11 +69,11 @@ export default class Wrapper implements BaseWrapper {
    * Returns an Array containing all the classes on the element
    */
   classes (): Array<string> {
-    let classes = this.element.className;
+    let classes = this.element.className
     if (classes instanceof SVGAnimatedString) {
-      classes = this.element.getAttribute('class') || [];
+      classes = this.element.getAttribute('class') || []
     } else {
-      classes = this.element.className ? this.element.className.split(' ') : [];
+      classes = this.element.className ? this.element.className.split(' ') : []
     }
     // Handle converting cssmodules identifiers back to the original class name
     if (this.vm && this.vm.$style) {

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -71,7 +71,7 @@ export default class Wrapper implements BaseWrapper {
   classes (): Array<string> {
     // works for HTML Element and SVG Element
     const className = this.element.getAttribute('class')
-    let classes = className ? className.split(' ') : []    
+    let classes = className ? className.split(' ') : []
     // Handle converting cssmodules identifiers back to the original class name
     if (this.vm && this.vm.$style) {
       const cssModuleIdentifiers = {}

--- a/src/wrappers/wrapper.js
+++ b/src/wrappers/wrapper.js
@@ -69,12 +69,10 @@ export default class Wrapper implements BaseWrapper {
    * Returns an Array containing all the classes on the element
    */
   classes (): Array<string> {
-    let classes = this.element.className
-    if (classes instanceof SVGAnimatedString) {
-      classes = this.element.getAttribute('class') || []
-    } else {
-      classes = this.element.className ? this.element.className.split(' ') : []
-    }
+    // works for HTML Element and SVG Element
+    let className = this.element.getAttribute('class')
+    let classes = className ? className.split(' ') : []
+    
     // Handle converting cssmodules identifiers back to the original class name
     if (this.vm && this.vm.$style) {
       const cssModuleIdentifiers = {}

--- a/test/specs/wrapper/classes.spec.js
+++ b/test/specs/wrapper/classes.spec.js
@@ -20,4 +20,12 @@ describeWithShallowAndMount('classes', (mountingMethod) => {
     const wrapper = mountingMethod(ComponentWithCssModules)
     expect(wrapper.classes()).to.eql(['extension', 'color-red'])
   })
+
+  it('returns array of class names for svg element', () => {
+    const compiled = compileToFunctions('<svg class="a-class b-class"><text class="c-class"/></svg>')
+    const wrapper = mountingMethod(compiled)
+    expect(wrapper.classes()).to.contain('a-class')
+    expect(wrapper.classes()).to.contain('b-class')
+    expect(wrapper.find('text').classes()).to.contain('c-class')
+  })
 })


### PR DESCRIPTION
Hello I had a problem using classes function on svg elements (same as #362).
This pull request should fix it as className returns a SVGAnimatedString object for svg elements instead of a simple string.
See notes in [(https://developer.mozilla.org/fr/docs/Web/API/Element/className)]

