### PR TITLE
fix: make component construct correctly which class extends from Vue

### DIFF
--- a/flow/vue.flow.js
+++ b/flow/vue.flow.js
@@ -2,6 +2,6 @@
 
 // Importing these types declares them, so they are available globally
 
-declare type Component = Object // eslint-disable-line no-undef
+declare type Component = Object | Function // eslint-disable-line no-undef
 declare type VNode = Object // eslint-disable-line no-undef
 declare type SlotValue = Component | string | Array<Component> | Array<string>

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -55,7 +55,7 @@ export default function createInstance (
 
   addEventLogger(vue)
 
-  const Constructor = vue.extend(component)
+  const Constructor = (typeof component === 'function' && component.prototype instanceof Vue) ? component : vue.extend(component)
 
   const instanceOptions = { ...options, propsData: { ...options.propsData }}
   deleteoptions(instanceOptions)


### PR DESCRIPTION
from `mount` typings we can pass a VueClass type component:
https://github.com/vuejs/vue-test-utils/blob/c0b2101f75b80e1dd5691656d0929085d5adb886/packages/test-utils/types/index.d.ts#L149

consider such a scenario
```js
class Component extends Vue {
    $mount() {
        // do something
    }
}
mount(Component)
```

or a more simple one:
```js
const Component = Vue.extend()
Component.prototype.$mount = function() { /* do something */}
mount(Component)
```

The Component prototype will be replaced if we extend the passed component directly.
https://github.com/vuejs/vue-test-utils/blob/c0b2101f75b80e1dd5691656d0929085d5adb886/packages/create-instance/create-instance.js#L58