### PR TITLE
add `createStub` function

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -5,5 +5,6 @@
 !!!include(docs/api/render.md)!!!
 !!!include(docs/api/renderToString.md)!!!
 !!!include(docs/api/selectors.md)!!!
+!!!include(docs/api/createStub.md)!!!
 !!!include(docs/api/createLocalVue.md)!!!
 !!!include(docs/api/config.md)!!!

--- a/docs/api/createStub.md
+++ b/docs/api/createStub.md
@@ -1,0 +1,31 @@
+## createStub()
+
+- **Arguments:**
+
+  - `{String} name`
+
+- **Returns:**
+  - `{Component}`
+
+- **Usage:**
+
+Creates a stub component. Useful when combined with [`find`](wrapper/find)  and [`findAll`](wrapper/findAll).
+
+```js
+import { shallowMount, createStub } from '@vue/test-utils'
+import ComponentWithChild from './ComponentWithChild.vue'
+
+describe('ComponentWithChild', () => {
+  it('renders a child component', () => {
+    const Child = createStub('Child')
+    const wrapper = shallowMount(ComponentWithChild, {
+      stubs: {
+        Child: Child
+      }
+    })
+    expect(wrapper.findAll(Child).length).toBe(1)
+  })
+})
+```
+
+Where `Child` is a component with `name: 'Child'`.

--- a/packages/test-utils/src/create-stub.js
+++ b/packages/test-utils/src/create-stub.js
@@ -1,0 +1,7 @@
+export default function createStub (name) {
+  return {
+    name,
+    render: h => h('div')
+  }
+}
+

--- a/packages/test-utils/src/index.js
+++ b/packages/test-utils/src/index.js
@@ -1,6 +1,7 @@
 import shallowMount from './shallow-mount'
 import mount from './mount'
 import createLocalVue from './create-local-vue'
+import createStub from './create-stub'
 import TransitionStub from './components/TransitionStub'
 import TransitionGroupStub from './components/TransitionGroupStub'
 import RouterLinkStub from './components/RouterLinkStub'
@@ -15,6 +16,7 @@ function shallow (component, options) {
 export default {
   createLocalVue,
   config,
+  createStub,
   mount,
   shallow,
   shallowMount,

--- a/test/specs/create-stub.spec.js
+++ b/test/specs/create-stub.spec.js
@@ -1,0 +1,16 @@
+import ComponentWithChild from '~resources/components/component-with-child.vue'
+import { describeWithShallowAndMount } from '~resources/utils'
+import { shallow, createStub } from '~vue/test-utils'
+
+describeWithShallowAndMount('createStub', (mountingMethod) => {
+  it('stubs a component', () => {
+    const ChildComponent = createStub('TestComponent')
+    const wrapper = mountingMethod(ComponentWithChild, {
+      stubs: {
+        'child-component': ChildComponent
+      }
+    })
+
+    expect(wrapper.findAll(ChildComponent).length).to.equal(1)
+  })
+})

--- a/test/specs/create-stub.spec.js
+++ b/test/specs/create-stub.spec.js
@@ -1,6 +1,6 @@
 import ComponentWithChild from '~resources/components/component-with-child.vue'
 import { describeWithShallowAndMount } from '~resources/utils'
-import { shallow, createStub } from '~vue/test-utils'
+import { createStub } from '~vue/test-utils'
 
 describeWithShallowAndMount('createStub', (mountingMethod) => {
   it('stubs a component', () => {


### PR DESCRIPTION
Regarding #651 

This PR adds a `createStub` method, which creates a component as such:

```js
const MyComp = createStub("MyComp")

MyComp //=>{ name: "MyComp", render: h => h("div") }
```
Useful for making it clear what is going on when you call `find` and `findAll`.




