### PR TITLE
Allow mocks to be set in config object

### DIFF
--- a/docs/.eslintrc
+++ b/docs/.eslintrc
@@ -14,6 +14,7 @@
   },
   "rules": {
     "no-unused-vars": 0,
-    "no-undef": 0
+    "no-undef": 0,
+    "no-labels": 0
   }
 }

--- a/docs/en/api/config.md
+++ b/docs/en/api/config.md
@@ -58,5 +58,5 @@ import VueTestUtils from '@vue/test-utils'
 
 VueTestUtils.config.methods['errors'] = () => {
   any: () => false
-}  
+}
 ```

--- a/docs/en/api/config.md
+++ b/docs/en/api/config.md
@@ -43,3 +43,20 @@ VueTestUtils.config.mocks['$store'] = {
   }
 }
 ```
+
+### `methods`
+
+- type: `Object`
+- default: `{}`
+
+You can configure default methods using the `config` object. This can be useful for plugins that inject methods to components, like [VeeValidate](https://vee-validate.logaretm.com/). You can override methods set in `config` by passing `methods` in the mounting options.
+
+Example:
+
+```js
+import VueTestUtils from '@vue/test-utils'
+
+VueTestUtils.config.methods['errors'] = () => {
+  any: () => false
+}  
+```

--- a/docs/en/api/config.md
+++ b/docs/en/api/config.md
@@ -37,7 +37,7 @@ Example:
 ```js
 import VueTestUtils from '@vue/test-utils'
 
-VueTestUtils.config.stubs['$store'] = {
+VueTestUtils.config.mocks['$store'] = {
   state: {
     id: 1
   }

--- a/docs/en/api/config.md
+++ b/docs/en/api/config.md
@@ -24,3 +24,22 @@ import VueTestUtils from '@vue/test-utils'
 
 VueTestUtils.config.stubs['my-component'] = '<div />'
 ```
+
+### `mocks`
+
+- type: `Object`
+- default: `{}`
+
+Like `stubs`, the values passed to `config.mocks` are used by default. Any values passed to the mounting options `mocks` object will take priority over the ones declared in `config.mocks`.
+
+Example:
+
+```js
+import VueTestUtils from '@vue/test-utils'
+
+VueTestUtils.config.stubs['$store'] = {
+  state: {
+    id: 1
+  }
+}
+```

--- a/flow/options.flow.js
+++ b/flow/options.flow.js
@@ -1,6 +1,7 @@
 declare type Options = { // eslint-disable-line no-undef
     attachToDocument?: boolean,
     mocks?: Object,
+    methods?: Object,
     slots?: Object,
     scopedSlots?: Object,
     localVue?: Component,

--- a/packages/shared/merge-options.js
+++ b/packages/shared/merge-options.js
@@ -16,12 +16,29 @@ function getStubs (optionStubs, config) {
   }
 }
 
+function getMocks (optionMocks, config) {
+  if (optionMocks ||
+    (config.mocks && Object.keys(config.mocks).length > 0)) {
+    if (Array.isArray(optionMocks)) {
+      return [
+        ...optionMocks,
+        ...Object.keys(config.mocks || {})]
+    } else {
+      return {
+        ...config.mocks,
+        ...optionMocks
+      }
+    }
+  }
+}
+
 export function mergeOptions (
   options: Options,
   config: Options
 ): Options {
   return {
     ...options,
-    stubs: getStubs(options.stubs, config)
+    stubs: getStubs(options.stubs, config),
+    mocks: getMocks(options.mocks, config)
   }
 }

--- a/packages/shared/merge-options.js
+++ b/packages/shared/merge-options.js
@@ -1,32 +1,16 @@
 // @flow
 
-function getStubs (optionStubs, config) {
-  if (optionStubs ||
-    (config.stubs && Object.keys(config.stubs).length > 0)) {
-    if (Array.isArray(optionStubs)) {
+function getOptions (key, options, config) {
+  if (options ||
+    (config[key] && Object.keys(config[key]).length > 0)) {
+    if (Array.isArray(options)) {
       return [
-        ...optionStubs,
-        ...Object.keys(config.stubs || {})]
+        ...options,
+        ...Object.keys(config[key] || {})]
     } else {
       return {
-        ...config.stubs,
-        ...optionStubs
-      }
-    }
-  }
-}
-
-function getMocks (optionMocks, config) {
-  if (optionMocks ||
-    (config.mocks && Object.keys(config.mocks).length > 0)) {
-    if (Array.isArray(optionMocks)) {
-      return [
-        ...optionMocks,
-        ...Object.keys(config.mocks || {})]
-    } else {
-      return {
-        ...config.mocks,
-        ...optionMocks
+        ...config[key],
+        ...options
       }
     }
   }
@@ -38,7 +22,8 @@ export function mergeOptions (
 ): Options {
   return {
     ...options,
-    stubs: getStubs(options.stubs, config),
-    mocks: getMocks(options.mocks, config)
+    stubs: getOptions('stubs', options.stubs, config),
+    mocks: getOptions('mocks', options.mocks, config)
   }
 }
+

--- a/packages/shared/merge-options.js
+++ b/packages/shared/merge-options.js
@@ -23,7 +23,8 @@ export function mergeOptions (
   return {
     ...options,
     stubs: getOptions('stubs', options.stubs, config),
-    mocks: getOptions('mocks', options.mocks, config)
+    mocks: getOptions('mocks', options.mocks, config),
+    methods: getOptions('methods', options.methods, config)
   }
 }
 

--- a/packages/test-utils/src/config.js
+++ b/packages/test-utils/src/config.js
@@ -5,5 +5,6 @@ export default {
   stubs: {
     transition: TransitionStub,
     'transition-group': TransitionGroupStub
-  }
+  },
+  mocks: {}
 }

--- a/packages/test-utils/src/config.js
+++ b/packages/test-utils/src/config.js
@@ -6,5 +6,6 @@ export default {
     transition: TransitionStub,
     'transition-group': TransitionGroupStub
   },
-  mocks: {}
+  mocks: {},
+  methods: {}
 }

--- a/test/specs/config.spec.js
+++ b/test/specs/config.spec.js
@@ -57,6 +57,21 @@ describe('config', () => {
     localVue.prototype.$t = undefined
   })
 
+  it('overrides a method', () => {
+    const testComponent = {
+      template: `
+        <div>{{ val() }}</div>
+      `
+    }
+
+    config.methods['val'] = () => 'method'
+
+    const wrapper = mount(testComponent)
+
+    expect(wrapper.vm.val()).to.equal('method')
+    expect(wrapper.text()).to.equal('method')
+  })
+
   it('doesn\'t stub transition when config.stubs.transition is set to false', () => {
     const testComponent = {
       template: `

--- a/test/specs/config.spec.js
+++ b/test/specs/config.spec.js
@@ -2,7 +2,8 @@ import {
   mount,
   config,
   TransitionStub,
-  TransitionGroupStub
+  TransitionGroupStub,
+  createLocalVue
 } from '~vue/test-utils'
 
 describe('config', () => {
@@ -31,6 +32,29 @@ describe('config', () => {
     const wrapper = mount(testComponent)
     expect(wrapper.contains(TransitionStub)).to.equal(true)
     expect(wrapper.contains(TransitionGroupStub)).to.equal(true)
+  })
+
+  it('mocks a global variable', () => {
+    const localVue = createLocalVue()
+    const t = 'real value'
+    localVue.prototype.$t = t
+
+    const testComponent = {
+      template: `
+        <div>{{ $t }}</div>
+      `
+    }
+
+    config.mocks['$t'] = 'mock value'
+
+    const wrapper = mount(testComponent, {
+      localVue, t
+    })
+
+    expect(wrapper.vm.$t).to.equal('mock value')
+    expect(wrapper.text()).to.equal('mock value')
+
+    localVue.prototype.$t = undefined
   })
 
   it('doesn\'t stub transition when config.stubs.transition is set to false', () => {

--- a/test/specs/mounting-options/methods.spec.js
+++ b/test/specs/mounting-options/methods.spec.js
@@ -1,0 +1,29 @@
+import { config } from '~vue/test-utils'
+import {
+  describeWithMountingMethods
+} from '~resources/utils'
+
+describeWithMountingMethods('options.methods', (mountingMethod) => {
+  it('prioritize mounting options over config', () => {
+    config.methods['val'] = () => 'methodFromConfig'
+
+    const TestComponent = {
+      template: `
+        <div>{{ val() }}</div>
+      `
+    }
+
+    const wrapper = mountingMethod(TestComponent, {
+      methods: {
+        val () {
+          return 'methodFromOptions'
+        }
+      }
+    })
+    const HTML = mountingMethod.name === 'renderToString'
+      ? wrapper
+      : wrapper.html()
+    console.log(wrapper)
+    expect(HTML).to.contain('methodFromOptions')
+  })
+})

--- a/test/specs/mounting-options/mocks.spec.js
+++ b/test/specs/mounting-options/mocks.spec.js
@@ -1,4 +1,4 @@
-import { createLocalVue } from '~vue/test-utils'
+import { createLocalVue, config } from '~vue/test-utils'
 import Component from '~resources/components/component.vue'
 import ComponentWithVuex from '~resources/components/component-with-vuex.vue'
 import {
@@ -7,6 +7,21 @@ import {
 } from '~resources/utils'
 
 describeWithMountingMethods('options.mocks', (mountingMethod) => {
+  let configStubsSave
+  // let serverConfigSave
+
+  beforeEach(() => {
+    configStubsSave = config.stubs
+    // serverConfigSave = serverConfig.stubs
+    config.stubs = {}
+    // serverConfig.stubs = {}
+  })
+
+  afterEach(() => {
+    config.stubs = configStubsSave
+    // serverConfig.stubs = serverConfigSave
+  })
+
   it('adds variables to vm when passed', () => {
     const TestComponent = {
       template: `
@@ -125,6 +140,29 @@ describeWithMountingMethods('options.mocks', (mountingMethod) => {
     const msg = '[vue-test-utils]: could not overwrite property $store, this usually caused by a plugin that has added the property as a read-only value'
     expect(error.calledWith(msg)).to.equal(true)
     error.restore()
+  })
+
+  it('prioritize mounting options over config', () => {
+    config.mocks['$global'] = 'globallyMockedValue'
+
+    const localVue = createLocalVue()
+    const TestComponent = {
+      template: `
+        <div>{{ $global }}</div>
+      `
+    }
+
+    const wrapper = mountingMethod(TestComponent, {
+      localVue,
+      mocks: {
+        '$global': 'locallyMockedValue'
+      }
+    })
+    const HTML = mountingMethod.name === 'renderToString'
+      ? wrapper
+      : wrapper.html()
+    console.log(wrapper)
+    expect(HTML).to.contain('locallyMockedValue')
   })
 
   it('logs that a property cannot be overwritten if there are problems writing', () => {

--- a/test/specs/mounting-options/mocks.spec.js
+++ b/test/specs/mounting-options/mocks.spec.js
@@ -7,19 +7,15 @@ import {
 } from '~resources/utils'
 
 describeWithMountingMethods('options.mocks', (mountingMethod) => {
-  let configStubsSave
-  // let serverConfigSave
+  let configMocksSave
 
   beforeEach(() => {
-    configStubsSave = config.stubs
-    // serverConfigSave = serverConfig.stubs
-    config.stubs = {}
-    // serverConfig.stubs = {}
+    configMocksSave = config.mocks
+    config.mocks = {}
   })
 
   afterEach(() => {
-    config.stubs = configStubsSave
-    // serverConfig.stubs = serverConfigSave
+    config.mocks = configMocksSave
   })
 
   it('adds variables to vm when passed', () => {
@@ -145,7 +141,6 @@ describeWithMountingMethods('options.mocks', (mountingMethod) => {
   it('prioritize mounting options over config', () => {
     config.mocks['$global'] = 'globallyMockedValue'
 
-    const localVue = createLocalVue()
     const TestComponent = {
       template: `
         <div>{{ $global }}</div>
@@ -153,7 +148,6 @@ describeWithMountingMethods('options.mocks', (mountingMethod) => {
     }
 
     const wrapper = mountingMethod(TestComponent, {
-      localVue,
       mocks: {
         '$global': 'locallyMockedValue'
       }


### PR DESCRIPTION
First try at #325 .

I am sure this is not the best way to write the test, though. 

Initially I was using `$store` instead of `$t`, which caused a test related to installing vuex on `createLocalVue` to fail. I wonder why?

