### PR TITLE
Docs: Add propsData to Mounting Options

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -9,6 +9,7 @@ Options for `mount` and `shallowMount`. The options object can contain both Vue 
 - [`mocks`](#mocks)
 - [`localVue`](#localvue)
 - [`attachToDocument`](#attachtodocument)
+- [`propsData`](#propsdata)
 - [`attrs`](#attrs)
 - [`listeners`](#listeners)
 - [`parentComponent`](#parentComponent)
@@ -205,6 +206,32 @@ Component will be attached to DOM when rendered if set to `true`.
 - type: `Object`
 
 Set the component instance's `$attrs` object.
+
+## propsData
+
+- type: `Object`
+
+Set the component instance's props. 
+
+Example:
+
+```js
+const Component = {
+  template: '<div>{{ msg }}</div>',
+  props: ['msg']
+}
+const wrapper = mount(Component, {
+  propsData: {
+    msg: 'aBC'
+  }
+})
+expect(wrapper.text()).toBe('aBC')
+```
+
+::: tip 
+It's worth noting that `propsData` is actually a [Vue API](https://vuejs.org/v2/api/#propsData), not a proprietary
+`vue-test-utils` option. It is processed through [`extends`](#other-options).
+::: 
 
 ## listeners
 

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -229,7 +229,7 @@ expect(wrapper.text()).toBe('aBC')
 ```
 
 ::: tip 
-It's worth noting that `propsData` is actually a [Vue API](https://vuejs.org/v2/api/#propsData), not a proprietary
+It's worth noting that `propsData` is actually a [Vue API](https://vuejs.org/v2/api/#propsData), not a 
 `vue-test-utils` option. It is processed through [`extends`](#other-options).
 ::: 
 

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -20,7 +20,7 @@ Options for `mount` and `shallowMount`. The options object can contain both Vue 
 
 - type: `Object`
 
-Passes context to functional component. Can only be used with functional components.
+Passes context to functional component. Can only be used with [functional components](https://vuejs.org/v2/guide/render-function.html#Functional-Components).
 
 Example:
 

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -12,7 +12,7 @@ Options for `mount` and `shallowMount`. The options object can contain both Vue 
 - [`propsData`](#propsdata)
 - [`attrs`](#attrs)
 - [`listeners`](#listeners)
-- [`parentComponent`](#parentComponent)
+- [`parentComponent`](#parentcomponent)
 - [`provide`](#provide)
 - [`sync`](#sync)
 


### PR DESCRIPTION
### Changes
- Add propsData documentation to mounting options 
- Add link to functional component definition in `context` description
- Fix broken link to `parentComponent`

### Notes
- I used the `::: tip` container, but I don't see it used elsewhere. Happy to remove that if preferred.

Closes #917 