### PR TITLE
feat: add scoped slots option

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -23,6 +23,7 @@ Vue Test Utils is the official unit testing utility library for Vue.js.
   * [Mounting Options](api/options.md)
     - [context](api/options.md#context)
     - [slots](api/options.md#slots)
+    - [scopedSlots](api/options.md#scopedslots)
     - [stubs](api/options.md#stubs)
     - [mocks](api/options.md#mocks)
     - [localVue](api/options.md#localvue)

--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -19,6 +19,7 @@
   * [Mounting Options](api/options.md)
     - [context](api/options.md#context)
     - [slots](api/options.md#slots)
+    - [scopedSlots](api/options.md#scopedslots)
     - [stubs](api/options.md#stubs)
     - [mocks](api/options.md#mocks)
     - [localVue](api/options.md#localvue)

--- a/docs/en/api/README.md
+++ b/docs/en/api/README.md
@@ -7,6 +7,7 @@
 * [Mounting Options](./options.md)
   - [context](./options.md#context)
   - [slots](./options.md#slots)
+  - [scopedSlots](./options.md#scopedslots)
   - [stubs](./options.md#stubs)
   - [mocks](./options.md#mocks)
   - [localVue](./options.md#localvue)

--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -73,7 +73,8 @@ Please use [Puppeteer](https://github.com/karma-runner/karma-chrome-launcher#hea
 
 - type: `{ [name: string]: string }`
 
-Provide an object of scoped slots contents to the component. The key corresponds to the slot name. The value can be a template string.  
+Provide an object of scoped slots contents to the component. The key corresponds to the slot name. The value can be a template string.
+
 There is two limitations.  
 
 * This supports vue@2.5+.
@@ -85,10 +86,10 @@ Example:
 ```js
 const wrapper = shallow(Component, {
   scopedSlots: {
-    bar: '<p slot-scope="props">{{props.index}},{{props.text}}</p>'
+    foo: '<p slot-scope="props">{{props.index}},{{props.text}}</p>'
   }
 })
-expect(wrapper.html()).toBe('<div><p>0,text1</p><p>1,text2</p><p>2,text3</p></div>')
+expect(wrapper.find('#fooWrapper').html()).toBe('<div id="fooWrapper"><p>0,text1</p><p>1,text2</p><p>2,text3</p></div>')
 ```
 
 ### `stubs`

--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -6,6 +6,7 @@ Options for `mount` and `shallow`. The options object can contain both Vue Test 
 
 - [`context`](#context)
 - [`slots`](#slots)
+- [`scopedSlots`](#scopedslots)
 - [`stubs`](#stubs)
 - [`mocks`](#mocks)
 - [`localVue`](#localvue)
@@ -67,6 +68,28 @@ There is a limitation to this.
 
 This does not support PhantomJS.  
 Please use [Puppeteer](https://github.com/karma-runner/karma-chrome-launcher#headless-chromium-with-puppeteer).
+
+### `scopedSlots`
+
+- type: `{ [name: string]: string }`
+
+Provide an object of scoped slots contents to the component. The key corresponds to the slot name. The value can be a template string.  
+There is two limitations.  
+
+* This supports vue@2.5+.
+
+* You can not set a `template` tag to top of `scopedSlots` option.
+
+Example:
+
+```js
+const wrapper = shallow(Component, {
+  scopedSlots: {
+    bar: '<p slot="item" slot-scope="props">{{props.index}},{{props.text}}</p>'
+  }
+})
+expect(wrapper.html()).toBe('<div><p>0,text1</p><p>1,text2</p><p>2,text3</p></div>')
+```
 
 ### `stubs`
 

--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -85,7 +85,7 @@ Example:
 ```js
 const wrapper = shallow(Component, {
   scopedSlots: {
-    bar: '<p slot="item" slot-scope="props">{{props.index}},{{props.text}}</p>'
+    bar: '<p slot-scope="props">{{props.index}},{{props.text}}</p>'
   }
 })
 expect(wrapper.html()).toBe('<div><p>0,text1</p><p>1,text2</p><p>2,text3</p></div>')

--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -75,11 +75,11 @@ Please use [Puppeteer](https://github.com/karma-runner/karma-chrome-launcher#hea
 
 Provide an object of scoped slots contents to the component. The key corresponds to the slot name. The value can be a template string.
 
-There is two limitations.  
+There are two limitations.  
 
-* This supports vue@2.5+.
+* This option is only supported in vue@2.5+.
 
-* You can not set a `template` tag to top of `scopedSlots` option.
+* You can not use `<template>` tag as the root element in the `scopedSlots` option.
 
 Example:
 

--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -75,11 +75,14 @@ Please use [Puppeteer](https://github.com/karma-runner/karma-chrome-launcher#hea
 
 Provide an object of scoped slots contents to the component. The key corresponds to the slot name. The value can be a template string.
 
-There are two limitations.
+There are three limitations.
 
 * This option is only supported in vue@2.5+.
 
 * You can not use `<template>` tag as the root element in the `scopedSlots` option.
+
+* This does not support PhantomJS.  
+Please use [Puppeteer](https://github.com/karma-runner/karma-chrome-launcher#headless-chromium-with-puppeteer).
 
 Example:
 

--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -75,7 +75,7 @@ Please use [Puppeteer](https://github.com/karma-runner/karma-chrome-launcher#hea
 
 Provide an object of scoped slots contents to the component. The key corresponds to the slot name. The value can be a template string.
 
-There are two limitations.  
+There are two limitations.
 
 * This option is only supported in vue@2.5+.
 

--- a/docs/en/api/options.md
+++ b/docs/en/api/options.md
@@ -67,7 +67,7 @@ You can pass text to `slots`.
 There is a limitation to this.
 
 This does not support PhantomJS.  
-Please use [Puppeteer](https://github.com/karma-runner/karma-chrome-launcher#headless-chromium-with-puppeteer).
+You can use [Puppeteer](https://github.com/karma-runner/karma-chrome-launcher#headless-chromium-with-puppeteer) as an alternative.
 
 ### `scopedSlots`
 
@@ -82,7 +82,7 @@ There are three limitations.
 * You can not use `<template>` tag as the root element in the `scopedSlots` option.
 
 * This does not support PhantomJS.  
-Please use [Puppeteer](https://github.com/karma-runner/karma-chrome-launcher#headless-chromium-with-puppeteer).
+You can use [Puppeteer](https://github.com/karma-runner/karma-chrome-launcher#headless-chromium-with-puppeteer) as an alternative.
 
 Example:
 

--- a/flow/options.flow.js
+++ b/flow/options.flow.js
@@ -2,6 +2,7 @@ declare type Options = { // eslint-disable-line no-undef
     attachToDocument?: boolean,
     mocks?: Object,
     slots?: Object,
+    scopedSlots?: Object,
     localVue?: Component,
     provide?: Object,
     stubs?: Object,

--- a/packages/create-instance/add-scoped-slots.js
+++ b/packages/create-instance/add-scoped-slots.js
@@ -9,6 +9,9 @@ export function addScopedSlots (vm: Component, scopedSlots: Object): void {
     if (template.substr(0, 9) === '<template') {
       throwError('the scopedSlots option does not support a template tag as the root element.')
     }
+    const domParser = new window.DOMParser()
+    const document = domParser.parseFromString(template, 'text/html')
     vm.$_vueTestUtils_scopedSlots[key] = compileToFunctions(template).render
+    vm.$_vueTestUtils_slotScopes[key] = document.body.firstChild.getAttribute('slot-scope')
   })
 }

--- a/packages/create-instance/add-scoped-slots.js
+++ b/packages/create-instance/add-scoped-slots.js
@@ -1,0 +1,14 @@
+// @flow
+
+import { compileToFunctions } from 'vue-template-compiler'
+import { throwError } from 'shared/util'
+
+export function addScopedSlots (vm: Component, scopedSlots: Object): void {
+  Object.keys(scopedSlots).forEach((key) => {
+    const template = scopedSlots[key].trim()
+    if (template.substr(0, 9) === '<template') {
+      throwError('scopedSlots option does not support template tag.')
+    }
+    vm.$_VueTestUtils_scopedSlots[key] = compileToFunctions(template).render
+  })
+}

--- a/packages/create-instance/add-scoped-slots.js
+++ b/packages/create-instance/add-scoped-slots.js
@@ -7,7 +7,7 @@ export function addScopedSlots (vm: Component, scopedSlots: Object): void {
   Object.keys(scopedSlots).forEach((key) => {
     const template = scopedSlots[key].trim()
     if (template.substr(0, 9) === '<template') {
-      throwError('scopedSlots option does not support template tag.')
+      throwError('the scopedSlots option does not support a template tag as the root element.')
     }
     vm.$_vueTestUtils_scopedSlots[key] = compileToFunctions(template).render
   })

--- a/packages/create-instance/add-scoped-slots.js
+++ b/packages/create-instance/add-scoped-slots.js
@@ -10,8 +10,8 @@ export function addScopedSlots (vm: Component, scopedSlots: Object): void {
       throwError('the scopedSlots option does not support a template tag as the root element.')
     }
     const domParser = new window.DOMParser()
-    const document = domParser.parseFromString(template, 'text/html')
+    const _document = domParser.parseFromString(template, 'text/html')
     vm.$_vueTestUtils_scopedSlots[key] = compileToFunctions(template).render
-    vm.$_vueTestUtils_slotScopes[key] = document.body.firstChild.getAttribute('slot-scope')
+    vm.$_vueTestUtils_slotScopes[key] = _document.body.firstChild.getAttribute('slot-scope')
   })
 }

--- a/packages/create-instance/add-scoped-slots.js
+++ b/packages/create-instance/add-scoped-slots.js
@@ -9,6 +9,6 @@ export function addScopedSlots (vm: Component, scopedSlots: Object): void {
     if (template.substr(0, 9) === '<template') {
       throwError('scopedSlots option does not support template tag.')
     }
-    vm.$_VueTestUtils_scopedSlots[key] = compileToFunctions(template).render
+    vm.$_vueTestUtils_scopedSlots[key] = compileToFunctions(template).render
   })
 }

--- a/packages/create-instance/add-slots.js
+++ b/packages/create-instance/add-slots.js
@@ -11,7 +11,7 @@ function addSlotToVm (vm: Component, slotName: string, slotValue: Component | st
       throwError('vueTemplateCompiler is undefined, you must pass components explicitly if vue-template-compiler is undefined')
     }
     if (window.navigator.userAgent.match(/PhantomJS/i)) {
-      throwError('option.slots does not support strings in PhantomJS. Please use Puppeteer, or pass a component')
+      throwError('the slots option does not support strings in PhantomJS. Please use Puppeteer, or pass a component.')
     }
     const domParser = new window.DOMParser()
     const document = domParser.parseFromString(slotValue, 'text/html')

--- a/packages/create-instance/add-slots.js
+++ b/packages/create-instance/add-slots.js
@@ -14,9 +14,9 @@ function addSlotToVm (vm: Component, slotName: string, slotValue: Component | st
       throwError('the slots option does not support strings in PhantomJS. Please use Puppeteer, or pass a component.')
     }
     const domParser = new window.DOMParser()
-    const document = domParser.parseFromString(slotValue, 'text/html')
+    const _document = domParser.parseFromString(slotValue, 'text/html')
     const _slotValue = slotValue.trim()
-    if (_slotValue[0] === '<' && _slotValue[_slotValue.length - 1] === '>' && document.body.childElementCount === 1) {
+    if (_slotValue[0] === '<' && _slotValue[_slotValue.length - 1] === '>' && _document.body.childElementCount === 1) {
       elem = vm.$createElement(compileToFunctions(slotValue))
     } else {
       const compiledResult = compileToFunctions(`<div>${slotValue}{{ }}</div>`)

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -61,7 +61,7 @@ export default function createInstance (
 
   if (options.scopedSlots) {
     if (window.navigator.userAgent.match(/PhantomJS/i)) {
-      throwError('the scopedSlots option does not support strings in PhantomJS. Please use Puppeteer, or pass a component.')
+      throwError('the scopedSlots option does not support in PhantomJS. Please use Puppeteer, or pass a component.')
     }
     const vueVersion = Number(`${Vue.version.split('.')[0]}.${Vue.version.split('.')[1]}`)
     if (vueVersion >= 2.5) {

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -75,10 +75,9 @@ export default function createInstance (
         if (scopedSlotFn) {
           props = { ...bindObject, ...props }
           const proxy = {}
-          Object.keys(vm._renderProxy).concat(Object.keys(Vue.prototype)).forEach((key) => {
-            if (key[0] === '_') {
-              proxy[key] = vm._renderProxy[key]
-            }
+          const helpers = ['_c', '_o', '_n', '_s', '_l', '_t', '_q', '_i', '_m', '_f', '_k', '_b', '_v', '_e', '_u', '_g']
+          helpers.forEach((key) => {
+            proxy[key] = vm._renderProxy[key]
           })
           proxy[slotScope] = props
           return scopedSlotFn.call(proxy)

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -62,10 +62,10 @@ export default function createInstance (
   if (options.scopedSlots) {
     const vueVersion = Number(`${Vue.version.split('.')[0]}.${Vue.version.split('.')[1]}`)
     if (vueVersion >= 2.5) {
-      vm.$_VueTestUtils_scopedSlots = {}
+      vm.$_vueTestUtils_scopedSlots = {}
       const renderSlot = vm._renderProxy._t
       vm._renderProxy._t = function (name, feedback, props, bindObject) {
-        const scopedSlotFn = vm.$_VueTestUtils_scopedSlots[name]
+        const scopedSlotFn = vm.$_vueTestUtils_scopedSlots[name]
         if (scopedSlotFn) {
           props = Object.assign({}, bindObject, props)
           vm._renderProxy.props = props

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -61,7 +61,7 @@ export default function createInstance (
 
   if (options.scopedSlots) {
     if (window.navigator.userAgent.match(/PhantomJS/i)) {
-      throwError('the scopedSlots option does not support in PhantomJS. Please use Puppeteer, or pass a component.')
+      throwError('the scopedSlots option does not support PhantomJS. Please use Puppeteer, or pass a component.')
     }
     const vueVersion = Number(`${Vue.version.split('.')[0]}.${Vue.version.split('.')[1]}`)
     if (vueVersion >= 2.5) {

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -71,7 +71,7 @@ export default function createInstance (
           vm._renderProxy.props = props
           return scopedSlotFn.call(vm._renderProxy)
         } else {
-          return renderSlot(name, feedback, props, bindObject)
+          return renderSlot.call(vm._renderProxy, name, feedback, props, bindObject)
         }
       }
       // $FlowIgnore

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -67,7 +67,7 @@ export default function createInstance (
       vm._renderProxy._t = function (name, feedback, props, bindObject) {
         const scopedSlotFn = vm.$_VueTestUtils_scopedSlots[name]
         if (scopedSlotFn) {
-          props = Object.assign(Object.assign({}, bindObject), props)
+          props = Object.assign({}, bindObject, props)
           vm._renderProxy.props = props
           return scopedSlotFn.call(vm._renderProxy)
         } else {

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -77,7 +77,7 @@ export default function createInstance (
       // $FlowIgnore
       addScopedSlots(vm, options.scopedSlots)
     } else {
-      throwError('scopedSlots option supports vue@2.5+.')
+      throwError('the scopedSlots option is only supported in vue@2.5+.')
     }
   }
 

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -1,5 +1,5 @@
 // @flow
-//
+
 import Vue from 'vue'
 import { addSlots } from './add-slots'
 import { addScopedSlots } from './add-scoped-slots'

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -1,6 +1,8 @@
 // @flow
-
+//
+import Vue from 'vue'
 import { addSlots } from './add-slots'
+import { addScopedSlots } from './add-scoped-slots'
 import addMocks from './add-mocks'
 import addAttrs from './add-attrs'
 import addListeners from './add-listeners'
@@ -12,6 +14,13 @@ import { compileTemplate } from './compile-template'
 import deleteoptions from './delete-mounting-options'
 import createFunctionalComponent from './create-functional-component'
 import { componentNeedsCompiling } from 'shared/validators'
+
+function extend (to: Object, _from: ?Object): Object {
+  for (const key in _from) {
+    to[key] = _from[key]
+  }
+  return to
+}
 
 export default function createInstance (
   component: Component,
@@ -56,6 +65,28 @@ export default function createInstance (
 
   addAttrs(vm, options.attrs)
   addListeners(vm, options.listeners)
+
+  if (options.scopedSlots) {
+    const vueVersion = Number(`${Vue.version.split('.')[0]}.${Vue.version.split('.')[1]}`)
+    if (vueVersion >= 2.5) {
+      vm.$_VueTestUtils_scopedSlots = {}
+      const renderSlot = vm._renderProxy._t
+      vm._renderProxy._t = function (name, feedback, props, bindObject) {
+        const scopedSlotFn = vm.$_VueTestUtils_scopedSlots[name]
+        if (scopedSlotFn) {
+          props = extend(extend({}, bindObject), props)
+          vm._renderProxy.props = props
+          return scopedSlotFn.call(vm._renderProxy)
+        } else {
+          return renderSlot(name, feedback, props, bindObject)
+        }
+      }
+      // $FlowIgnore
+      addScopedSlots(vm, options.scopedSlots)
+    } else {
+      throwError('scopedSlots option supports vue@2.5+.')
+    }
+  }
 
   if (options.slots) {
     addSlots(vm, options.slots)

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -15,13 +15,6 @@ import deleteoptions from './delete-mounting-options'
 import createFunctionalComponent from './create-functional-component'
 import { componentNeedsCompiling } from 'shared/validators'
 
-function extend (to: Object, _from: ?Object): Object {
-  for (const key in _from) {
-    to[key] = _from[key]
-  }
-  return to
-}
-
 export default function createInstance (
   component: Component,
   options: Options,
@@ -74,7 +67,7 @@ export default function createInstance (
       vm._renderProxy._t = function (name, feedback, props, bindObject) {
         const scopedSlotFn = vm.$_VueTestUtils_scopedSlots[name]
         if (scopedSlotFn) {
-          props = extend(extend({}, bindObject), props)
+          props = Object.assign(Object.assign({}, bindObject), props)
           vm._renderProxy.props = props
           return scopedSlotFn.call(vm._renderProxy)
         } else {

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -67,7 +67,7 @@ export default function createInstance (
       vm._renderProxy._t = function (name, feedback, props, bindObject) {
         const scopedSlotFn = vm.$_vueTestUtils_scopedSlots[name]
         if (scopedSlotFn) {
-          props = Object.assign({}, bindObject, props)
+          props = { ...bindObject, ...props }
           vm._renderProxy.props = props
           return scopedSlotFn.call(vm._renderProxy)
         } else {

--- a/packages/server-test-utils/types/index.d.ts
+++ b/packages/server-test-utils/types/index.d.ts
@@ -32,6 +32,7 @@ interface MountOptions<V extends Vue> extends ComponentOptions<V> {
   localVue?: typeof Vue
   mocks?: object
   slots?: Slots
+  scopedSlots?: Record<string, string>
   stubs?: Stubs,
   attrs?: object
   listeners?: object

--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -113,7 +113,7 @@ interface MountOptions<V extends Vue> extends ComponentOptions<V> {
   localVue?: typeof Vue
   mocks?: object
   slots?: Slots
-  scopedSlots?: object
+  scopedSlots?: Record<string, string>
   stubs?: Stubs,
   attrs?: object
   listeners?: object

--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -113,7 +113,7 @@ interface MountOptions<V extends Vue> extends ComponentOptions<V> {
   localVue?: typeof Vue
   mocks?: object
   slots?: Slots
-  scopedSlots?: string
+  scopedSlots?: object
   stubs?: Stubs,
   attrs?: object
   listeners?: object

--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -113,6 +113,7 @@ interface MountOptions<V extends Vue> extends ComponentOptions<V> {
   localVue?: typeof Vue
   mocks?: object
   slots?: Slots
+  scopedSlots?: string
   stubs?: Stubs,
   attrs?: object
   listeners?: object

--- a/packages/test-utils/types/test/mount.ts
+++ b/packages/test-utils/types/test/mount.ts
@@ -33,6 +33,9 @@ mount(ClassComponent, {
     foo: [normalOptions, functionalOptions],
     bar: ClassComponent
   },
+  scopedSlots: {
+    baz: `<div>Baz</div>`
+  },
   stubs: {
     foo: normalOptions,
     bar: functionalOptions,

--- a/test/resources/components/component-with-scoped-slots.vue
+++ b/test/resources/components/component-with-scoped-slots.vue
@@ -13,17 +13,7 @@
     name: 'component-with-scoped-slots',
     data () {
       return {
-        items: [
-          {
-            text: 'text1'
-          },
-          {
-            text: 'text2'
-          },
-          {
-            text: 'text3'
-          }
-        ]
+        items: [{ text: 'a1' }, { text: 'a2' }, { text: 'a3' }]
       }
     }
   }

--- a/test/resources/components/component-with-scoped-slots.vue
+++ b/test/resources/components/component-with-scoped-slots.vue
@@ -1,10 +1,15 @@
 <template>
   <div>
-    <slot name="item"
-          v-for="(item, index) in items"
-          :text="item.text"
-          :index="index">
-    </slot>
+    <div id="scopedSlots">
+      <slot name="item"
+            v-for="(item, index) in items"
+            :text="item.text"
+            :index="index">
+      </slot>
+    </div>
+    <div id="slots">
+      <slot></slot>
+    </div>
   </div>
 </template>
 

--- a/test/resources/components/component-with-scoped-slots.vue
+++ b/test/resources/components/component-with-scoped-slots.vue
@@ -1,8 +1,15 @@
 <template>
   <div>
-    <div id="scopedSlots">
-      <slot name="item"
-            v-for="(item, index) in items"
+    <div id="foo">
+      <slot name="foo"
+            v-for="(item, index) in foo"
+            :text="item.text"
+            :index="index">
+      </slot>
+    </div>
+    <div id="bar">
+      <slot name="bar"
+            v-for="(item, index) in bar"
             :text="item.text"
             :index="index">
       </slot>
@@ -18,7 +25,8 @@
     name: 'component-with-scoped-slots',
     data () {
       return {
-        items: [{ text: 'a1' }, { text: 'a2' }, { text: 'a3' }]
+        foo: [{ text: 'a1' }, { text: 'a2' }, { text: 'a3' }],
+        bar: [{ text: 'A1' }, { text: 'A2' }, { text: 'A3' }]
       }
     }
   }

--- a/test/resources/components/component-with-scoped-slots.vue
+++ b/test/resources/components/component-with-scoped-slots.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <slot name="item"
+          v-for="(item, index) in items"
+          :text="item.text"
+          :index="index">
+    </slot>
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'component-with-scoped-slots',
+    data () {
+      return {
+        items: [
+          {
+            text: 'text1'
+          },
+          {
+            text: 'text2'
+          },
+          {
+            text: 'text3'
+          }
+        ]
+      }
+    }
+  }
+</script>

--- a/test/specs/mounting-options/scopedSlots.js
+++ b/test/specs/mounting-options/scopedSlots.js
@@ -9,7 +9,9 @@ describeWithShallowAndMount('scopedSlots', (mountingMethod) => {
           'item': '<p slot="item" slot-scope="props">{{props.index}},{{props.text}}</p>'
         }
       })
-      expect(wrapper.html()).to.equal('<div><p>0,text1</p><p>1,text2</p><p>2,text3</p></div>')
+      expect(wrapper.html()).to.equal('<div><p>0,a1</p><p>1,a2</p><p>2,a3</p></div>')
+      wrapper.vm.items = [{ text: 'b1' }, { text: 'b2' }, { text: 'b3' }]
+      expect(wrapper.html()).to.equal('<div><p>0,b1</p><p>1,b2</p><p>2,b3</p></div>')
     })
     it('throws exception when it is seted to template tag at top', () => {
       const fn = () => {

--- a/test/specs/mounting-options/scopedSlots.js
+++ b/test/specs/mounting-options/scopedSlots.js
@@ -5,13 +5,15 @@ describeWithShallowAndMount('scopedSlots', (mountingMethod) => {
   itDoNotRunIf(vueVersion < 2.5,
     'mounts component scoped slots', () => {
       const wrapper = mountingMethod(ComponentWithScopedSlots, {
+        slots: { default: '<span>123</span>' },
         scopedSlots: {
           'item': '<p slot-scope="props">{{props.index}},{{props.text}}</p>'
         }
       })
-      expect(wrapper.html()).to.equal('<div><p>0,a1</p><p>1,a2</p><p>2,a3</p></div>')
+      expect(wrapper.find('#slots').html()).to.equal('<div id="slots"><span>123</span></div>')
+      expect(wrapper.find('#scopedSlots').html()).to.equal('<div id="scopedSlots"><p>0,a1</p><p>1,a2</p><p>2,a3</p></div>')
       wrapper.vm.items = [{ text: 'b1' }, { text: 'b2' }, { text: 'b3' }]
-      expect(wrapper.html()).to.equal('<div><p>0,b1</p><p>1,b2</p><p>2,b3</p></div>')
+      expect(wrapper.find('#scopedSlots').html()).to.equal('<div id="scopedSlots"><p>0,b1</p><p>1,b2</p><p>2,b3</p></div>')
     }
   )
 

--- a/test/specs/mounting-options/scopedSlots.js
+++ b/test/specs/mounting-options/scopedSlots.js
@@ -1,19 +1,22 @@
-import { describeWithShallowAndMount, vueVersion } from '~resources/utils'
+import { describeWithShallowAndMount, vueVersion, itDoNotRunIf } from '~resources/utils'
 import ComponentWithScopedSlots from '~resources/components/component-with-scoped-slots.vue'
 
 describeWithShallowAndMount('scopedSlots', (mountingMethod) => {
-  if (vueVersion >= 2.5) {
-    it('mounts component scoped slots', () => {
+  itDoNotRunIf(vueVersion < 2.5,
+    'mounts component scoped slots', () => {
       const wrapper = mountingMethod(ComponentWithScopedSlots, {
         scopedSlots: {
-          'item': '<p slot="item" slot-scope="props">{{props.index}},{{props.text}}</p>'
+          'item': '<p slot-scope="props">{{props.index}},{{props.text}}</p>'
         }
       })
       expect(wrapper.html()).to.equal('<div><p>0,a1</p><p>1,a2</p><p>2,a3</p></div>')
       wrapper.vm.items = [{ text: 'b1' }, { text: 'b2' }, { text: 'b3' }]
       expect(wrapper.html()).to.equal('<div><p>0,b1</p><p>1,b2</p><p>2,b3</p></div>')
-    })
-    it('throws exception when it is seted to template tag at top', () => {
+    }
+  )
+
+  itDoNotRunIf(vueVersion < 2.5,
+    'throws exception when it is seted to template tag at top', () => {
       const fn = () => {
         mountingMethod(ComponentWithScopedSlots, {
           scopedSlots: {
@@ -23,9 +26,11 @@ describeWithShallowAndMount('scopedSlots', (mountingMethod) => {
       }
       const message = '[vue-test-utils]: scopedSlots option does not support template tag.'
       expect(fn).to.throw().with.property('message', message)
-    })
-  } else {
-    it('throws exception when vue version < 2.5', () => {
+    }
+  )
+
+  itDoNotRunIf(vueVersion >= 2.5,
+    'throws exception when vue version < 2.5', () => {
       const fn = () => {
         mountingMethod(ComponentWithScopedSlots, {
           scopedSlots: {
@@ -35,6 +40,6 @@ describeWithShallowAndMount('scopedSlots', (mountingMethod) => {
       }
       const message = '[vue-test-utils]: scopedSlots option supports vue@2.5+.'
       expect(fn).to.throw().with.property('message', message)
-    })
-  }
+    }
+  )
 })

--- a/test/specs/mounting-options/scopedSlots.js
+++ b/test/specs/mounting-options/scopedSlots.js
@@ -1,0 +1,38 @@
+import { describeWithShallowAndMount, vueVersion } from '~resources/utils'
+import ComponentWithScopedSlots from '~resources/components/component-with-scoped-slots.vue'
+
+describeWithShallowAndMount('scopedSlots', (mountingMethod) => {
+  if (vueVersion >= 2.5) {
+    it('mounts component scoped slots', () => {
+      const wrapper = mountingMethod(ComponentWithScopedSlots, {
+        scopedSlots: {
+          'item': '<p slot="item" slot-scope="props">{{props.index}},{{props.text}}</p>'
+        }
+      })
+      expect(wrapper.html()).to.equal('<div><p>0,text1</p><p>1,text2</p><p>2,text3</p></div>')
+    })
+    it('throws exception when it is seted to template tag at top', () => {
+      const fn = () => {
+        mountingMethod(ComponentWithScopedSlots, {
+          scopedSlots: {
+            'item': '<template></template>'
+          }
+        })
+      }
+      const message = '[vue-test-utils]: scopedSlots option does not support template tag.'
+      expect(fn).to.throw().with.property('message', message)
+    })
+  } else {
+    it('throws exception when vue version < 2.5', () => {
+      const fn = () => {
+        mountingMethod(ComponentWithScopedSlots, {
+          scopedSlots: {
+            'item': '<p slot="item" slot-scope="props">{{props.index}},{{props.text}}</p>'
+          }
+        })
+      }
+      const message = '[vue-test-utils]: scopedSlots option supports vue@2.5+.'
+      expect(fn).to.throw().with.property('message', message)
+    })
+  }
+})

--- a/test/specs/mounting-options/scopedSlots.spec.js
+++ b/test/specs/mounting-options/scopedSlots.spec.js
@@ -74,7 +74,7 @@ describeWithShallowAndMount('scopedSlots', (mountingMethod) => {
           }
         })
       }
-      const message = '[vue-test-utils]: the scopedSlots option does not support in PhantomJS. Please use Puppeteer, or pass a component.'
+      const message = '[vue-test-utils]: the scopedSlots option does not support PhantomJS. Please use Puppeteer, or pass a component.'
       expect(fn).to.throw().with.property('message', message)
     }
   )

--- a/test/specs/mounting-options/scopedSlots.spec.js
+++ b/test/specs/mounting-options/scopedSlots.spec.js
@@ -61,7 +61,7 @@ describeWithShallowAndMount('scopedSlots', (mountingMethod) => {
     }
   )
 
-  itDoNotRunIf(!window.navigator.userAgent.match(/PhantomJS/i),
+  itDoNotRunIf(vueVersion < 2.5,
     'throws exception when using PhantomJS', () => {
       if (window.navigator.userAgent.match(/Chrome/i)) {
         return

--- a/test/specs/mounting-options/scopedSlots.spec.js
+++ b/test/specs/mounting-options/scopedSlots.spec.js
@@ -26,7 +26,7 @@ describeWithShallowAndMount('scopedSlots', (mountingMethod) => {
           }
         })
       }
-      const message = '[vue-test-utils]: scopedSlots option does not support template tag.'
+      const message = '[vue-test-utils]: the scopedSlots option does not support a template tag as the root element.'
       expect(fn).to.throw().with.property('message', message)
     }
   )
@@ -40,7 +40,7 @@ describeWithShallowAndMount('scopedSlots', (mountingMethod) => {
           }
         })
       }
-      const message = '[vue-test-utils]: scopedSlots option supports vue@2.5+.'
+      const message = '[vue-test-utils]: the scopedSlots option is only supported in vue@2.5+.'
       expect(fn).to.throw().with.property('message', message)
     }
   )

--- a/test/specs/mounting-options/scopedSlots.spec.js
+++ b/test/specs/mounting-options/scopedSlots.spec.js
@@ -34,7 +34,7 @@ describeWithShallowAndMount('scopedSlots', (mountingMethod) => {
   )
 
   itDoNotRunIf(vueVersion < 2.5,
-    'throws exception when it is seted to template tag at top', () => {
+    'throws exception when it is seted to a template tag at top', () => {
       const fn = () => {
         mountingMethod(ComponentWithScopedSlots, {
           scopedSlots: {
@@ -74,7 +74,7 @@ describeWithShallowAndMount('scopedSlots', (mountingMethod) => {
           }
         })
       }
-      const message = '[vue-test-utils]: the scopedSlots option does not support strings in PhantomJS. Please use Puppeteer, or pass a component.'
+      const message = '[vue-test-utils]: the scopedSlots option does not support in PhantomJS. Please use Puppeteer, or pass a component.'
       expect(fn).to.throw().with.property('message', message)
     }
   )

--- a/test/specs/mounting-options/slots.spec.js
+++ b/test/specs/mounting-options/slots.spec.js
@@ -76,7 +76,7 @@ describeWithMountingMethods('options.slots', (mountingMethod) => {
       return
     }
     window = { navigator: { userAgent: 'PhantomJS' }} // eslint-disable-line no-native-reassign
-    const message = '[vue-test-utils]: option.slots does not support strings in PhantomJS. Please use Puppeteer, or pass a component'
+    const message = '[vue-test-utils]: the slots option does not support strings in PhantomJS. Please use Puppeteer, or pass a component.'
     const fn = () => mountingMethod(ComponentWithSlots, { slots: { default: 'foo' }})
     expect(fn).to.throw().with.property('message', message)
   })


### PR DESCRIPTION
This is related to #156 .
This adds `scopedSlots` option by replacing the [renderSlot](https://github.com/vuejs/vue/blob/5a9da95b8a865416f082952a48416ffc091e4078/src/core/instance/render-helpers/render-slot.js#L8) method.
It is supported at vue@2.5+.
It does not support `template` tag.