### PR TITLE
fix: Do not deep merge array data in setData

### DIFF
--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -421,7 +421,8 @@ export default class Wrapper implements BaseWrapper {
     }
 
     Object.keys(data).forEach((key) => {
-      if (typeof data[key] === 'object' && data[key] !== null) {
+      if (typeof data[key] === 'object' && data[key] !== null &&
+						!Array.isArray(data[key])) {
         // $FlowIgnore : Problem with possibly null this.vm
         const newObj = merge(this.vm[key], data[key])
         // $FlowIgnore : Problem with possibly null this.vm

--- a/test/specs/wrapper/setData.spec.js
+++ b/test/specs/wrapper/setData.spec.js
@@ -178,4 +178,17 @@ describeWithShallowAndMount('setData', (mountingMethod) => {
     expect(wrapper.vm.anObject.propA.prop1).to.equal('a')
     expect(wrapper.vm.anObject.propA.prop2).to.equal('b')
   })
+
+  it('sets array data properly', () => {
+    const TestComponent = {
+      data: () => ({
+        items: [1, 2]
+      })
+    }
+    const wrapper = mountingMethod(TestComponent)
+    wrapper.setData({
+      items: [3]
+    })
+    expect(wrapper.vm.items).to.deep.equal([3])
+  })
 })


### PR DESCRIPTION
## What went wrong?

In https://github.com/vuejs/vue-test-utils/pull/565, we do a deep merge on Object data however if the data is an array deep merge would mutate the data so `vm.$set` would have no effect.

The `typeof` operator is kind of inconsistent (i.e. `typeof [] === 'object'`) and we need also array checking to avoid deep merge array data. 