### PR TITLE
fix: reconcile the overridden prototype of component with _Vue mixins

### DIFF
--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -126,9 +126,23 @@ export default function createInstance (
     component.options._base = _Vue
   }
 
+  function getExtendedComponent (component, instanceOptions) {
+    const extendedComponent = component.extend(instanceOptions)
+    // to keep the possible overridden prototype and _Vue mixins,
+    // we need change the proto chains manually
+    // @see https://github.com/vuejs/vue-test-utils/pull/856
+    // code below equals to
+    // `extendedComponent.prototype.__proto__.__proto__ = _Vue.prototype`
+    const extendedComponentProto =
+      Object.getPrototypeOf(extendedComponent.prototype)
+    Object.setPrototypeOf(extendedComponentProto, _Vue.prototype)
+
+    return extendedComponent
+  }
+
   // extend component from _Vue to add properties and mixins
-  const Constructor = typeof component === 'function' && vueVersion < 2.3
-    ? component.extend(instanceOptions)
+  const Constructor = typeof component === 'function'
+    ? getExtendedComponent(component, instanceOptions)
     : _Vue.extend(component).extend(instanceOptions)
 
   Object.keys(instanceOptions.components || {}).forEach(key => {

--- a/test/specs/mount.spec.js
+++ b/test/specs/mount.spec.js
@@ -153,14 +153,14 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'mount', () => {
     expect(stub).not.called
   })
 
-  it.skip('overrides component prototype', () => {
+  it('overrides component prototype', () => {
     const mountSpy = sinon.spy()
     const destroySpy = sinon.spy()
     const Component = Vue.extend({})
     const { $mount: originalMount, $destroy: originalDestroy } = Component.prototype
     Component.prototype.$mount = function (...args) {
-      mountSpy()
       originalMount.apply(this, args)
+      mountSpy()
       return this
     }
     Component.prototype.$destroy = function () {


### PR DESCRIPTION
refer to https://github.com/vuejs/vue-test-utils/pull/856