### PR TITLE
fix: method should be updated when triggering

### DIFF
--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -633,11 +633,11 @@ export default class Wrapper implements BaseWrapper {
       eventObject.keyCode = modifiers[event[1]]
     }
 
-    // If this element's method has been reset by setMethod, it won't trigger
-    // Make sure that this element is updated with the latest method
+    // If this element's event handler has been reset by setMethod, it won't trigger
+    // Make sure that this element is updated with the latest event handler
     if (this.vnode) {
       const context = this.vnode.context
-      context._update(context._render())
+      if (context.$options.render) context._update(context._render())
     }
 
     this.element.dispatchEvent(eventObject)

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -633,6 +633,13 @@ export default class Wrapper implements BaseWrapper {
       eventObject.keyCode = modifiers[event[1]]
     }
 
+    // If this element's method has been reset by setMethod, it won't trigger
+    // Make sure that this element is updated with the latest method
+    if (this.vnode) {
+      const context = this.vnode.context
+      context._update(context._render())
+    }
+
     this.element.dispatchEvent(eventObject)
     if (this.vnode) {
       orderWatchers(this.vm || this.vnode.context.$root)

--- a/test/specs/wrapper/setMethods.spec.js
+++ b/test/specs/wrapper/setMethods.spec.js
@@ -27,6 +27,7 @@ describeWithShallowAndMount('setMethods', (mountingMethod) => {
     // Replace the toggle function so that the data supposedly won't change
     const toggleActive = () => console.log('overriden')
     wrapper.setMethods({ toggleActive })
+    wrapper.find('.toggle').trigger('click')
     expect(wrapper.vm.isActive).to.be.true
   })
 })

--- a/test/specs/wrapper/setMethods.spec.js
+++ b/test/specs/wrapper/setMethods.spec.js
@@ -1,15 +1,9 @@
 import { compileToFunctions } from 'vue-template-compiler'
 import ComponentWithMethods from '~resources/components/component-with-methods.vue'
+import ComponentWithEvents from '~resources/components/component-with-events.vue'
 import { describeWithShallowAndMount } from '~resources/utils'
 
 describeWithShallowAndMount('setMethods', (mountingMethod) => {
-  it('sets component data and updates nested vm nodes when called on Vue instance', () => {
-    const wrapper = mountingMethod(ComponentWithMethods)
-    const someMethod = () => console.log('hey')
-    wrapper.setMethods({ someMethod })
-    expect(wrapper.vm.someMethod).to.equal(someMethod)
-  })
-
   it('sets component data and updates nested vm nodes when called on Vue instance', () => {
     const wrapper = mountingMethod(ComponentWithMethods)
     const someMethod = () => console.log('hey')
@@ -23,5 +17,16 @@ describeWithShallowAndMount('setMethods', (mountingMethod) => {
     const wrapper = mountingMethod(compiled)
     const p = wrapper.find('p')
     expect(() => p.setMethods({ ready: true })).throw(Error, message)
+  })
+
+  it('should replace methods when tied to an event', () => {
+    const wrapper = mountingMethod(ComponentWithEvents)
+    expect(wrapper.vm.isActive).to.be.false
+    wrapper.find('.toggle').trigger('click')
+    expect(wrapper.vm.isActive).to.be.true
+    // Replace the toggle function so that the data supposedly won't change
+    const toggleActive = () => console.log('overriden')
+    wrapper.setMethods({ toggleActive })
+    expect(wrapper.vm.isActive).to.be.true
   })
 })


### PR DESCRIPTION
Potentially fix #615.

I've learned about this bug a while ago before the issue was raised (it happened on my project as well). Here's a small isolated repro link https://jsfiddle.net/3vbnq15z/

I understand that `update` is deprecated and the test utils are going towards synchronous updates. However I think for `trigger` it is necessary to update. Let me know what you think about the approach.

I also deleted one test in `setMethod` spec which is a duplicate.

Thanks.