### PR TITLE
perf: use extends instead of createLocalVue

### DIFF
--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -13,6 +13,7 @@ import { componentNeedsCompiling, isPlainObject } from 'shared/validators'
 import { validateSlots } from './validate-slots'
 import createScopedSlots from './create-scoped-slots'
 import { extendExtendedComponents } from './extend-extended-components'
+import Vue from 'vue'
 
 function compileTemplateForSlots (slots: Object): void {
   Object.keys(slots).forEach(key => {
@@ -43,12 +44,17 @@ const UNSUPPORTED_VERSION_OPTIONS = [
 
 export default function createInstance (
   component: Component,
-  options: Options,
-  _Vue: Component,
-  elm?: Element
+  options: Options
 ): Component {
   // Remove cached constructor
   delete component._Ctor
+
+  const _Vue = options.localVue
+    ? options.localVue.extend()
+    : Vue.extend()
+
+  // make sure all extends are based on this instance
+  _Vue.options._base = _Vue
 
   if (
     vueVersion < 2.3 &&

--- a/packages/server-test-utils/src/renderToString.js
+++ b/packages/server-test-utils/src/renderToString.js
@@ -4,7 +4,6 @@ import Vue from 'vue'
 import createInstance from 'create-instance'
 import { throwError } from 'shared/util'
 import { createRenderer } from 'vue-server-renderer'
-import testUtils from '@vue/test-utils'
 import { mergeOptions } from 'shared/merge-options'
 import config from './config'
 
@@ -28,11 +27,10 @@ export default function renderToString (
   if (options.attachToDocument) {
     throwError(`you cannot use attachToDocument with ` + `renderToString`)
   }
-  const vueConstructor = testUtils.createLocalVue(options.localVue)
+
   const vm = createInstance(
     component,
-    mergeOptions(options, config),
-    vueConstructor
+    mergeOptions(options, config)
   )
   let renderedString = ''
 

--- a/packages/test-utils/src/mount.js
+++ b/packages/test-utils/src/mount.js
@@ -6,7 +6,6 @@ import Vue from 'vue'
 import VueWrapper from './vue-wrapper'
 import createInstance from 'create-instance'
 import createElement from './create-element'
-import createLocalVue from './create-local-vue'
 import errorHandler from './error-handler'
 import { findAllVueComponentsFromVm } from './find-vue-components'
 import { mergeOptions } from 'shared/merge-options'
@@ -27,7 +26,6 @@ export default function mount (
 
   // Remove cached constructor
   delete component._Ctor
-  const vueConstructor = createLocalVue(options.localVue)
 
   const elm = options.attachToDocument ? createElement() : undefined
 
@@ -35,9 +33,7 @@ export default function mount (
 
   const parentVm = createInstance(
     component,
-    mergedOptions,
-    vueConstructor,
-    elm
+    mergedOptions
   )
 
   const vm = parentVm.$mount(elm).$refs.vm


### PR DESCRIPTION
- `createLocalVue` uses `cloneDeep` which can take a long time when there are lots of properties on the Vue constructor. 

https://github.com/vuejs/vue-test-utils/issues/892