### PR TITLE
docs: switch 'Action' component to 'Getters' to match other Vuex examples

### DIFF
--- a/docs/en/guides/using-with-vuex.md
+++ b/docs/en/guides/using-with-vuex.md
@@ -139,7 +139,7 @@ Let’s see the test:
 ``` js
 import { shallow, createLocalVue } from '@vue/test-utils'
 import Vuex from 'vuex'
-import Actions from '../../../src/components/Getters'
+import Getters from '../../../src/components/Getters'
 
 const localVue = createLocalVue()
 
@@ -161,13 +161,13 @@ describe('Getters.vue', () => {
   })
 
   it('Renders "state.inputValue" in first p tag', () => {
-    const wrapper = shallow(Actions, { store, localVue })
+    const wrapper = shallow(Getters, { store, localVue })
     const p = wrapper.find('p')
     expect(p.text()).toBe(getters.inputValue())
   })
 
   it('Renders "state.clicks" in second p tag', () => {
-    const wrapper = shallow(Actions, { store, localVue })
+    const wrapper = shallow(Getters, { store, localVue })
     const p = wrapper.findAll('p').at(1)
     expect(p.text()).toBe(getters.clicks().toString())
   })

--- a/docs/fr/guides/using-with-vuex.md
+++ b/docs/fr/guides/using-with-vuex.md
@@ -136,7 +136,7 @@ Jetons un œil à un test :
 ``` js
 import { shallow, createLocalVue } from '@vue/test-utils'
 import Vuex from 'vuex'
-import Actions from '../../../src/components/Getters'
+import Getters from '../../../src/components/Getters'
 
 const localVue = createLocalVue()
 
@@ -158,13 +158,13 @@ describe('Getters.vue', () => {
   })
 
   it('affiche `state.inputValue` dans la première balise <p>', () => {
-    const wrapper = shallow(Actions, { store, localVue })
+    const wrapper = shallow(Getters, { store, localVue })
     const p = wrapper.find('p')
     expect(p.text()).toBe(getters.inputValue())
   })
 
   it('affiche `stat.clicks` dans la seconde balise <p>', () => {
-    const wrapper = shallow(Actions, { store, localVue })
+    const wrapper = shallow(Getters, { store, localVue })
     const p = wrapper.findAll('p').at(1)
     expect(p.text()).toBe(getters.clicks().toString())
   })

--- a/docs/ja/guides/using-with-vuex.md
+++ b/docs/ja/guides/using-with-vuex.md
@@ -139,7 +139,7 @@ export default{
 ``` js
 import { shallow, createLocalVue } from '@vue/test-utils'
 import Vuex from 'vuex'
-import Actions from '../../../src/components/Getters'
+import Getters from '../../../src/components/Getters'
 
 const localVue = createLocalVue()
 
@@ -161,13 +161,13 @@ describe('Getters.vue', () => {
   })
 
   it('Renders state.inputValue in first p tag', () => {
-    const wrapper = shallow(Actions, { store, localVue })
+    const wrapper = shallow(Getters, { store, localVue })
     const p = wrapper.find('p')
     expect(p.text()).toBe(getters.inputValue())
   })
 
   it('Renders state.clicks in second p tag', () => {
-    const wrapper = shallow(Actions, { store, localVue })
+    const wrapper = shallow(Getters, { store, localVue })
     const p = wrapper.findAll('p').at(1)
     expect(p.text()).toBe(getters.clicks().toString())
   })

--- a/docs/kr/guides/using-with-vuex.md
+++ b/docs/kr/guides/using-with-vuex.md
@@ -137,7 +137,7 @@ export default{
 ``` js
 import { shallow, createLocalVue } from '@vue/test-utils'
 import Vuex from 'vuex'
-import Actions from '../../../src/components/Getters'
+import Getters from '../../../src/components/Getters'
 
 const localVue = createLocalVue()
 
@@ -159,13 +159,13 @@ describe('Getters.vue', () => {
   })
 
   it('Renders state.inputValue in first p tag', () => {
-    const wrapper = shallow(Actions, { store, localVue })
+    const wrapper = shallow(Getters, { store, localVue })
     const p = wrapper.find('p')
     expect(p.text()).toBe(getters.inputValue())
   })
 
   it('Renders state.clicks in second p tag', () => {
-    const wrapper = shallow(Actions, { store, localVue })
+    const wrapper = shallow(Getters, { store, localVue })
     const p = wrapper.findAll('p').at(1)
     expect(p.text()).toBe(getters.clicks().toString())
   })

--- a/docs/ru/guides/using-with-vuex.md
+++ b/docs/ru/guides/using-with-vuex.md
@@ -136,7 +136,7 @@ export default{
 ``` js
 import { shallow, createLocalVue } from '@vue/test-utils'
 import Vuex from 'vuex'
-import Actions from '../../../src/components/Getters'
+import Getters from '../../../src/components/Getters'
 
 const localVue = createLocalVue()
 
@@ -158,13 +158,13 @@ describe('Getters.vue', () => {
   })
 
   it('Отображает "state.inputValue" в первом теге p', () => {
-    const wrapper = shallow(Actions, { store, localVue })
+    const wrapper = shallow(Getters, { store, localVue })
     const p = wrapper.find('p')
     expect(p.text()).toBe(getters.inputValue())
   })
 
   it('Отображает "state.clicks" во втором теге p', () => {
-    const wrapper = shallow(Actions, { store, localVue })
+    const wrapper = shallow(Getters, { store, localVue })
     const p = wrapper.findAll('p').at(1)
     expect(p.text()).toBe(getters.clicks().toString())
   })

--- a/docs/zh-cn/guides/using-with-vuex.md
+++ b/docs/zh-cn/guides/using-with-vuex.md
@@ -139,7 +139,7 @@ export default{
 ``` js
 import { shallow, createLocalVue } from '@vue/test-utils'
 import Vuex from 'vuex'
-import Actions from '../../../src/components/Getters'
+import Getters from '../../../src/components/Getters'
 
 const localVue = createLocalVue()
 
@@ -161,13 +161,13 @@ describe('Getters.vue', () => {
   })
 
   it('在第一个 p 标签中渲染“state.inputValue”', () => {
-    const wrapper = shallow(Actions, { store, localVue })
+    const wrapper = shallow(Getters, { store, localVue })
     const p = wrapper.find('p')
     expect(p.text()).toBe(getters.inputValue())
   })
 
   it('在第二个 p 标签中渲染“state.clicks”', () => {
-    const wrapper = shallow(Actions, { store, localVue })
+    const wrapper = shallow(Getters, { store, localVue })
     const p = wrapper.findAll('p').at(1)
     expect(p.text()).toBe(getters.clicks().toString())
   })


### PR DESCRIPTION
Resubmitting on the correct branch this time.

Other Vuex examples are using the the type of store method as the name of the component:

Actions:
```
import Actions from '../../../src/components/Actions'
```

Modules:
```
import Modules from '../../../src/components/Modules'
```

Set Getters example component to match these to minimize confusion. Looks like Portuguese was already fixed.