### PR TITLE
fix: update context after setMethods

### DIFF
--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -501,6 +501,11 @@ export default class Wrapper implements BaseWrapper {
       // $FlowIgnore : Problem with possibly null this.vm
       this.vm.$options.methods[key] = methods[key]
     })
+
+    if (this.vnode) {
+      const context = this.vnode.context
+      if (context.$options.render) context._update(context._render())
+    }
   }
 
   /**
@@ -741,13 +746,6 @@ export default class Wrapper implements BaseWrapper {
     if (event.length === 2) {
       // $FlowIgnore
       eventObject.keyCode = modifiers[event[1]]
-    }
-
-    // If this element's event handler has been reset by setMethod, it won't trigger
-    // Make sure that this element is updated with the latest event handler
-    if (this.vnode) {
-      const context = this.vnode.context
-      if (context.$options.render) context._update(context._render())
     }
 
     this.element.dispatchEvent(eventObject)


### PR DESCRIPTION
I made a mistake and released before the CI passed.

A change in setMethods caused setValue to fail, this fixes setValue.

I will release beta.18 once this is merged.