### PR TITLE
feat: Adds `provide` to the global config.

### DIFF
--- a/docs/en/api/config.md
+++ b/docs/en/api/config.md
@@ -60,3 +60,22 @@ VueTestUtils.config.methods['errors'] = () => {
   any: () => false
 }
 ```
+
+### `provide`
+
+- type: `Object`
+- default: `{}`
+
+Like `stubs` or `mocks`, the values passed to `config.provide` are used by default. Any values passed to the mounting options `provide` object will take priority over the ones declared in `config.provide`. **Please take note that it is not supported to pass a function as `config.provide`.**
+
+Example:
+
+```js
+import VueTestUtils from '@vue/test-utils'
+
+VueTestUtils.config.provide['$logger'] = {
+  log: (...args) => {
+    console.log(...args)
+  }
+}
+```

--- a/packages/shared/merge-options.js
+++ b/packages/shared/merge-options.js
@@ -3,15 +3,19 @@
 function getOptions (key, options, config) {
   if (options ||
     (config[key] && Object.keys(config[key]).length > 0)) {
-    if (Array.isArray(options)) {
+    if (options instanceof Function) {
+      return options
+    } else if (Array.isArray(options)) {
       return [
         ...options,
         ...Object.keys(config[key] || {})]
-    } else {
+    } else if (!(config[key] instanceof Function)) {
       return {
         ...config[key],
         ...options
       }
+    } else {
+      throw new Error(`Config can't be a Function.`)
     }
   }
 }
@@ -24,7 +28,8 @@ export function mergeOptions (
     ...options,
     stubs: getOptions('stubs', options.stubs, config),
     mocks: getOptions('mocks', options.mocks, config),
-    methods: getOptions('methods', options.methods, config)
+    methods: getOptions('methods', options.methods, config),
+    provide: getOptions('provide', options.provide, config)
   }
 }
 

--- a/packages/test-utils/src/config.js
+++ b/packages/test-utils/src/config.js
@@ -7,5 +7,6 @@ export default {
     'transition-group': TransitionGroupStub
   },
   mocks: {},
-  methods: {}
+  methods: {},
+  provide: {}
 }


### PR DESCRIPTION
While working on our current project, we noticed that mocking global provides (usually provided by the root Vue instance) is quite painful because it needs to be added to every single mount()/shallow() in the tests. 

This implements the config abilities that the mocks, stubs and methods also have.

The only feature that we can not easily support is the merging of functions (obviously). We did implement an error to signal this very clearly.