### PR TITLE
docs(ru): add link for propsData

### DIFF
--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -28,6 +28,7 @@ Vue Test Utils — официальная библиотека модульно�
     - [localVue](api/options.md#localvue)
     - [attachToDocument](api/options.md#attachtodocument)
     - [attrs](api/options.md#attrs)
+    - [propsData](api/options.md#propsdata)
     - [listeners](api/options.md#listeners)
     - [parentComponent](api/options.md#parentComponent)
     - [provide](api/options.md#provide)

--- a/docs/ru/api/options.md
+++ b/docs/ru/api/options.md
@@ -221,7 +221,7 @@ expect(wrapper.text()).toBe('aBC')
 
 ::: tip 
 Стоит отметить, что `propsData` относятся на самом деле к [API Vue](https://ru.vuejs.org/v2/api/#propsData),
-а не к опции монтирования Vue Test Utils. Эта опция обрабатывается через [`extends`](https://vuejs.org/v2/api/#extends).
+а не к опции монтирования Vue Test Utils. Эта опция обрабатывается через [`extends`](https://ru.vuejs.org/v2/api/#extends).
 Смотрите также [другие опции](#другие-опции).
 ::: 
 

--- a/docs/ru/api/options.md
+++ b/docs/ru/api/options.md
@@ -202,7 +202,7 @@ expect(wrapper.vm.$route).toBeInstanceOf(Object)
 
 - Тип: `Object`
  
-Установите входные параметры экземпляра компонента.
+Устанавливает входные параметры экземпляра компонента, когда он примонтирован.
  
 Пример:
 
@@ -221,7 +221,8 @@ expect(wrapper.text()).toBe('aBC')
 
 ::: tip 
 Стоит отметить, что `propsData` относятся на самом деле к [API Vue](https://ru.vuejs.org/v2/api/#propsData),
-а не к `vue-test-utils`. Он обрабатывается через [`extends`](#другие-опции).
+а не к опции монтирования Vue Test Utils. Эта опция обрабатывается через [`extends`](https://vuejs.org/v2/api/#extends).
+Смотрите также [другие опции](#другие-опции).
 ::: 
 
 ## listeners


### PR DESCRIPTION
According to https://github.com/vuejs/vue-test-utils/commit/7d2980113816a7cec93d689b8f7250f8db1bcc82

cc @Alex-Sokolov