### PR TITLE
fix: allow extended components as stubs

### DIFF
--- a/packages/shared/stub-components.js
+++ b/packages/shared/stub-components.js
@@ -10,19 +10,20 @@ import {
 } from './util'
 import {
   componentNeedsCompiling,
-  templateContainsComponent
+  templateContainsComponent,
+  isVueComponent
 } from './validators'
 import { compileTemplate } from './compile-template'
 
-function isVueComponent (comp): boolean {
-  return comp && (comp.render || comp.template || comp.options)
+function isVueComponentStub (comp): boolean {
+  return comp && comp.template || isVueComponent(comp);
 }
 
 function isValidStub (stub: any): boolean {
   return (
     (!!stub && typeof stub === 'string') ||
     stub === true ||
-    isVueComponent(stub)
+    isVueComponentStub(stub)
   )
 }
 

--- a/packages/shared/stub-components.js
+++ b/packages/shared/stub-components.js
@@ -16,7 +16,7 @@ import {
 import { compileTemplate } from './compile-template'
 
 function isVueComponentStub (comp): boolean {
-  return comp && comp.template || isVueComponent(comp);
+  return comp && comp.template || isVueComponent(comp)
 }
 
 function isValidStub (stub: any): boolean {

--- a/test/specs/mounting-options/stubs.spec.js
+++ b/test/specs/mounting-options/stubs.spec.js
@@ -33,13 +33,15 @@ describeWithMountingMethods('options.stub', mountingMethod => {
   it('accepts valid component stubs', () => {
     const ComponentWithRender = { render: h => h('div') }
     const ComponentWithoutRender = { template: '<div></div>' }
-    const ExtendedComponent = Vue.extend({ template: '<div></div>' })
+    const ExtendedComponent = { extends: ComponentWithRender }
+    const SubclassedComponent = Vue.extend({ template: '<div></div>' })
     mountingMethod(ComponentWithChild, {
       stubs: {
         ChildComponent: ComponentAsAClass,
         ChildComponent2: ComponentWithRender,
         ChildComponent3: ComponentWithoutRender,
-        ChildComponent4: ExtendedComponent
+        ChildComponent4: ExtendedComponent,
+        ChildComponent5: SubclassedComponent
       }
     })
   })


### PR DESCRIPTION
The current test for accepting valid component stubs references an `ExtendedComponent`, but technically doesn't allow components that extend another component via the single-file means of `{ extends: Component }`.

This makes use of the existing shared `isVueComponent` function and combines it with the current stub-version of `isVueComponent`, which looks like it's present because `{ template }` support isn't included in the shared `isVueComponent`.