### PR TITLE
chore(types): remove unnecessary type definition

### DIFF
--- a/flow/modules.flow.js
+++ b/flow/modules.flow.js
@@ -1,9 +1,5 @@
 // @flow
 
-declare module 'sizzle' {
-  declare module.exports: any;
-}
-
 declare module 'vue' {
   declare module.exports: any;
 }


### PR DESCRIPTION
`sizzle` is not used in this repository.