### PR TITLE
Fix bug where `Vue.mixin` overrides global components registered by plugins

### DIFF
--- a/packages/test-utils/src/shallow-mount.js
+++ b/packages/test-utils/src/shallow-mount.js
@@ -23,6 +23,7 @@ export default function shallowMount (
     delete component.components[hyphenate(component.name)]
   }
 
+  console.log(createComponentStubsForGlobals(vue))
   return mount(component, {
     ...options,
     components: {

--- a/test/resources/components/component-using-vuetify.vue
+++ b/test/resources/components/component-using-vuetify.vue
@@ -1,0 +1,17 @@
+<template>
+  <v-app>
+    <v-container>
+      <v-layout>
+        <v-flex>
+          <h1>hello</h1>
+        </v-flex>
+      </v-layout>
+    </v-container>
+  </v-app>
+</template>
+
+<script>
+export default {
+  name: 'ComponentUsingVuetify'
+}
+</script>

--- a/test/specs/create-local-vue.spec.js
+++ b/test/specs/create-local-vue.spec.js
@@ -2,8 +2,10 @@ import Vue from 'vue'
 import Vuex from 'vuex'
 import Vuetify from 'vuetify'
 import VueRouter from 'vue-router'
-import { createLocalVue } from '~vue/test-utils'
+import { createLocalVue, shallowMount } from '~vue/test-utils'
 import Component from '~resources/components/component.vue'
+import ComponentWithChild from '~resources/components/component-with-child.vue'
+import ComponentUsingVuetify from '~resources/components/component-using-vuetify.vue'
 import ComponentWithVuex from '~resources/components/component-with-vuex.vue'
 import ComponentWithRouter from '~resources/components/component-with-router.vue'
 import { describeWithShallowAndMount } from '~resources/utils'
@@ -112,9 +114,38 @@ describeWithShallowAndMount('createLocalVue', mountingMethod => {
     localVue.use(plugin, pluginOptions)
   })
 
-  it('installs Vutify successfuly', () => {
+  it('installs Vuetify successfully', () => {
     const localVue = createLocalVue()
     localVue.use(Vuetify)
+  })
+
+  const myPlugin = {
+    install: function (Vue, opts) {
+      Vue.mixin({
+        created: function() { console.log(Vue.components) }
+        // doing Vue.mixin breaks existing plugins
+      })
+    }
+  }
+
+  it.only('installs a plugin followed by Vuetify without conflict', () => {
+    const localVue = createLocalVue()
+    localVue.use(myPlugin)
+    localVue.use(Vuetify)
+
+    const wrapper = mountingMethod(ComponentUsingVuetify, { localVue })
+
+    expect(wrapper.vm.$el.children.length).to.equal(0)
+  })
+
+  it.only('installs Vuetify followed by a plugin without conflict', () => {
+    const localVue = createLocalVue()
+    localVue.use(Vuetify)
+    localVue.use(myPlugin)
+
+    const wrapper = mountingMethod(ComponentUsingVuetify, { localVue })
+
+    expect(wrapper.vm.$el.children.length).to.equal(0)
   })
 
   it('installs plugin into local Vue regardless of previous install in Vue', () => {

--- a/test/specs/create-local-vue.spec.js
+++ b/test/specs/create-local-vue.spec.js
@@ -128,7 +128,7 @@ describeWithShallowAndMount('createLocalVue', mountingMethod => {
     }
   }
 
-  it.only('installs a plugin followed by Vuetify without conflict', () => {
+  it('installs a plugin followed by Vuetify without conflict', () => {
     const localVue = createLocalVue()
     localVue.use(myPlugin)
     localVue.use(Vuetify)
@@ -138,7 +138,7 @@ describeWithShallowAndMount('createLocalVue', mountingMethod => {
     expect(wrapper.vm.$el.children.length).to.equal(0)
   })
 
-  it.only('installs Vuetify followed by a plugin without conflict', () => {
+  it('installs Vuetify followed by a plugin without conflict', () => {
     const localVue = createLocalVue()
     localVue.use(Vuetify)
     localVue.use(myPlugin)

--- a/test/specs/shallow-mount.spec.js
+++ b/test/specs/shallow-mount.spec.js
@@ -50,12 +50,20 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'shallowMount', () => {
     expect(mountedWrapper.findAll(Component).length).to.equal(1)
   })
 
+  // FIXME
   it('stubs globally registered components when options.localVue is provided', () => {
+    const myPlugin = {
+      install: function (Vue, opts) {
+        Vue.mixin({ })
+      }
+    }
     const localVue = Vue.extend()
     localVue.component('registered-component', ComponentWithLifecycleHooks)
     const TestComponent = {
       render: h => h('registered-component')
     }
+    localVue.use(myPlugin)
+
     shallowMount(TestComponent, { localVue })
     localVue.component('registered-component', ComponentWithLifecycleHooks)
     mount(TestComponent, { localVue })

--- a/test/specs/shallow-mount.spec.js
+++ b/test/specs/shallow-mount.spec.js
@@ -51,7 +51,7 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'shallowMount', () => {
   })
 
   // FIXME
-  it('stubs globally registered components when options.localVue is provided', () => {
+  it.only('stubs globally registered components when options.localVue is provided', () => {
     const myPlugin = {
       install: function (Vue, opts) {
         Vue.mixin({ })
@@ -62,7 +62,7 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'shallowMount', () => {
     const TestComponent = {
       render: h => h('registered-component')
     }
-    localVue.use(myPlugin)
+    //localVue.use(myPlugin)
 
     shallowMount(TestComponent, { localVue })
     localVue.component('registered-component', ComponentWithLifecycleHooks)


### PR DESCRIPTION
I am working towards isolating and fixing a (potential) bug which might be causing #658 and #819 . I think something odd is happening around `Vue.mixin` when used with `localVue`.

I added a reproduction test and need some opinions on if this is the right way to go.
___

The last test in the diff (in test/specs/shallow-mount.spec.js)  with `it.only` has a comment like this:

```js
// localVue.use(myPlugin)
```

Uncommenting causes a failure which I don't think should be happening.

In `shallow-mount.js`, if you do `console.log(createComponentStubsForGlobals(vue))` __after__ `Vue.mixin` is called, the `options.components` is empty. That's why the bug in https://github.com/vuejs/vue-test-utils/issues/658 is occurring, I think, and others than reply on plugins or `Vue.mixin`.

Spend a long time on this but not sure why, but I feel like this is the source of several bug reports. @eddyerburgh do you have any thoughts/ideas (or am I going in the complete wrong direction with this? Does what I tried to explain above even make sense?)

Thanks for any ideas of input, I understand you are busy with many other issues and PRs. 
