### PR TITLE
docs(ja): fix example command

### DIFF
--- a/docs/ja/guides/testing-single-file-components-with-mocha-webpack.md
+++ b/docs/ja/guides/testing-single-file-components-with-mocha-webpack.md
@@ -165,7 +165,7 @@ describe('Counter.vue', () => {
 これでテストを実行できます:
 
 ```
-npm run unit
+npm run test
 ```
 
 やったー！テストを実行している!


### PR DESCRIPTION
Correctly it is `test`, not `unit`. I think so.
The corresponding English page is also `test`.
https://vue-test-utils.vuejs.org/guides/testing-single-file-components-with-mocha-webpack.html