### PR TITLE
fix: added quotes in warn message

### DIFF
--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -67,7 +67,7 @@ export default function createInstance (
     ) {
       if (options.logModifiedComponents) {
         warn(
-          `an extended child component ${c} has been modified ` +
+          `an extended child component "${c}" has been modified ` +
           `to ensure it has the correct instance properties. ` +
           `This means it is not possible to find the component ` +
           `with a component selector. To find the component, ` +


### PR DESCRIPTION
When the component has a name "test" or something similar the generated error message `an extended child component test has been modified` is not very clear at the first glance