### PR TITLE
fix: keep object prototype when adding stubs

### DIFF
--- a/packages/create-instance/patch-render.js
+++ b/packages/create-instance/patch-render.js
@@ -108,10 +108,9 @@ export function patchRender (_Vue, stubs, stubAllComponents) {
         const stub = createStubIfNeeded(stubAllComponents, original, _Vue, el)
 
         if (stub) {
-          vm.$options.components = {
-            ...vm.$options.components,
+          Object.assign(vm.$options.components, {
             [el]: stub
-          }
+          })
           modifiedComponents.add(el)
         }
       }

--- a/test/specs/shallow-mount.spec.js
+++ b/test/specs/shallow-mount.spec.js
@@ -13,8 +13,8 @@ import { describeRunIf, itDoNotRunIf } from 'conditional-specs'
 
 describeRunIf(process.env.TEST_ENV !== 'node', 'shallowMount', () => {
   beforeEach(() => {
-    sinon.stub(console, 'info')
-    sinon.stub(console, 'error')
+    sinon.stub(console, 'info').callThrough()
+    sinon.stub(console, 'error').callThrough()
   })
 
   afterEach(() => {
@@ -489,5 +489,26 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'shallowMount', () => {
         '<anonymous-stub></anonymous-stub>' +
         '</div>'
     )
+  })
+
+  it('does not error when rendering a previously stubbed component', () => {
+    const ChildComponent = {
+      render: h => h('div')
+    }
+    const TestComponent = {
+      template: `
+        <div>
+          <extended-component />
+          <child-component />
+        </div>
+      `,
+      components: {
+        ExtendedComponent: Vue.extend({ render: h => h('div') }),
+        ChildComponent
+      }
+    }
+    shallowMount(TestComponent)
+    mount(TestComponent)
+    expect(console.error).not.called
   })
 })

--- a/test/specs/shallow-mount.spec.js
+++ b/test/specs/shallow-mount.spec.js
@@ -491,24 +491,29 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'shallowMount', () => {
     )
   })
 
-  it('does not error when rendering a previously stubbed component', () => {
-    const ChildComponent = {
-      render: h => h('div')
-    }
-    const TestComponent = {
-      template: `
+  itDoNotRunIf(
+    vueVersion < 2.1,
+    'does not error when rendering a previously stubbed component', () => {
+      const ChildComponent = {
+        render: h => h('div')
+      }
+      const TestComponent = {
+        template: `
         <div>
           <extended-component />
-          <child-component />
+          <keep-alive>
+            <child-component />
+          </keep-alive>
         </div>
       `,
-      components: {
-        ExtendedComponent: Vue.extend({ render: h => h('div') }),
-        ChildComponent
+        components: {
+          ExtendedComponent: Vue.extend({ render: h => h('div') }),
+          ChildComponent
+        }
       }
-    }
-    shallowMount(TestComponent)
-    mount(TestComponent)
-    expect(console.error).not.called
-  })
+      shallowMount(TestComponent)
+      mount(TestComponent)
+      expect(console.error)
+        .not.calledWith(sinon.match('Unknown custom element'))
+    })
 })


### PR DESCRIPTION
- Fixes #1069,
- Fixes #1054 
- Fixes #1070