### PR TITLE
fix: keep the overrides prototype information of component

### DIFF
--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -110,7 +110,9 @@ export default function createInstance (
     component.options._base = _Vue
   }
 
-  const Constructor = vueVersion < 2.3 && typeof component === 'function'
+  // when component constructed by Vue.extend,
+  // use its own extend method to keep component information
+  const Constructor = typeof component === 'function'
     ? component.extend(instanceOptions)
     : _Vue.extend(component).extend(instanceOptions)
 

--- a/test/specs/mount.spec.js
+++ b/test/specs/mount.spec.js
@@ -153,6 +153,28 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'mount', () => {
     expect(stub).not.called
   })
 
+  it('overrides component prototype', () => {
+    const mountSpy = sinon.spy()
+    const destroySpy = sinon.spy()
+    const Component = Vue.extend({})
+    const { $mount: originalMount, $destroy: originalDestroy } = Component.prototype
+    Component.prototype.$mount = function (...args) {
+      mountSpy()
+      originalMount.apply(this, args)
+      return this
+    }
+    Component.prototype.$destroy = function () {
+      originalDestroy.apply(this)
+      destroySpy()
+    }
+
+    const wrapper = mount(Component)
+    expect(mountSpy).called
+    expect(destroySpy).not.called
+    wrapper.destroy()
+    expect(destroySpy).called
+  })
+
   // Problems accessing options of twice extended components in Vue < 2.3
   itDoNotRunIf(vueVersion < 2.3, 'compiles extended components', () => {
     const TestComponent = Vue.component('test-component', {


### PR DESCRIPTION
add the component prototype override scenario and remove the version condition.
@eddyerburgh Actually I don't know why we need add a version condition here: https://github.com/vuejs/vue-test-utils/pull/709/commits/cacfda8acb2dfed54295b82fbd93e84205cec9d3 , any special reason?