### PR TITLE
docs: Improve axios mock on async testing

### DIFF
--- a/docs/guides/testing-async-components.md
+++ b/docs/guides/testing-async-components.md
@@ -8,9 +8,7 @@ The implementation of the `axios` mock looks like this:
 
 ``` js
 export default {
-  get: () => new Promise(resolve => {
-    resolve({ data: 'value' })
-  })
+  get: () => Promise.resolve({ data: 'value' })
 }
 ```
 

--- a/docs/ja/guides/testing-async-components.md
+++ b/docs/ja/guides/testing-async-components.md
@@ -8,9 +8,7 @@
 
 ``` js
 export default {
-  get: () => new Promise(resolve => {
-    resolve({ data: 'value' })
-  })
+  get: () => Promise.resolve({ data: 'value' })
 }
 ```
 

--- a/docs/ru/guides/testing-async-components.md
+++ b/docs/ru/guides/testing-async-components.md
@@ -8,9 +8,7 @@
 
 ``` js
 export default {
-  get: () => new Promise(resolve => {
-    resolve({ data: 'value' })
-  })
+  get: () => Promise.resolve({ data: 'value' })
 }
 ```
 

--- a/docs/zh/guides/testing-async-components.md
+++ b/docs/zh/guides/testing-async-components.md
@@ -8,9 +8,7 @@ API 调用和 Vuex action 都是最常见的异步行为之一。下列例子展
 
 ``` js
 export default {
-  get: () => new Promise(resolve => {
-    resolve({ data: 'value' })
-  })
+  get: () => Promise.resolve({ data: 'value' })
 }
 ```
 


### PR DESCRIPTION
Hello, first time I open a pull request on an open source project, I may have missed something.

I use the library for like a month now and found a little improvement in the docs by using [`Promise.resolve`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve) directly.

I made the same change in other languages too.
I did not bother creating an issue for a tiny change like that, but I can create one if you like.