### PR TITLE
#631 - Silent "Avoid mutating a prop directly" warning when updating prop

### DIFF
--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -94,3 +94,17 @@ import VueTestUtils from '@vue/test-utils'
 
 VueTestUtils.config.logModifiedComponents = false
 ```
+
+### `silentWarnings`
+
+- type: `Boolean`
+- default: `true`
+
+It suppresses warnings triggered by Vue while mutating component's observables (e.g. props). When set to `false`, all warnings are visible in the console. This is a configurable way which relies on `Vue.config.silent`.
+Example:
+
+```js
+import VueTestUtils from '@vue/test-utils'
+
+VueTestUtils.config.silentWarnings = false
+```

--- a/packages/test-utils/src/config.js
+++ b/packages/test-utils/src/config.js
@@ -10,5 +10,5 @@ export default {
   methods: {},
   provide: {},
   logModifiedComponents: true,
-  silentWarning: true
+  silentWarnings: true
 }

--- a/packages/test-utils/src/config.js
+++ b/packages/test-utils/src/config.js
@@ -9,5 +9,6 @@ export default {
   mocks: {},
   methods: {},
   provide: {},
-  logModifiedComponents: true
+  logModifiedComponents: true,
+  silentWarning: true
 }

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -509,7 +509,7 @@ export default class Wrapper implements BaseWrapper {
    */
   setProps (data: Object) {
     const originalConfig = Vue.config.silent
-    Vue.config.silent = config.silentWarning
+    Vue.config.silent = config.silentWarnings
     if (this.isFunctionalComponent) {
       throwError('wrapper.setProps() cannot be called on a functional component')
     }

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -27,13 +27,6 @@ import {
   orderWatchers
 } from './order-watchers'
 
-const silent = function (fn) {
-  const originalConfig = Vue.config.silent
-  Vue.config.silent = config.silentWarning
-  fn.apply(this)
-  Vue.config.silent = originalConfig
-}
-
 export default class Wrapper implements BaseWrapper {
   vnode: VNode | null;
   vm: Component | null;
@@ -515,42 +508,43 @@ export default class Wrapper implements BaseWrapper {
    * Sets vm props
    */
   setProps (data: Object) {
-    silent(() => {
-      if (this.isFunctionalComponent) {
-        throwError('wrapper.setProps() cannot be called on a functional component')
+    const originalConfig = Vue.config.silent
+    Vue.config.silent = config.silentWarning
+    if (this.isFunctionalComponent) {
+      throwError('wrapper.setProps() cannot be called on a functional component')
+    }
+    if (!this.isVueInstance() || !this.vm) {
+      throwError('wrapper.setProps() can only be called on a Vue instance')
+    }
+    if (this.vm && this.vm.$options && !this.vm.$options.propsData) {
+      this.vm.$options.propsData = {}
+    }
+    Object.keys(data).forEach((key) => {
+      // Ignore properties that were not specified in the component options
+      // $FlowIgnore : Problem with possibly null this.vm
+      if (!this.vm.$options._propKeys || !this.vm.$options._propKeys.some(prop => prop === key)) {
+        throwError(`wrapper.setProps() called with ${key} property which is not defined on component`)
       }
-      if (!this.isVueInstance() || !this.vm) {
-        throwError('wrapper.setProps() can only be called on a Vue instance')
-      }
-      if (this.vm && this.vm.$options && !this.vm.$options.propsData) {
-        this.vm.$options.propsData = {}
-      }
-      Object.keys(data).forEach((key) => {
-        // Ignore properties that were not specified in the component options
-        // $FlowIgnore : Problem with possibly null this.vm
-        if (!this.vm.$options._propKeys || !this.vm.$options._propKeys.some(prop => prop === key)) {
-          throwError(`wrapper.setProps() called with ${key} property which is not defined on component`)
-        }
-
-        // $FlowIgnore : Problem with possibly null this.vm
-        if (this.vm._props) {
-          this.vm._props[key] = data[key]
-          // $FlowIgnore : Problem with possibly null this.vm.$props
-          this.vm.$props[key] = data[key]
-          // $FlowIgnore : Problem with possibly null this.vm.$options
-          this.vm.$options.propsData[key] = data[key]
-        } else {
-          // $FlowIgnore : Problem with possibly null this.vm
-          this.vm[key] = data[key]
-          // $FlowIgnore : Problem with possibly null this.vm.$options
-          this.vm.$options.propsData[key] = data[key]
-        }
-      })
 
       // $FlowIgnore : Problem with possibly null this.vm
-      this.vnode = this.vm._vnode
-      orderWatchers(this.vm || this.vnode.context.$root)
+      if (this.vm._props) {
+        this.vm._props[key] = data[key]
+        // $FlowIgnore : Problem with possibly null this.vm.$props
+        this.vm.$props[key] = data[key]
+        // $FlowIgnore : Problem with possibly null this.vm.$options
+        this.vm.$options.propsData[key] = data[key]
+      } else {
+        // $FlowIgnore : Problem with possibly null this.vm
+        this.vm[key] = data[key]
+        // $FlowIgnore : Problem with possibly null this.vm.$options
+        this.vm.$options.propsData[key] = data[key]
+      }
     })
+
+    // $FlowIgnore : Problem with possibly null this.vm
+    this.vnode = this.vm._vnode
+    orderWatchers(this.vm || this.vnode.context.$root)
+    Vue.config.silent = originalConfig
   }
 
   /**

--- a/test/specs/config.spec.js
+++ b/test/specs/config.spec.js
@@ -11,15 +11,17 @@ import { config, TransitionStub, TransitionGroupStub, createLocalVue } from '~vu
 import Vue from 'vue'
 
 describeWithShallowAndMount('config', (mountingMethod) => {
-  let configStubsSave
-  let consoleError
-  let configLogSave
+  let configStubsSave,
+    consoleError,
+    configLogSave,
+    configSilentWarningsSave
 
   beforeEach(() => {
     TransitionGroupStub.name = 'another-temp-name'
     TransitionStub.name = 'a-temp-name'
     configStubsSave = config.stubs
     configLogSave = config.logModifiedComponents
+    configSilentWarningsSave = config.silentWarnings
     consoleError = sinon.stub(console, 'error')
   })
 
@@ -28,6 +30,7 @@ describeWithShallowAndMount('config', (mountingMethod) => {
     TransitionStub.name = 'transition'
     config.stubs = configStubsSave
     config.logModifiedComponents = configLogSave
+    config.silentWarnings = configSilentWarningsSave
     consoleError.restore()
   })
 

--- a/test/specs/config.spec.js
+++ b/test/specs/config.spec.js
@@ -138,8 +138,8 @@ describeWithShallowAndMount('config', (mountingMethod) => {
     expect(wrapper.contains(TransitionStub)).to.equal(false)
   })
 
-  it('doesn\'t throw Vue warning when silentWarning is set to true', () => {
-    config.silentWarning = true
+  it('doesn\'t throw Vue warning when silentWarnings is set to true', () => {
+    config.silentWarnings = true
     const localVue = createLocalVue()
     const wrapper = mountingMethod(ComponentWithProps, {
       propsData: {
@@ -154,8 +154,8 @@ describeWithShallowAndMount('config', (mountingMethod) => {
     expect(consoleError.called).to.equal(false)
   })
 
-  it('does throw Vue warning when silentWarning is set to false', () => {
-    config.silentWarning = false
+  it('does throw Vue warning when silentWarnings is set to false', () => {
+    config.silentWarnings = false
     const localVue = createLocalVue()
     const wrapper = mountingMethod(ComponentWithProps, {
       propsData: {

--- a/test/specs/config.spec.js
+++ b/test/specs/config.spec.js
@@ -2,6 +2,7 @@ import {
   describeWithShallowAndMount,
   vueVersion
 } from '~resources/utils'
+import ComponentWithProps from '~resources/components/component-with-props.vue'
 import {
   itDoNotRunIf,
   itSkipIf
@@ -135,6 +136,38 @@ describeWithShallowAndMount('config', (mountingMethod) => {
     const wrapper = mountingMethod(testComponent)
     expect(wrapper.contains(TransitionGroupStub)).to.equal(false)
     expect(wrapper.contains(TransitionStub)).to.equal(false)
+  })
+
+  it('doesn\'t throw Vue warning when silentWarning is set to true', () => {
+    config.silentWarning = true
+    const localVue = createLocalVue()
+    const wrapper = mountingMethod(ComponentWithProps, {
+      propsData: {
+        prop1: 'example'
+      },
+      localVue
+    })
+    expect(wrapper.vm.prop1).to.equal('example')
+    wrapper.setProps({
+      prop1: 'new value'
+    })
+    expect(consoleError.called).to.equal(false)
+  })
+
+  it('does throw Vue warning when silentWarning is set to false', () => {
+    config.silentWarning = false
+    const localVue = createLocalVue()
+    const wrapper = mountingMethod(ComponentWithProps, {
+      propsData: {
+        prop1: 'example'
+      },
+      localVue
+    })
+    expect(wrapper.vm.prop1).to.equal('example')
+    wrapper.setProps({
+      prop1: 'new value'
+    })
+    expect(consoleError.called).to.equal(true)
   })
 
   itSkipIf(


### PR DESCRIPTION
This PR aims to solve #631 

By default, Vue is throwing warnings when setProps is used/invoked, due to changes to observers and "Vue.config.silent" is false by default https://vuejs.org/v2/api/#silent

Since "silent" suppress all warnings and logs, it would be great to reduce the scope just to the desired functions/blocks.

Please, take this as an initial proposal and discuss if it makes sense to adopt this strategy and feel free to point missing implementation.

