### PR TITLE
Update attributes.md in the dics

### DIFF
--- a/docs/api/wrapper/attributes.md
+++ b/docs/api/wrapper/attributes.md
@@ -1,4 +1,4 @@
-### attributes()
+## attributes()
 
 Returns `Wrapper` DOM node attribute object.
 


### PR DESCRIPTION
Give it a "##"-type header, just like the other Methods,
so that `attributes()` will appear in the overview column as well (on the left-hand side of the screen).