### PR TITLE
fix: remove circular dependency checks

### DIFF
--- a/test/specs/mounting-options/stubs.spec.js
+++ b/test/specs/mounting-options/stubs.spec.js
@@ -299,9 +299,9 @@ describeWithMountingMethods('options.stub', (mountingMethod) => {
     expect(HTML).contains('No render function')
   })
 
-  const invalidValues = ['child-component', 'ChildComponent', 'childComponent']
-  invalidValues.forEach(invalidValue => {
-    it('throws an error when passed a circular reference', () => {
+  it.skip('throws an error when passed a circular reference', () => {
+    const invalidValues = ['child-component', 'ChildComponent', 'childComponent']
+    invalidValues.forEach(invalidValue => {
       const error = '[vue-test-utils]: options.stub cannot contain a circular reference'
       const fn = () => mountingMethod(ComponentWithChild, {
         stubs: {


### PR DESCRIPTION
The checks currently fail for lots of edge cases:

```
stubs: {
  UnreadState: '<div data-stub-unread-state v-bind="$props"><slot/></div>',
  UnreadState: '<div>unread-state</div>',
}
```

This removes checks for circular dependencies when using the stubs option. This was simple error handling, but I believe the logic to implement it effectively is substantial. For the moment, we should remove the check