### PR TITLE
fix: more readable log modified components warning

### DIFF
--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -67,7 +67,7 @@ export default function createInstance (
     ) {
       if (options.logModifiedComponents) {
         warn(
-          `an extended child component ${c} has been modified ` +
+          `an extended child component <${c}> has been modified ` +
           `to ensure it has the correct instance properties. ` +
           `This means it is not possible to find the component ` +
           `with a component selector. To find the component, ` +

--- a/test/specs/mount.spec.js
+++ b/test/specs/mount.spec.js
@@ -169,7 +169,7 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'mount', () => {
 
   it('logs if component is extended', () => {
     const msg =
-      `[vue-test-utils]: an extended child component ChildComponent ` +
+      `[vue-test-utils]: an extended child component <ChildComponent> ` +
       `has been modified to ensure it has the correct instance properties. ` +
       `This means it is not possible to find the component with a component ` +
       `selector. To find the component, you must stub it manually using the ` +


### PR DESCRIPTION
When the component has a name "test" or something similar the generated error message 

`an extended child component test has been modified`

 is not very clear at the first glance. I've changed it to

`an extended child component <test> has been modified`

(this is also the way the component names are displayed for example here https://github.com/vuejs/vue-test-utils/blob/dev/test/specs/components/TransitionStub.spec.js#L60)