### PR TITLE
Update warning doc links

### DIFF
--- a/docs/api/wrapper/attributes.md
+++ b/docs/api/wrapper/attributes.md
@@ -1,4 +1,4 @@
-### attributes()
+## attributes()
 
 Returns `Wrapper` DOM node attribute object.
 

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -183,7 +183,7 @@ export default class Wrapper implements BaseWrapper {
     warn(
       `hasAttribute() has been deprecated and will be ` +
       `removed in version 1.0.0. Use attributes() ` +
-      `instead—https://vue-test-utils.vuejs.org/en/api/wrapper/attributes`
+      `instead—https://vue-test-utils.vuejs.org/api/wrapper/attributes.html`
     )
 
     if (typeof attribute !== 'string') {
@@ -208,7 +208,7 @@ export default class Wrapper implements BaseWrapper {
     warn(
       `hasClass() has been deprecated and will be removed ` +
       `in version 1.0.0. Use classes() ` +
-      `instead—https://vue-test-utils.vuejs.org/en/api/wrapper/classes`
+      `instead—https://vue-test-utils.vuejs.org/api/wrapper/classes.html`
     )
     let targetClass = className
 
@@ -235,7 +235,7 @@ export default class Wrapper implements BaseWrapper {
     warn(
       `hasProp() has been deprecated and will be removed ` +
       `in version 1.0.0. Use props() ` +
-      `instead—https://vue-test-utils.vuejs.org/en/api/wrapper/props`
+      `instead—https://vue-test-utils.vuejs.org/api/wrapper/props.html`
     )
 
     if (!this.isVueInstance()) {

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -183,7 +183,7 @@ export default class Wrapper implements BaseWrapper {
     warn(
       `hasAttribute() has been deprecated and will be ` +
       `removed in version 1.0.0. Use attributes() ` +
-      `instead—https://vue-test-utils.vuejs.org/api/wrapper/attributes.html`
+      `instead—https://vue-test-utils.vuejs.org/api/wrapper/#attributes`
     )
 
     if (typeof attribute !== 'string') {
@@ -208,7 +208,7 @@ export default class Wrapper implements BaseWrapper {
     warn(
       `hasClass() has been deprecated and will be removed ` +
       `in version 1.0.0. Use classes() ` +
-      `instead—https://vue-test-utils.vuejs.org/api/wrapper/classes.html`
+      `instead—https://vue-test-utils.vuejs.org/api/wrapper/#classes`
     )
     let targetClass = className
 
@@ -235,7 +235,7 @@ export default class Wrapper implements BaseWrapper {
     warn(
       `hasProp() has been deprecated and will be removed ` +
       `in version 1.0.0. Use props() ` +
-      `instead—https://vue-test-utils.vuejs.org/api/wrapper/props.html`
+      `instead—https://vue-test-utils.vuejs.org/api/wrapper/#props`
     )
 
     if (!this.isVueInstance()) {
@@ -869,7 +869,7 @@ export default class Wrapper implements BaseWrapper {
       throwError(
         `you cannot set the target value of an event. See ` +
           `the notes section of the docs for more ` +
-          `details—https://vue-test-utils.vuejs.org/api/wrapper/trigger.html`
+          `details—https://vue-test-utils.vuejs.org/api/wrapper/#trigger`
       )
     }
 


### PR DESCRIPTION
Noticed these broken links in the warnings and thought I'd help you out in fixing them @eddyerburgh.
Not sure if the `.html` extension is preferred or if that should be prettified in the Netlify's redirects file?