### PR TITLE
Fix scoped slots typing

### DIFF
--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -132,7 +132,7 @@ interface MountOptions<V extends Vue> extends ComponentOptions<V> {
   mocks?: object | false
   parentComponent?: Component
   slots?: Slots
-  scopedSlots?: Record<string, string>
+  scopedSlots?: Record<string, string | Function>
   stubs?: Stubs | false,
   attrs?: Record<string, string>
   listeners?: Record<string, Function | Function[]>

--- a/packages/test-utils/types/test/shallow.ts
+++ b/packages/test-utils/types/test/shallow.ts
@@ -1,5 +1,5 @@
 import Vuex from 'vuex'
-import { shallowMount, createLocalVue } from '../'
+import { shallowMount, createLocalVue } from '..'
 import { normalOptions, functionalOptions, ClassComponent } from './resources'
 
 /**
@@ -32,6 +32,12 @@ shallowMount(ClassComponent, {
     default: `<div>Foo</div>`,
     foo: [normalOptions, functionalOptions],
     baz: ClassComponent
+  },
+  scopedSlots: {
+    scopedFoo: `<div>scopedFoo</div>`,
+    scopedBaz() {
+      return `<div>scopedBaz</div>`;
+    },
   },
   stubs: {
     foo: normalOptions,

--- a/packages/test-utils/types/test/shallow.ts
+++ b/packages/test-utils/types/test/shallow.ts
@@ -1,5 +1,5 @@
 import Vuex from 'vuex'
-import { shallowMount, createLocalVue } from '..'
+import { shallowMount, createLocalVue } from '../'
 import { normalOptions, functionalOptions, ClassComponent } from './resources'
 
 /**


### PR DESCRIPTION
Scoped slot attribute accepts functions, but typing allows only ```Record<string, string>```
Updated typings, added test for scoped slots types