### PR TITLE
fix: message for logModifiedComponents

### DIFF
--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -74,7 +74,7 @@ export default function createInstance (
     if (component.components[c].extendOptions &&
       !instanceOptions.components[c]) {
       if (options.logModifiedComponents) {
-        warn(`an extended child component ${c} has been modified to ensure it has the correct instance properties. This means it is not possible to find the component with a component selector. To find the component, you must stub it manually using the mocks mounting option.`)
+        warn(`an extended child component ${c} has been modified to ensure it has the correct instance properties. This means it is not possible to find the component with a component selector. To find the component, you must stub it manually using the stubs mounting option.`)
       }
       instanceOptions.components[c] = vue.extend(component.components[c])
     }

--- a/test/specs/mount.spec.js
+++ b/test/specs/mount.spec.js
@@ -131,7 +131,7 @@ describeIf(process.env.TEST_ENV !== 'node',
     })
 
     it('logs if component is extended', () => {
-      const msg = '[vue-test-utils]: an extended child component ChildComponent has been modified to ensure it has the correct instance properties. This means it is not possible to find the component with a component selector. To find the component, you must stub it manually using the mocks mounting option.'
+      const msg = '[vue-test-utils]: an extended child component ChildComponent has been modified to ensure it has the correct instance properties. This means it is not possible to find the component with a component selector. To find the component, you must stub it manually using the stubs mounting option.'
       const ChildComponent = Vue.extend({
         template: '<span />'
       })


### PR DESCRIPTION
Since it is possible to stub by `stubs` mounting options, not `mocks` mounting options,
I think `stubs` is correct.