### PR TITLE
[docs][en] Replace from mapCoverage to collectCoverage in Jest sample.

### DIFF
--- a/docs/en/guides/testing-SFCs-with-jest.md
+++ b/docs/en/guides/testing-SFCs-with-jest.md
@@ -159,7 +159,7 @@ Jest recommends creating a `__tests__` directory right next to the code being te
 
 Jest can be used to generate coverage reports in multiple formats. The following is a simple example to get started with:
 
-Extend your `jest` config (usually in `package.json` or `jest.config.js`) with the [`collectCoverage`](https://facebook.github.io/jest/docs/en/configuration.html#collectcoverage-boolean) option, and then add the [`collectCoverageFrom`](https://facebook.github.io/jest/docs/en/configuration.html#collectcoveragefrom-array) array to define the files for which coverage information should be collected. You'll also want [`collectCoverage`](https://facebook.github.io/jest/docs/en/configuration.html#mapcoverage-boolean) to be `true`, for coverage data to be accurate.
+Extend your `jest` config (usually in `package.json` or `jest.config.js`) with the [`collectCoverage`](https://facebook.github.io/jest/docs/en/configuration.html#collectcoverage-boolean) option, and then add the [`collectCoverageFrom`](https://facebook.github.io/jest/docs/en/configuration.html#collectcoveragefrom-array) array to define the files for which coverage information should be collected.
 
 ```json
 {
@@ -169,8 +169,7 @@ Extend your `jest` config (usually in `package.json` or `jest.config.js`) with t
     "collectCoverageFrom": [
       "**/*.{js,vue}",
       "!**/node_modules/**"
-    ],
-    "collectCoverage": true
+    ]
   }
 }
 ```

--- a/docs/en/guides/testing-SFCs-with-jest.md
+++ b/docs/en/guides/testing-SFCs-with-jest.md
@@ -48,8 +48,7 @@ Next, create a `jest` block in `package.json`:
     "transform": {
       // process `*.vue` files with `vue-jest`
       ".*\\.(vue)$": "<rootDir>/node_modules/vue-jest"
-    },
-    "collectCoverage": true
+    }
   }
 }
 ```

--- a/docs/en/guides/testing-SFCs-with-jest.md
+++ b/docs/en/guides/testing-SFCs-with-jest.md
@@ -49,7 +49,7 @@ Next, create a `jest` block in `package.json`:
       // process `*.vue` files with `vue-jest`
       ".*\\.(vue)$": "<rootDir>/node_modules/vue-jest"
     },
-    "mapCoverage": true
+    "collectCoverage": true
   }
 }
 ```
@@ -159,7 +159,7 @@ Jest recommends creating a `__tests__` directory right next to the code being te
 
 Jest can be used to generate coverage reports in multiple formats. The following is a simple example to get started with:
 
-Extend your `jest` config (usually in `package.json` or `jest.config.js`) with the [`collectCoverage`](https://facebook.github.io/jest/docs/en/configuration.html#collectcoverage-boolean) option, and then add the [`collectCoverageFrom`](https://facebook.github.io/jest/docs/en/configuration.html#collectcoveragefrom-array) array to define the files for which coverage information should be collected. You'll also want [`mapCoverage`](https://facebook.github.io/jest/docs/en/configuration.html#mapcoverage-boolean) to be `true`, for coverage data to be accurate.
+Extend your `jest` config (usually in `package.json` or `jest.config.js`) with the [`collectCoverage`](https://facebook.github.io/jest/docs/en/configuration.html#collectcoverage-boolean) option, and then add the [`collectCoverageFrom`](https://facebook.github.io/jest/docs/en/configuration.html#collectcoveragefrom-array) array to define the files for which coverage information should be collected. You'll also want [`collectCoverage`](https://facebook.github.io/jest/docs/en/configuration.html#mapcoverage-boolean) to be `true`, for coverage data to be accurate.
 
 ```json
 {
@@ -170,7 +170,7 @@ Extend your `jest` config (usually in `package.json` or `jest.config.js`) with t
       "**/*.{js,vue}",
       "!**/node_modules/**"
     ],
-    "mapCoverage": true
+    "collectCoverage": true
   }
 }
 ```


### PR DESCRIPTION
The mapCoverage option is already deprecated.
If you move this sample, an error will be displayed and it will not work.
The error is displayed as "Option 'mapCoverage' has been removed, as it no longer necessary."