### PR TITLE
docs: extend examples in find api (#473)

### DIFF
--- a/docs/en/api/wrapper/find.md
+++ b/docs/en/api/wrapper/find.md
@@ -27,8 +27,8 @@ expect(bar.is(Bar)).toBe(true)
 const barByName = wrapper.find({ name: 'bar' })
 expect(barByName.is(Bar)).toBe(true)
 
-const barRef = wrapper.find({ ref: 'bar' })
-expect(barRef.is(Bar)).toBe(true)
+const fooRef = wrapper.find({ ref: 'foo' })
+expect(fooRef.is(Foo)).toBe(true)
 ```
 
 - **See also:** [Wrapper](README.md)

--- a/docs/en/api/wrapper/find.md
+++ b/docs/en/api/wrapper/find.md
@@ -17,10 +17,18 @@ import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 
 const wrapper = mount(Foo)
+
 const div = wrapper.find('div')
 expect(div.is('div')).toBe(true)
+
 const bar = wrapper.find(Bar)
 expect(bar.is(Bar)).toBe(true)
+
+const barByName = wrapper.find({ name: 'bar' })
+expect(barByName.is(Bar)).toBe(true)
+
+const barRef = wrapper.find({ ref: 'bar' })
+expect(barRef.is(Bar)).toBe(true)
 ```
 
 - **See also:** [Wrapper](README.md)


### PR DESCRIPTION
Regarding #473 i updated the documentation of the `.find(selector)` function. Whether the proposed API will be implemented, I guess the `.find(selector)` function stays the same more or less and documentation about getting a component should include all possibilities.

I included examples of every selector possible so people might see it. I also included some whitespace so the different types of selections are separated.

Thanks for the great project 👍 