### PR TITLE
fix: clone propsData to avoid mutation

### DIFF
--- a/flow/options.flow.js
+++ b/flow/options.flow.js
@@ -1,5 +1,6 @@
 declare type Options = { // eslint-disable-line no-undef
     attachToDocument?: boolean,
+    propsData?: Object,
     mocks?: Object,
     methods?: Object,
     slots?: Object,

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -57,7 +57,7 @@ export default function createInstance (
 
   const Constructor = vue.extend(component)
 
-  const instanceOptions = { ...options }
+  const instanceOptions = { ...options, propsData : { ...options.propsData } }
   deleteoptions(instanceOptions)
   // $FlowIgnore
   const stubComponents = createComponentStubs(component.components, options.stubs)

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -57,7 +57,7 @@ export default function createInstance (
 
   const Constructor = vue.extend(component)
 
-  const instanceOptions = { ...options, propsData : { ...options.propsData } }
+  const instanceOptions = { ...options, propsData: { ...options.propsData }}
   deleteoptions(instanceOptions)
   // $FlowIgnore
   const stubComponents = createComponentStubs(component.components, options.stubs)

--- a/test/specs/mounting-options/propsData.spec.js
+++ b/test/specs/mounting-options/propsData.spec.js
@@ -1,0 +1,34 @@
+import { shallowMount } from '~vue/test-utils'
+import ComponentWithProps from '~resources/components/component-with-props.vue'
+import { describeIf } from '~resources/utils'
+
+const baseData = {
+  prop1: ['', '']
+}
+
+describeIf(process.env.TEST_ENV !== 'node',
+  'propsData', () => {
+    let wrapper
+
+    beforeEach(() => {
+      wrapper = shallowMount(ComponentWithProps, {
+        propsData : baseData,
+      })
+    })
+
+    afterEach(() => {
+      wrapper = null
+    })
+
+    describe('should not modify propsData between tests', () => {
+      it('should have the correct props after modifying', () => {
+        expect(wrapper.vm.prop1).to.have.length(2)
+        wrapper.setProps({ prop1: [] });
+        expect(wrapper.vm.prop1).to.have.length(0)
+      })
+
+      it('should have the default props despite being modified in the previous test', () => {
+        expect(wrapper.vm.prop1).to.have.length(2)
+      })
+    })
+  })

--- a/test/specs/mounting-options/propsData.spec.js
+++ b/test/specs/mounting-options/propsData.spec.js
@@ -12,7 +12,7 @@ describeIf(process.env.TEST_ENV !== 'node',
 
     beforeEach(() => {
       wrapper = shallowMount(ComponentWithProps, {
-        propsData : baseData,
+        propsData: baseData
       })
     })
 
@@ -23,7 +23,7 @@ describeIf(process.env.TEST_ENV !== 'node',
     describe('should not modify propsData between tests', () => {
       it('should have the correct props after modifying', () => {
         expect(wrapper.vm.prop1).to.have.length(2)
-        wrapper.setProps({ prop1: [] });
+        wrapper.setProps({ prop1: [] })
         expect(wrapper.vm.prop1).to.have.length(0)
       })
 


### PR DESCRIPTION
Potentially fix #393.

In the issue it was mentioned that cloning might cause other problems with stubbing. Was wondering if doing this might break it? Seems like all other tests are passing, maybe I'm missing something 🤔 @eddyerburgh 

Also, I've added a test to make sure it won't happen again, but I am not sure if this is the best way to do it, whether it belongs to `mounting-options` or not, whether the test structure adheres the repo standard, etc. I'm open for suggestions.

Thanks.