### PR TITLE
fix: run vm.$forceUpdate in setData and setProps method

### DIFF
--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -432,6 +432,9 @@ export default class Wrapper implements BaseWrapper {
         this.vm.$set(this.vm, [key], data[key])
       }
     })
+    if (this.vm) {
+      this.vm.$forceUpdate()
+    }
   }
 
   /**
@@ -539,6 +542,9 @@ export default class Wrapper implements BaseWrapper {
     // $FlowIgnore : Problem with possibly null this.vm
     this.vnode = this.vm._vnode
     orderWatchers(this.vm || this.vnode.context.$root)
+    if (this.vm) {
+      this.vm.$forceUpdate()
+    }
   }
 
   /**


### PR DESCRIPTION
After update from vue-test-utils from `1.0.0-beta.11` to current version, I noticed that children are not always updated:

    it('download button is disabled when content is empty', () => {    
        wrapper.setData({ content: [] });
        expect(wrapper.find(vButton).vm.disabled).to.be.true;
    });

Using `wrapper.vm.$forceUpdate()` fixed this issue. To be honest I'm not sure why :)