### PR TITLE
fix: SetValue can not be used with textarea.

### DIFF
--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -695,7 +695,7 @@ export default class Wrapper implements BaseWrapper {
           `type="radio" /> element. Use wrapper.setChecked() ` +
           `instead`
       )
-    } else if (tagName === 'INPUT' || tagName === 'textarea') {
+    } else if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
       // $FlowIgnore
       this.element.value = value
       this.trigger('input')

--- a/test/resources/components/component-with-input.vue
+++ b/test/resources/components/component-with-input.vue
@@ -4,6 +4,7 @@
     <input type="radio" v-model="radioVal" id="radioFoo" value="radioFooResult">
     <input type="radio" v-model="radioVal" id="radioBar" value="radioBarResult">
     <input type="text" v-model="textVal">
+    <textarea v-model="textareaVal"></textarea>
     <select v-model="selectVal">
       <option value="selectA"></option>
       <option value="selectB"></option>
@@ -35,6 +36,7 @@
       return {
         checkboxVal: undefined,
         textVal: undefined,
+        textareaVal: undefined,
         radioVal: undefined,
         selectVal: undefined,
         counter: 0

--- a/test/specs/wrapper/setValue.spec.js
+++ b/test/specs/wrapper/setValue.spec.js
@@ -2,12 +2,20 @@ import ComponentWithInput from '~resources/components/component-with-input.vue'
 import { describeWithShallowAndMount } from '~resources/utils'
 
 describeWithShallowAndMount('setValue', mountingMethod => {
-  it('sets element value', () => {
+  it('sets element of input value', () => {
     const wrapper = mountingMethod(ComponentWithInput)
     const input = wrapper.find('input[type="text"]')
     input.setValue('foo')
 
     expect(input.element.value).to.equal('foo')
+  })
+
+  it('sets element of textarea value', () => {
+    const wrapper = mountingMethod(ComponentWithInput)
+    const textarea = wrapper.find('textarea')
+    textarea.setValue('foo')
+
+    expect(textarea.element.value).to.equal('foo')
   })
 
   it('updates dom with v-model', () => {


### PR DESCRIPTION
It's actually happening.

```
const wrapper = shallowMount(TextareaComponent)
const textarea = wrapper.find('textarea')
textarea.setValue('foo')  // [vue-test-utils]: wrapper.setValue() cannot be called on this element
```

Because tagName was in lowercase.
https://github.com/vuejs/vue-test-utils/blob/dev/packages/test-utils/src/wrapper.js#L702

I added a test and fixed that tagName was lowercase.