### PR TITLE
fix(types): update packages/server-test-utils/types/index.d.ts

### DIFF
--- a/packages/server-test-utils/types/index.d.ts
+++ b/packages/server-test-utils/types/index.d.ts
@@ -35,6 +35,7 @@ interface MountOptions<V extends Vue> extends ComponentOptions<V> {
   stubs?: Stubs,
   attrs?: object
   listeners?: object
+  sync?: boolean
 }
 
 type ThisTypedMountOptions<V extends Vue> = MountOptions<V> & ThisType<V>


### PR DESCRIPTION
This adds the type for [sync](https://github.com/vuejs/vue-test-utils/blob/74a27ae0eb7be0d9705a0ae9106e1942e758e9ea/docs/en/api/options.md#sync).