### PR TITLE
docs: improve docs/api/options.md

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -107,6 +107,8 @@ shallowMount(Component, {
     // stub with a specific implementation
     'registered-component': Foo,
     // create default stub
+    // another-component is the default stub component name
+    // the default stub is <${default stub component name}-stub>
     'another-component': true
   }
 })

--- a/test/specs/mounting-options/stubs.spec.js
+++ b/test/specs/mounting-options/stubs.spec.js
@@ -174,19 +174,23 @@ describeWithMountingMethods('options.stub', mountingMethod => {
       expect(HTML).not.to.contain('<span>')
     })
 
-  it('stubs components with dummy when passed a boolean', () => {
-    const ComponentWithGlobalComponent = {
-      render: h => h('div', [h('registered-component')])
-    }
-    const wrapper = mountingMethod(ComponentWithGlobalComponent, {
-      stubs: {
-        'registered-component': true
+  itDoNotRunIf(
+    mountingMethod.name === 'renderToString',
+    'stubs components with dummy which has name when passed a boolean', () => {
+      const ComponentWithGlobalComponent = {
+        render: h => h('div', [h('registered-component')])
       }
+      const wrapper = mountingMethod(ComponentWithGlobalComponent, {
+        stubs: {
+          'registered-component': true
+        }
+      })
+      const HTML =
+        mountingMethod.name === 'renderToString' ? wrapper : wrapper.html()
+      expect(HTML).to.contain('<registered-component-stub>')
+      expect(wrapper.find({ name: 'registered-component' }).html())
+        .to.equal('<registered-component-stub></registered-component-stub>')
     })
-    const HTML =
-      mountingMethod.name === 'renderToString' ? wrapper : wrapper.html()
-    expect(HTML).to.contain('<registered-component-stub>')
-  })
 
   it('stubs components with dummy when passed as an array', () => {
     const ComponentWithGlobalComponent = {


### PR DESCRIPTION
This adds the description that a key of stubs mounting options is a default component name.