### PR TITLE
refactor: remove unnecessary export

### DIFF
--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -1,4 +1,3 @@
-export * from './add-slots'
 export * from './compile-template'
 export * from './stub-components'
 export * from './util'


### PR DESCRIPTION
`packages/shared/index.js` does not exist.