### PR TITLE
docs: switch 'Action' component to 'Getters' to match other Vuex examples

### DIFF
--- a/en/guides/using-with-vuex.html
+++ b/en/guides/using-with-vuex.html
@@ -1238,7 +1238,7 @@ describe(<span class="hljs-string">&apos;Actions.vue&apos;</span>, () =&gt; {
 <p>Let&#x2019;s see the test:</p>
 <pre><code class="lang-js"><span class="hljs-keyword">import</span> { shallow, createLocalVue } <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;@vue/test-utils&apos;</span>
 <span class="hljs-keyword">import</span> Vuex <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;vuex&apos;</span>
-<span class="hljs-keyword">import</span> Actions <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;../../../src/components/Getters&apos;</span>
+<span class="hljs-keyword">import</span> Getters <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;../../../src/components/Getters&apos;</span>
 
 <span class="hljs-keyword">const</span> localVue = createLocalVue()
 
@@ -1260,13 +1260,13 @@ describe(<span class="hljs-string">&apos;Getters.vue&apos;</span>, () =&gt; {
   })
 
   it(<span class="hljs-string">&apos;Renders &quot;state.inputValue&quot; in first p tag&apos;</span>, () =&gt; {
-    <span class="hljs-keyword">const</span> wrapper = shallow(Actions, { store, localVue })
+    <span class="hljs-keyword">const</span> wrapper = shallow(Getters, { store, localVue })
     <span class="hljs-keyword">const</span> p = wrapper.find(<span class="hljs-string">&apos;p&apos;</span>)
     expect(p.text()).toBe(getters.inputValue())
   })
 
   it(<span class="hljs-string">&apos;Renders &quot;state.clicks&quot; in second p tag&apos;</span>, () =&gt; {
-    <span class="hljs-keyword">const</span> wrapper = shallow(Actions, { store, localVue })
+    <span class="hljs-keyword">const</span> wrapper = shallow(Getters, { store, localVue })
     <span class="hljs-keyword">const</span> p = wrapper.findAll(<span class="hljs-string">&apos;p&apos;</span>).at(<span class="hljs-number">1</span>)
     expect(p.text()).toBe(getters.clicks().toString())
   })

--- a/fr/guides/using-with-vuex.html
+++ b/fr/guides/using-with-vuex.html
@@ -1146,7 +1146,7 @@ describe(<span class="hljs-string">&apos;Actions.vue&apos;</span>, () =&gt; {
 <p>Jetons un &#x153;il &#xE0; un test :</p>
 <pre><code class="lang-js"><span class="hljs-keyword">import</span> { shallow, createLocalVue } <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;@vue/test-utils&apos;</span>
 <span class="hljs-keyword">import</span> Vuex <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;vuex&apos;</span>
-<span class="hljs-keyword">import</span> Actions <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;../../../src/components/Getters&apos;</span>
+<span class="hljs-keyword">import</span> Getters <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;../../../src/components/Getters&apos;</span>
 
 <span class="hljs-keyword">const</span> localVue = createLocalVue()
 
@@ -1168,13 +1168,13 @@ describe(<span class="hljs-string">&apos;Getters.vue&apos;</span>, () =&gt; {
   })
 
   it(<span class="hljs-string">&apos;affiche `state.inputValue` dans la premi&#xE8;re balise &lt;p&gt;&apos;</span>, () =&gt; {
-    <span class="hljs-keyword">const</span> wrapper = shallow(Actions, { store, localVue })
+    <span class="hljs-keyword">const</span> wrapper = shallow(Getters, { store, localVue })
     <span class="hljs-keyword">const</span> p = wrapper.find(<span class="hljs-string">&apos;p&apos;</span>)
     expect(p.text()).toBe(getters.inputValue())
   })
 
   it(<span class="hljs-string">&apos;affiche `stat.clicks` dans la seconde balise &lt;p&gt;&apos;</span>, () =&gt; {
-    <span class="hljs-keyword">const</span> wrapper = shallow(Actions, { store, localVue })
+    <span class="hljs-keyword">const</span> wrapper = shallow(Getters, { store, localVue })
     <span class="hljs-keyword">const</span> p = wrapper.findAll(<span class="hljs-string">&apos;p&apos;</span>).at(<span class="hljs-number">1</span>)
     expect(p.text()).toBe(getters.clicks().toString())
   })

--- a/ja/guides/using-with-vuex.html
+++ b/ja/guides/using-with-vuex.html
@@ -1225,7 +1225,7 @@ describe(<span class="hljs-string">&apos;Actions.vue&apos;</span>, () =&gt; {
 <p>&#x30C6;&#x30B9;&#x30C8;&#x3092;&#x898B;&#x3066;&#x307F;&#x307E;&#x3057;&#x3087;&#x3046;:</p>
 <pre><code class="lang-js"><span class="hljs-keyword">import</span> { shallow, createLocalVue } <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;@vue/test-utils&apos;</span>
 <span class="hljs-keyword">import</span> Vuex <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;vuex&apos;</span>
-<span class="hljs-keyword">import</span> Actions <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;../../../src/components/Getters&apos;</span>
+<span class="hljs-keyword">import</span> Getters <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;../../../src/components/Getters&apos;</span>
 
 <span class="hljs-keyword">const</span> localVue = createLocalVue()
 
@@ -1247,13 +1247,13 @@ describe(<span class="hljs-string">&apos;Getters.vue&apos;</span>, () =&gt; {
   })
 
   it(<span class="hljs-string">&apos;Renders state.inputValue in first p tag&apos;</span>, () =&gt; {
-    <span class="hljs-keyword">const</span> wrapper = shallow(Actions, { store, localVue })
+    <span class="hljs-keyword">const</span> wrapper = shallow(Getters, { store, localVue })
     <span class="hljs-keyword">const</span> p = wrapper.find(<span class="hljs-string">&apos;p&apos;</span>)
     expect(p.text()).toBe(getters.inputValue())
   })
 
   it(<span class="hljs-string">&apos;Renders state.clicks in second p tag&apos;</span>, () =&gt; {
-    <span class="hljs-keyword">const</span> wrapper = shallow(Actions, { store, localVue })
+    <span class="hljs-keyword">const</span> wrapper = shallow(Getters, { store, localVue })
     <span class="hljs-keyword">const</span> p = wrapper.findAll(<span class="hljs-string">&apos;p&apos;</span>).at(<span class="hljs-number">1</span>)
     expect(p.text()).toBe(getters.clicks().toString())
   })

--- a/kr/guides/using-with-vuex.html
+++ b/kr/guides/using-with-vuex.html
@@ -1107,7 +1107,7 @@ describe(<span class="hljs-string">&apos;Actions.vue&apos;</span>, () =&gt; {
 <p>&#xD14C;&#xC2A4;&#xD2B8;&#xB97C; &#xBD05;&#xB2C8;&#xB2E4;.</p>
 <pre><code class="lang-js"><span class="hljs-keyword">import</span> { shallow, createLocalVue } <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;@vue/test-utils&apos;</span>
 <span class="hljs-keyword">import</span> Vuex <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;vuex&apos;</span>
-<span class="hljs-keyword">import</span> Actions <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;../../../src/components/Getters&apos;</span>
+<span class="hljs-keyword">import</span> Getters <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;../../../src/components/Getters&apos;</span>
 
 <span class="hljs-keyword">const</span> localVue = createLocalVue()
 
@@ -1129,13 +1129,13 @@ describe(<span class="hljs-string">&apos;Getters.vue&apos;</span>, () =&gt; {
   })
 
   it(<span class="hljs-string">&apos;Renders state.inputValue in first p tag&apos;</span>, () =&gt; {
-    <span class="hljs-keyword">const</span> wrapper = shallow(Actions, { store, localVue })
+    <span class="hljs-keyword">const</span> wrapper = shallow(Getters, { store, localVue })
     <span class="hljs-keyword">const</span> p = wrapper.find(<span class="hljs-string">&apos;p&apos;</span>)
     expect(p.text()).toBe(getters.inputValue())
   })
 
   it(<span class="hljs-string">&apos;Renders state.clicks in second p tag&apos;</span>, () =&gt; {
-    <span class="hljs-keyword">const</span> wrapper = shallow(Actions, { store, localVue })
+    <span class="hljs-keyword">const</span> wrapper = shallow(Getters, { store, localVue })
     <span class="hljs-keyword">const</span> p = wrapper.findAll(<span class="hljs-string">&apos;p&apos;</span>).at(<span class="hljs-number">1</span>)
     expect(p.text()).toBe(getters.clicks().toString())
   })

--- a/ru/guides/using-with-vuex.html
+++ b/ru/guides/using-with-vuex.html
@@ -1133,7 +1133,7 @@ describe(<span class="hljs-string">&apos;Actions.vue&apos;</span>, () =&gt; {
 <p>&#x414;&#x430;&#x432;&#x430;&#x439;&#x442;&#x435; &#x43F;&#x43E;&#x441;&#x43C;&#x43E;&#x442;&#x440;&#x438;&#x43C; &#x43D;&#x430; &#x442;&#x435;&#x441;&#x442;:</p>
 <pre><code class="lang-js"><span class="hljs-keyword">import</span> { shallow, createLocalVue } <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;@vue/test-utils&apos;</span>
 <span class="hljs-keyword">import</span> Vuex <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;vuex&apos;</span>
-<span class="hljs-keyword">import</span> Actions <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;../../../src/components/Getters&apos;</span>
+<span class="hljs-keyword">import</span> Getters <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;../../../src/components/Getters&apos;</span>
 
 <span class="hljs-keyword">const</span> localVue = createLocalVue()
 
@@ -1155,13 +1155,13 @@ describe(<span class="hljs-string">&apos;Getters.vue&apos;</span>, () =&gt; {
   })
 
   it(<span class="hljs-string">&apos;&#x41E;&#x442;&#x43E;&#x431;&#x440;&#x430;&#x436;&#x430;&#x435;&#x442; &quot;state.inputValue&quot; &#x432; &#x43F;&#x435;&#x440;&#x432;&#x43E;&#x43C; &#x442;&#x435;&#x433;&#x435; p&apos;</span>, () =&gt; {
-    <span class="hljs-keyword">const</span> wrapper = shallow(Actions, { store, localVue })
+    <span class="hljs-keyword">const</span> wrapper = shallow(Getters, { store, localVue })
     <span class="hljs-keyword">const</span> p = wrapper.find(<span class="hljs-string">&apos;p&apos;</span>)
     expect(p.text()).toBe(getters.inputValue())
   })
 
   it(<span class="hljs-string">&apos;&#x41E;&#x442;&#x43E;&#x431;&#x440;&#x430;&#x436;&#x430;&#x435;&#x442; &quot;state.clicks&quot; &#x432;&#x43E; &#x432;&#x442;&#x43E;&#x440;&#x43E;&#x43C; &#x442;&#x435;&#x433;&#x435; p&apos;</span>, () =&gt; {
-    <span class="hljs-keyword">const</span> wrapper = shallow(Actions, { store, localVue })
+    <span class="hljs-keyword">const</span> wrapper = shallow(Getters, { store, localVue })
     <span class="hljs-keyword">const</span> p = wrapper.findAll(<span class="hljs-string">&apos;p&apos;</span>).at(<span class="hljs-number">1</span>)
     expect(p.text()).toBe(getters.clicks().toString())
   })

--- a/zh-cn/guides/using-with-vuex.html
+++ b/zh-cn/guides/using-with-vuex.html
@@ -1238,7 +1238,7 @@ describe(<span class="hljs-string">&apos;Actions.vue&apos;</span>, () =&gt; {
 <p>&#x8BA9;&#x6211;&#x4EEC;&#x770B;&#x770B;&#x8FD9;&#x4E2A;&#x6D4B;&#x8BD5;&#xFF1A;</p>
 <pre><code class="lang-js"><span class="hljs-keyword">import</span> { shallow, createLocalVue } <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;@vue/test-utils&apos;</span>
 <span class="hljs-keyword">import</span> Vuex <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;vuex&apos;</span>
-<span class="hljs-keyword">import</span> Actions <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;../../../src/components/Getters&apos;</span>
+<span class="hljs-keyword">import</span> Getters <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;../../../src/components/Getters&apos;</span>
 
 <span class="hljs-keyword">const</span> localVue = createLocalVue()
 
@@ -1260,13 +1260,13 @@ describe(<span class="hljs-string">&apos;Getters.vue&apos;</span>, () =&gt; {
   })
 
   it(<span class="hljs-string">&apos;&#x5728;&#x7B2C;&#x4E00;&#x4E2A; p &#x6807;&#x7B7E;&#x4E2D;&#x6E32;&#x67D3;&#x201C;state.inputValue&#x201D;&apos;</span>, () =&gt; {
-    <span class="hljs-keyword">const</span> wrapper = shallow(Actions, { store, localVue })
+    <span class="hljs-keyword">const</span> wrapper = shallow(Getters, { store, localVue })
     <span class="hljs-keyword">const</span> p = wrapper.find(<span class="hljs-string">&apos;p&apos;</span>)
     expect(p.text()).toBe(getters.inputValue())
   })
 
   it(<span class="hljs-string">&apos;&#x5728;&#x7B2C;&#x4E8C;&#x4E2A; p &#x6807;&#x7B7E;&#x4E2D;&#x6E32;&#x67D3;&#x201C;state.clicks&#x201D;&apos;</span>, () =&gt; {
-    <span class="hljs-keyword">const</span> wrapper = shallow(Actions, { store, localVue })
+    <span class="hljs-keyword">const</span> wrapper = shallow(Getters, { store, localVue })
     <span class="hljs-keyword">const</span> p = wrapper.findAll(<span class="hljs-string">&apos;p&apos;</span>).at(<span class="hljs-number">1</span>)
     expect(p.text()).toBe(getters.clicks().toString())
   })


### PR DESCRIPTION
Other Vuex examples are using the the type of store method as the name of the component:

Actions:
```
import Actions from '../../../src/components/Actions'
```

Modules:
```
import Modules from '../../../src/components/Modules'
```

Set Getters example component to match these to minimize confusion. Looks like Portuguese was already fixed.