### PR TITLE
fix: improve emitted type

### DIFF
--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -104,7 +104,8 @@ export interface Wrapper<V extends Vue | null> extends BaseWrapper {
   text (): string
   name (): string
 
-  emitted (event?: string): { [name: string]: Array<Array<any>> }
+  emitted (): { [name: string]: Array<Array<any>> }
+  emitted (event: string): Array<any>
   emittedByOrder (): Array<{ name: string, args: Array<any> }>
 }
 

--- a/packages/test-utils/types/test/wrapper.ts
+++ b/packages/test-utils/types/test/wrapper.ts
@@ -26,8 +26,8 @@ bool = wrapper.isVueInstance()
 
 wrapper.vm.$emit('hello')
 
-const emitted = wrapper.emitted()
-const arr: Array<any> = emitted.hello
+let n: number = wrapper.emitted().hello[0][0]
+let o: string = wrapper.emitted('hello')[0]
 
 const emittedByOrder = wrapper.emittedByOrder()
 const name: string = emittedByOrder[0].name


### PR DESCRIPTION
- Add missing type for `emitted(s: string)`

closes #924 