### PR TITLE
fix: #455

### DIFF
--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -1,6 +1,7 @@
 // @flow
 
 import Vue from 'vue'
+import cloneDeep from 'lodash/cloneDeep'
 import { addSlots } from './add-slots'
 import { addScopedSlots } from './add-scoped-slots'
 import addMocks from './add-mocks'
@@ -91,6 +92,19 @@ export default function createInstance (
 
   addAttrs(vm, options.attrs)
   addListeners(vm, options.listeners)
+
+  vm.$_vueTestUtils_mountingOptionsSlots = options.slots
+  vm.$_vueTestUtils_originalSlots = cloneDeep(vm.$slots)
+  vm.$_vueTestUtils_originalUpdate = vm._update
+  vm._update = function (vnode, hydrating) {
+    // updating slot
+    if (this.$_vueTestUtils_mountingOptionsSlots) {
+      this.$slots = cloneDeep(this.$_vueTestUtils_originalSlots)
+      addSlots(this, this.$_vueTestUtils_mountingOptionsSlots)
+      vnode = this._render()
+    }
+    this.$_vueTestUtils_originalUpdate(vnode, hydrating)
+  }
 
   if (options.scopedSlots) {
     if (window.navigator.userAgent.match(/PhantomJS/i)) {

--- a/packages/test-utils/src/set-watchers-to-sync.js
+++ b/packages/test-utils/src/set-watchers-to-sync.js
@@ -27,10 +27,11 @@ export function setWatchersToSync (vm) {
 
   vm.$children.forEach(setWatchersToSync)
 
-  if (!vm.$_vueTestUtils_update) {
-    vm.$_vueTestUtils_update = vm._update
+  // preventing double registration
+  if (!vm.$_vueTestUtils_updateInSetWatcherSync) {
+    vm.$_vueTestUtils_updateInSetWatcherSync = vm._update
     vm._update = function (vnode, hydrating) {
-      this.$_vueTestUtils_update(vnode, hydrating)
+      this.$_vueTestUtils_updateInSetWatcherSync(vnode, hydrating)
       if (VUE_VERSION >= 2.1 && this._isMounted && this.$options.updated) {
         this.$options.updated.forEach((handler) => {
           handler.call(this)

--- a/packages/test-utils/src/set-watchers-to-sync.js
+++ b/packages/test-utils/src/set-watchers-to-sync.js
@@ -1,5 +1,3 @@
-import { VUE_VERSION } from './consts'
-
 function setDepsSync (dep) {
   dep.subs.forEach(setWatcherSync)
 }
@@ -26,17 +24,4 @@ export function setWatchersToSync (vm) {
   setWatcherSync(vm._watcher)
 
   vm.$children.forEach(setWatchersToSync)
-
-  // preventing double registration
-  if (!vm.$_vueTestUtils_updateInSetWatcherSync) {
-    vm.$_vueTestUtils_updateInSetWatcherSync = vm._update
-    vm._update = function (vnode, hydrating) {
-      this.$_vueTestUtils_updateInSetWatcherSync(vnode, hydrating)
-      if (VUE_VERSION >= 2.1 && this._isMounted && this.$options.updated) {
-        this.$options.updated.forEach((handler) => {
-          handler.call(this)
-        })
-      }
-    }
-  }
 }

--- a/packages/test-utils/src/set-watchers-to-sync.js
+++ b/packages/test-utils/src/set-watchers-to-sync.js
@@ -1,3 +1,5 @@
+import { VUE_VERSION } from './consts'
+
 function setDepsSync (dep) {
   dep.subs.forEach(setWatcherSync)
 }
@@ -24,4 +26,16 @@ export function setWatchersToSync (vm) {
   setWatcherSync(vm._watcher)
 
   vm.$children.forEach(setWatchersToSync)
+
+  if (!vm.$_vueTestUtils_update) {
+    vm.$_vueTestUtils_update = vm._update
+    vm._update = function (vnode, hydrating) {
+      this.$_vueTestUtils_update(vnode, hydrating)
+      if (VUE_VERSION >= 2.1 && this._isMounted && this.$options.updated) {
+        this.$options.updated.forEach((handler) => {
+          handler.call(this)
+        })
+      }
+    }
+  }
 }

--- a/test/specs/mounting-options/slots.spec.js
+++ b/test/specs/mounting-options/slots.spec.js
@@ -113,6 +113,7 @@ describeWithMountingMethods('options.slots', (mountingMethod) => {
     const wrapper5 = mountingMethod(ComponentWithSlots, { slots: { default: '1{{ foo }}2' }})
     expect(wrapper5.find('main').html()).to.equal('<main>1bar2</main>')
     wrapper5.trigger('keydown')
+    expect(wrapper5.find('main').html()).to.equal('<main>1BAR2</main>')
     const wrapper6 = mountingMethod(ComponentWithSlots, { slots: { default: '<p>1</p><p>2</p>' }})
     expect(wrapper6.find('main').html()).to.equal('<main><p>1</p><p>2</p></main>')
     const wrapper7 = mountingMethod(ComponentWithSlots, { slots: { default: '1<p>2</p>3' }})

--- a/test/specs/mounting-options/sync.spec.js
+++ b/test/specs/mounting-options/sync.spec.js
@@ -1,3 +1,4 @@
+import sinon from 'sinon'
 import { describeWithShallowAndMount } from '~resources/utils'
 
 describeWithShallowAndMount('options.sync', (mountingMethod) => {
@@ -46,7 +47,7 @@ describeWithShallowAndMount('options.sync', (mountingMethod) => {
             <pre>computed.text: <em>{{ computedText }}</em></pre>
           </div>
         </div>
-        </div>
+      </div>
       `,
       data () {
         return {
@@ -109,5 +110,26 @@ describeWithShallowAndMount('options.sync', (mountingMethod) => {
       expect(wrapper.text()).to.equal('world')
       done()
     })
+  })
+
+  it('call updated when sync is not false', () => {
+    const spy = sinon.stub()
+    const TestComponent = {
+      template: '<div>{{ foo }}</div>',
+      data () {
+        return {
+          foo: 'foo'
+        }
+      },
+      updated () {
+        spy()
+      }
+    }
+    const wrapper = mountingMethod(TestComponent, {
+      sync: true
+    })
+    expect(spy.notCalled).to.equal(true)
+    wrapper.vm.foo = 'bar'
+    expect(spy.calledOnce).to.equal(true)
   })
 })

--- a/test/specs/mounting-options/sync.spec.js
+++ b/test/specs/mounting-options/sync.spec.js
@@ -113,9 +113,17 @@ describeWithShallowAndMount('options.sync', (mountingMethod) => {
   })
 
   it('call updated when sync is not false', () => {
+    const fooSpy = sinon.stub()
+    const Foo = {
+      template: '<div>{{ foo }}</div>',
+      props: ['foo'],
+      updated () {
+        fooSpy()
+      }
+    }
     const spy = sinon.stub()
     const TestComponent = {
-      template: '<div>{{ foo }}</div>',
+      template: '<div>{{ foo }}<foo :foo="foo" /></div>',
       data () {
         return {
           foo: 'foo'
@@ -126,10 +134,14 @@ describeWithShallowAndMount('options.sync', (mountingMethod) => {
       }
     }
     const wrapper = mountingMethod(TestComponent, {
+      stubs: { foo: Foo },
       sync: true
     })
     expect(spy.notCalled).to.equal(true)
+    expect(fooSpy.notCalled).to.equal(true)
     wrapper.vm.foo = 'bar'
     expect(spy.calledOnce).to.equal(true)
+    expect(fooSpy.calledOnce).to.equal(true)
+    expect(wrapper.html()).to.equal('<div>bar<div>bar</div></div>')
   })
 })

--- a/test/specs/mounting-options/sync.spec.js
+++ b/test/specs/mounting-options/sync.spec.js
@@ -1,4 +1,3 @@
-import sinon from 'sinon'
 import { describeWithShallowAndMount } from '~resources/utils'
 
 describeWithShallowAndMount('options.sync', (mountingMethod) => {
@@ -110,38 +109,5 @@ describeWithShallowAndMount('options.sync', (mountingMethod) => {
       expect(wrapper.text()).to.equal('world')
       done()
     })
-  })
-
-  it('call updated when sync is not false', () => {
-    const fooSpy = sinon.stub()
-    const Foo = {
-      template: '<div>{{ foo }}</div>',
-      props: ['foo'],
-      updated () {
-        fooSpy()
-      }
-    }
-    const spy = sinon.stub()
-    const TestComponent = {
-      template: '<div>{{ foo }}<foo :foo="foo" /></div>',
-      data () {
-        return {
-          foo: 'foo'
-        }
-      },
-      updated () {
-        spy()
-      }
-    }
-    const wrapper = mountingMethod(TestComponent, {
-      stubs: { foo: Foo },
-      sync: true
-    })
-    expect(spy.notCalled).to.equal(true)
-    expect(fooSpy.notCalled).to.equal(true)
-    wrapper.vm.foo = 'bar'
-    expect(spy.calledOnce).to.equal(true)
-    expect(fooSpy.calledOnce).to.equal(true)
-    expect(wrapper.html()).to.equal('<div>bar<div>bar</div></div>')
   })
 })


### PR DESCRIPTION
This is related to #455 and #582.

updated hook is called in `vm._update()` at 2.0.8.
https://raw.githubusercontent.com/vuejs/vue/v2.0.8/dist/vue.js

I read below lines.

https://github.com/vuejs/vue/blob/f43ce3a5d8f73e273f2d03c9d86ea5662cda481a/src/core/instance/lifecycle.js#L182-L190

https://github.com/vuejs/vue/blob/653aac2c57d15f0e93a2c1cc7e6fad156658df19/src/core/observer/watcher.js#L187-L202

https://github.com/vuejs/vue/blob/b7445a2b945dcded287601ace8e711ab5cf35ab5/src/core/observer/scheduler.js#L130-L151

https://github.com/vuejs/vue/blob/653aac2c57d15f0e93a2c1cc7e6fad156658df19/src/core/observer/scheduler.js#L35-L94

https://github.com/vuejs/vue/blob/b7445a2b945dcded287601ace8e711ab5cf35ab5/src/core/observer/scheduler.js#L96-L105

https://github.com/vuejs/vue/blob/f43ce3a5d8f73e273f2d03c9d86ea5662cda481a/src/core/instance/lifecycle.js#L315
