### PR TITLE
docs: Use classes instead of hasClass.

### DIFF
--- a/docs/api/wrapper-array/filter.md
+++ b/docs/api/wrapper-array/filter.md
@@ -19,5 +19,5 @@ import Foo from './Foo.vue'
 
 const wrapper = shallowMount(Foo)
 const filteredDivArray = wrapper.findAll('div')
-  .filter(w => !w.hasClass('filtered'))
+  .filter(w => !w.classes('filtered'))
 ```

--- a/docs/ja/api/wrapper-array/filter.md
+++ b/docs/ja/api/wrapper-array/filter.md
@@ -19,5 +19,5 @@ import Foo from './Foo.vue'
 
 const wrapper = shallowMount(Foo)
 const filteredDivArray = wrapper.findAll('div')
-  .filter(w => !w.hasClass('filtered'))
+  .filter(w => !w.classes('filtered'))
 ```

--- a/docs/ru/api/wrapper-array/filter.md
+++ b/docs/ru/api/wrapper-array/filter.md
@@ -19,5 +19,5 @@ import Foo from './Foo.vue'
 
 const wrapper = shallowMount(Foo)
 const filteredDivArray = wrapper.findAll('div')
-  .filter(w => !w.hasClass('filtered'))
+  .filter(w => !w.classes('filtered'))
 ```

--- a/docs/zh/api/wrapper-array/filter.md
+++ b/docs/zh/api/wrapper-array/filter.md
@@ -19,5 +19,5 @@ import Foo from './Foo.vue'
 
 const wrapper = shallowMount(Foo)
 const filteredDivArray = wrapper.findAll('div')
-  .filter(w => !w.hasClass('filtered'))
+  .filter(w => !w.classes('filtered'))
 ```


### PR DESCRIPTION
`hasClass()` has been deprecated.
Used `classes()` instead.