### PR TITLE
docs: update slots section in options.md

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -47,16 +47,23 @@ Example:
 
 ```js
 import Foo from './Foo.vue'
-import Bar from './Bar.vue'
+
+const bazComponent = {
+  name: 'baz-component',
+  template: '<p>baz</p>'
+}
 
 const wrapper = shallowMount(Component, {
   slots: {
-    default: [Foo, Bar],
+    default: [Foo, '<my-component />', 'text'],
     fooBar: Foo, // Will match `<slot name="FooBar" />`.
     foo: '<div />',
-    bar: 'bar'
+    bar: 'bar',
+    baz: bazComponent,
+    qux: '<my-component />'
   }
 })
+
 expect(wrapper.find('div')).toBe(true)
 ```
 


### PR DESCRIPTION
This is related to #813.
The following object was supported.

```js
const bazComponent = {
  name: 'baz-component',
  template: '<p>baz</p>'
}
```