### PR TITLE
refactor: Update setData method (address #563)

### DIFF
--- a/flow/modules.flow.js
+++ b/flow/modules.flow.js
@@ -12,6 +12,10 @@ declare module 'lodash/cloneDeep' {
   declare module.exports: any;
 }
 
+declare module 'lodash/merge' {
+  declare module.exports: any;
+}
+
 declare module 'vue-template-compiler' {
   declare module.exports: any;
 }

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -420,13 +420,14 @@ export default class Wrapper implements BaseWrapper {
     }
 
     Object.keys(data).forEach((key) => {
-      // $FlowIgnore : Problem with possibly null this.vm
-      if (typeof data[key] === typeof {} && data[key] !== null) {
+      if (typeof data[key] === 'object' && data[key] !== null) {
         Object.keys(data[key]).forEach((key2) => {
-          var newObj = Object.assign({}, data[key], data[key][key2])
+          const newObj = { ...data[key], ...data[key][key2] }
+          // $FlowIgnore : Problem with possibly null this.vm
           this.vm.$set(this.vm, [key], newObj)
         })
       } else {
+        // $FlowIgnore : Problem with possibly null this.vm
         this.vm.$set(this.vm, [key], data[key])
       }
     })

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -421,7 +421,14 @@ export default class Wrapper implements BaseWrapper {
 
     Object.keys(data).forEach((key) => {
       // $FlowIgnore : Problem with possibly null this.vm
-      this.vm.$set(this.vm, [key], data[key])
+      if (typeof data[key] === typeof {} && data[key] !== null) {
+        Object.keys(data[key]).forEach((key2) => {
+          var newObj = Object.assign({}, data[key], data[key][key2])
+          this.vm.$set(this.vm, [key], newObj)
+        })
+      } else {
+        this.vm.$set(this.vm, [key], data[key])
+      }
     })
   }
 

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -1,6 +1,7 @@
 // @flow
 
 import Vue from 'vue'
+import merge from 'lodash/merge'
 import getSelectorTypeOrThrow from './get-selector-type'
 import {
   REF_SELECTOR,
@@ -421,11 +422,10 @@ export default class Wrapper implements BaseWrapper {
 
     Object.keys(data).forEach((key) => {
       if (typeof data[key] === 'object' && data[key] !== null) {
-        Object.keys(data[key]).forEach((key2) => {
-          const newObj = { ...data[key], ...data[key][key2] }
-          // $FlowIgnore : Problem with possibly null this.vm
-          this.vm.$set(this.vm, [key], newObj)
-        })
+        // $FlowIgnore : Problem with possibly null this.vm
+        const newObj = merge(this.vm[key], data[key])
+        // $FlowIgnore : Problem with possibly null this.vm
+        this.vm.$set(this.vm, [key], newObj)
       } else {
         // $FlowIgnore : Problem with possibly null this.vm
         this.vm.$set(this.vm, [key], data[key])

--- a/test/specs/wrapper/setData.spec.js
+++ b/test/specs/wrapper/setData.spec.js
@@ -132,4 +132,25 @@ describeWithShallowAndMount('setData', (mountingMethod) => {
     wrapper.setData({ message: null })
     expect(wrapper.text()).to.equal('There is no message yet')
   })
+  it('should update a data object', () => {
+    const Cmp = {
+      data: () => ({
+        anObject: {
+          propA: {
+            prop1: 'a'
+          },
+          propB: 'b'
+        }
+      })
+    }
+    const wrapper = mountingMethod(Cmp)
+    wrapper.setData({
+      anObject: {
+        propA: {
+          prop1: 'c'
+        }
+      }
+    })
+    expect(wrapper.vm.anObject.propA.prop1).to.equal('c')
+  })
 })

--- a/test/specs/wrapper/setData.spec.js
+++ b/test/specs/wrapper/setData.spec.js
@@ -132,8 +132,9 @@ describeWithShallowAndMount('setData', (mountingMethod) => {
     wrapper.setData({ message: null })
     expect(wrapper.text()).to.equal('There is no message yet')
   })
-  it('should update a data object', () => {
-    const Cmp = {
+
+  it('should update an existing property in a data object', () => {
+    const TestComponent = {
       data: () => ({
         anObject: {
           propA: {
@@ -143,7 +144,7 @@ describeWithShallowAndMount('setData', (mountingMethod) => {
         }
       })
     }
-    const wrapper = mountingMethod(Cmp)
+    const wrapper = mountingMethod(TestComponent)
     wrapper.setData({
       anObject: {
         propA: {
@@ -151,6 +152,30 @@ describeWithShallowAndMount('setData', (mountingMethod) => {
         }
       }
     })
+    expect(wrapper.vm.anObject.propB).to.equal('b')
     expect(wrapper.vm.anObject.propA.prop1).to.equal('c')
+  })
+
+  it('should append a new property to an object without removing existing properties', () => {
+    const TestComponent = {
+      data: () => ({
+        anObject: {
+          propA: {
+            prop1: 'a'
+          },
+          propB: 'b'
+        }
+      })
+    }
+    const wrapper = mountingMethod(TestComponent)
+    wrapper.setData({
+      anObject: {
+        propA: {
+          prop2: 'b'
+        }
+      }
+    })
+    expect(wrapper.vm.anObject.propA.prop1).to.equal('a')
+    expect(wrapper.vm.anObject.propA.prop2).to.equal('b')
   })
 })


### PR DESCRIPTION
This is a refactor of the setData method to allow for setting data values and objects. The current implementation of setData only allows for setting values and not objects. 

Addresses #563 