### PR TITLE
fix(types): add render() to packages/server-test-utils/types/index.d.ts

### DIFF
--- a/packages/server-test-utils/types/index.d.ts
+++ b/packages/server-test-utils/types/index.d.ts
@@ -55,6 +55,10 @@ interface VueTestUtilsConfigOptions {
 
 export declare let config: VueTestUtilsConfigOptions
 
+export declare function render<V extends Vue> (component: VueClass<V>, options?: ThisTypedMountOptions<V>): string
+export declare function render<V extends Vue> (component: ComponentOptions<V>, options?: ThisTypedMountOptions<V>): string
+export declare function render (component: FunctionalComponentOptions, options?: MountOptions<Vue>): string
+
 export declare function renderToString<V extends Vue> (component: VueClass<V>, options?: ThisTypedMountOptions<V>): string
 export declare function renderToString<V extends Vue> (component: ComponentOptions<V>, options?: ThisTypedMountOptions<V>): string
 export declare function renderToString (component: FunctionalComponentOptions, options?: MountOptions<Vue>): string

--- a/packages/server-test-utils/types/test/renderToString.ts
+++ b/packages/server-test-utils/types/test/renderToString.ts
@@ -1,8 +1,21 @@
 import Vuex from 'vuex'
-import { renderToString, config } from '../'
+import { render, renderToString, config } from '../'
 import { normalOptions, functionalOptions, Normal, ClassComponent } from './resources'
 
 const store = new Vuex.Store({})
+
+render(
+  {
+    template: '<p>foo</p>'
+  },
+  {
+    attachToDocument: true,
+    scopedSlots: {
+      foo: `<div>Foo</div>`
+    },
+    sync: false
+  }
+)
 
 renderToString(ClassComponent, {
   mocks: {


### PR DESCRIPTION
This adds the type of [render()](https://vue-test-utils.vuejs.org/en/api/render.html). 