### PR TITLE
docs: enable Algolia search

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -23,11 +23,11 @@ module.exports = {
   },
   serviceWorker: true,
   theme: 'vue',
-  algolia: {
-    apiKey: 'ee1b8516c9e5a5be9b6c25684eafc42f',
-    indexName: 'vue_test_utils'
-  },
   themeConfig: {
+    algolia: {
+      apiKey: 'ee1b8516c9e5a5be9b6c25684eafc42f',
+      indexName: 'vue_test_utils'
+    },
     repo: 'vuejs/vue-test-utils',
     docsDir: 'docs',
     editLinks: true,


### PR DESCRIPTION
closes #920 
fixes what was put in #938

according to https://vuepress.vuejs.org/default-theme-config/#algolia-search, we need to put it in themeConfig