### PR TITLE
fix: setProps() throws an error if the property is the same reference

### DIFF
--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -657,6 +657,17 @@ export default class Wrapper implements BaseWrapper {
           `is not defined on the component`
         )
       }
+      if (
+        typeof data[key] === 'object' &&
+        data[key] !== null &&
+        // $FlowIgnore : Problem with possibly null this.vm
+        data[key] === this.vm[key]
+      ) {
+        throwError(
+          `wrapper.setProps() called with ${key} property ` +
+          `needs to create a new Object`
+        )
+      }
 
       if (this.vm && this.vm._props) {
         this.vm._props[key] = data[key]

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -664,8 +664,10 @@ export default class Wrapper implements BaseWrapper {
         data[key] === this.vm[key]
       ) {
         throwError(
-          `wrapper.setProps() called with ${key} property ` +
-          `needs to create a new Object`
+          `wrapper.setProps() called with the same object ` +
+          `of the existing ${key} property. ` +
+          `You must call wrapper.setProps() with a new object ` +
+          `to trigger reactivity`
         )
       }
 

--- a/test/specs/wrapper/setProps.spec.js
+++ b/test/specs/wrapper/setProps.spec.js
@@ -169,6 +169,36 @@ describeWithShallowAndMount('setProps', mountingMethod => {
     expect(wrapper.vm.data).to.equal('1,2,3,4,5')
   })
 
+  it('should same reference when called with same object', () => {
+    const TestComponent = {
+      template: `<div></div>`,
+      props: ['obj']
+    }
+    const wrapper = mountingMethod(TestComponent)
+    const obj = {}
+    wrapper.setProps({ obj })
+    expect(wrapper.props().obj).to.equal(obj)
+  })
+
+  it('throws an error if property is same reference', () => {
+    const TestComponent = {
+      template: `<div></div>`,
+      props: ['obj']
+    }
+    const obj = {}
+    const wrapper = mountingMethod(TestComponent, {
+      propsData: {
+        obj
+      }
+    })
+
+    const message = '[vue-test-utils]: wrapper.setProps() called with obj property needs to create a new Object'
+    const fn = () => wrapper.setProps({ obj })
+    expect(fn)
+      .to.throw()
+      .with.property('message', message)
+  })
+
   it('throws an error if node is not a Vue instance', () => {
     const message = 'wrapper.setProps() can only be called on a Vue instance'
     const compiled = compileToFunctions('<div><p></p></div>')

--- a/test/specs/wrapper/setProps.spec.js
+++ b/test/specs/wrapper/setProps.spec.js
@@ -192,7 +192,7 @@ describeWithShallowAndMount('setProps', mountingMethod => {
       }
     })
 
-    const message = '[vue-test-utils]: wrapper.setProps() called with obj property needs to create a new Object'
+    const message = '[vue-test-utils]: wrapper.setProps() called with the same object of the existing obj property. You must call wrapper.setProps() with a new object to trigger reactivity'
     const fn = () => wrapper.setProps({ obj })
     expect(fn)
       .to.throw()


### PR DESCRIPTION
Related: #761, #787  

Changes

- setProps() throws an error if the property is the same reference
- Added test that props are the same reference

Please tell me if there is a better error message.