### PR TITLE
Fix broken links for deprecated methods

### DIFF
--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -200,7 +200,7 @@ export default class Wrapper implements BaseWrapper {
     warn(
       `hasAttribute() has been deprecated and will be ` +
       `removed in version 1.0.0. Use attributes() ` +
-      `instead—https://vue-test-utils.vuejs.org/en/api/wrapper/attributes`
+      `instead—https://vue-test-utils.vuejs.org/api/wrapper/#attributes`
     )
 
     if (typeof attribute !== 'string') {
@@ -225,7 +225,7 @@ export default class Wrapper implements BaseWrapper {
     warn(
       `hasClass() has been deprecated and will be removed ` +
       `in version 1.0.0. Use classes() ` +
-      `instead—https://vue-test-utils.vuejs.org/en/api/wrapper/classes`
+      `instead—https://vue-test-utils.vuejs.org/api/wrapper/#classes`
     )
     let targetClass = className
 
@@ -252,7 +252,7 @@ export default class Wrapper implements BaseWrapper {
     warn(
       `hasProp() has been deprecated and will be removed ` +
       `in version 1.0.0. Use props() ` +
-      `instead—https://vue-test-utils.vuejs.org/en/api/wrapper/props`
+      `instead—https://vue-test-utils.vuejs.org/api/wrapper/#props`
     )
 
     if (!this.isVueInstance()) {


### PR DESCRIPTION
As commented on https://github.com/vuejs/vue-test-utils/issues/669#issuecomment-397873602 there where a few broken links due to url changes.