### PR TITLE
fix router name :it should be wrapper.vm.$route.path not $router.path

### DIFF
--- a/docs/zh/guides/using-with-vue-router.md
+++ b/docs/zh/guides/using-with-vue-router.md
@@ -69,7 +69,7 @@ const wrapper = shallowMount(Component, {
   }
 })
 
-wrapper.vm.$router.path // /some/path
+wrapper.vm.$route.path // /some/path
 ```
 
 ### 常识


### PR DESCRIPTION
```javascript

import { shallowMount } from '@vue/test-utils'

const $route = {
  path: '/some/path'
}

const wrapper = shallowMount(Component, {
  mocks: {
    $route
  }
})

wrapper.vm.$router.path // /some/path

it should be wrapper.vm.$route.path  not $router.path

```

[pls check issue link] (https://github.com/vuejs/vue-test-utils/issues/905)