### PR TITLE
DOCS: replace hasProp() to props() in docs examples

### DIFF
--- a/docs/en/api/mount.md
+++ b/docs/en/api/mount.md
@@ -42,7 +42,7 @@ describe('Foo', () => {
         color: 'red'
       }
     })
-    expect(wrapper.hasProp('color', 'red')).toBe(true)
+    expect(wrapper.props().color).toBe('red')
   })
 })
 ```

--- a/docs/en/api/shallow.md
+++ b/docs/en/api/shallow.md
@@ -51,7 +51,7 @@ describe('Foo', () => {
         color: 'red'
       }
     })
-    expect(wrapper.hasProp('color', 'red')).toBe(true)
+    expect(wrapper.props().color).toBe('red')
   })
 })
 ```

--- a/docs/fr/api/mount.md
+++ b/docs/fr/api/mount.md
@@ -44,7 +44,7 @@ describe('Foo', () => {
         color: 'red'
       }
     })
-    expect(wrapper.hasProp('color', 'red')).toBe(true)
+    expect(wrapper.props().color).toBe('red')
   })
 })
 ```

--- a/docs/fr/api/shallow.md
+++ b/docs/fr/api/shallow.md
@@ -55,7 +55,7 @@ describe('Foo', () => {
         color: 'red'
       }
     })
-    expect(wrapper.hasProp('color', 'red')).toBe(true)
+    expect(wrapper.props().color).toBe('red')
   })
 })
 ```

--- a/docs/ja/api/mount.md
+++ b/docs/ja/api/mount.md
@@ -41,7 +41,7 @@ describe('Foo', () => {
         color: 'red'
       }
     })
-    expect(wrapper.hasProp('color', 'red')).toBe(true)
+    expect(wrapper.props().color).toBe('red')
   })
 })
 ```

--- a/docs/ja/api/shallow.md
+++ b/docs/ja/api/shallow.md
@@ -52,7 +52,7 @@ describe('Foo', () => {
         color: 'red'
       }
     })
-    expect(wrapper.hasProp('color', 'red')).toBe(true)
+    expect(wrapper.props().color).toBe('red')
   })
 })
 ```

--- a/docs/kr/api/mount.md
+++ b/docs/kr/api/mount.md
@@ -43,7 +43,7 @@ describe('Foo', () => {
         color: 'red'
       }
     })
-    expect(wrapper.hasProp('color', 'red')).toBe(true)
+    expect(wrapper.props().color).toBe('red')
   })
 })
 ```

--- a/docs/kr/api/shallow.md
+++ b/docs/kr/api/shallow.md
@@ -55,7 +55,7 @@ describe('Foo', () => {
         color: 'red'
       }
     })
-    expect(wrapper.hasProp('color', 'red')).toBe(true)
+    expect(wrapper.props().color).toBe('red')
   })
 })
 ```

--- a/docs/pt-br/api/mount.md
+++ b/docs/pt-br/api/mount.md
@@ -44,7 +44,7 @@ describe('Foo', () => {
         cor: 'vermelha'
       }
     })
-    expect(wrapper.hasProp('cor', 'vermelha')).toBe(true)
+    expect(wrapper.props().cor).toBe('vermelha')
   })
 })
 ```

--- a/docs/pt-br/api/shallow.md
+++ b/docs/pt-br/api/shallow.md
@@ -55,7 +55,7 @@ describe('Foo', () => {
         color: 'red'
       }
     })
-    expect(wrapper.hasProp('color', 'red')).toBe(true)
+    expect(wrapper.props().color).toBe('red')
   })
 })
 ```

--- a/docs/ru/api/mount.md
+++ b/docs/ru/api/mount.md
@@ -42,7 +42,7 @@ describe('Foo', () => {
         color: 'red'
       }
     })
-    expect(wrapper.hasProp('color', 'red')).toBe(true)
+    expect(wrapper.props().color).toBe('red')
   })
 })
 ```

--- a/docs/ru/api/shallow.md
+++ b/docs/ru/api/shallow.md
@@ -51,7 +51,7 @@ describe('Foo', () => {
         color: 'red'
       }
     })
-    expect(wrapper.hasProp('color', 'red')).toBe(true)
+    expect(wrapper.props().color).toBe('red')
   })
 })
 ```

--- a/docs/zh-cn/api/mount.md
+++ b/docs/zh-cn/api/mount.md
@@ -42,7 +42,7 @@ describe('Foo', () => {
         color: 'red'
       }
     })
-    expect(wrapper.hasProp('color', 'red')).toBe(true)
+    expect(wrapper.props().color).toBe('red')
   })
 })
 ```

--- a/docs/zh-cn/api/shallow.md
+++ b/docs/zh-cn/api/shallow.md
@@ -51,7 +51,7 @@ describe('Foo', () => {
         color: 'red'
       }
     })
-    expect(wrapper.hasProp('color', 'red')).toBe(true)
+    expect(wrapper.props().color).toBe('red')
   })
 })
 ```


### PR DESCRIPTION
Hey!

I've noticed that `hasProp` is deprecated:

```
console.error node_modules/@vue/test-utils/dist/vue-test-utils.js:15
      [vue-test-utils]: hasProp() has been deprecated and will be removed in version 1.0.0. Use props() instead—https://vue-test-utils.vuejs.org/en/api/wrapper/props
```

So I replaced `hasProps` to `props` in the docs.