### PR TITLE
fix: add custom data to events

### DIFF
--- a/packages/test-utils/src/create-dom-event.js
+++ b/packages/test-utils/src/create-dom-event.js
@@ -67,14 +67,14 @@ export default function createDOMEvent (type, options) {
     ? createEvent(eventType, modifier, meta, options)
     : createOldEvent(eventType, modifier, meta)
 
-  const eventProperties = Object.getOwnPropertyDescriptors(
-    Object.getPrototypeOf(event)
-  )
-
+  const eventPrototype = Object.getPrototypeOf(event)
   Object.keys(options || {}).forEach(key => {
+    const propertyDescriptor =
+      Object.getOwnPropertyDescriptor(eventPrototype, key)
+
     const canSetProperty = !(
-      eventProperties[key] &&
-      eventProperties[key].setter === undefined
+      propertyDescriptor &&
+      propertyDescriptor.setter === undefined
     )
     if (canSetProperty) {
       event[key] = options[key]

--- a/packages/test-utils/src/create-dom-event.js
+++ b/packages/test-utils/src/create-dom-event.js
@@ -36,8 +36,8 @@ function createEvent (
       : window.Event
 
   const event = new SupportedEventInterface(type, {
-    // event options can only be added when the event is
-    // custom options must be added after the event has been created
+    // event properties can only be added when the event is instantiated
+    // custom properties must be added after the event has been instantiated
     ...options,
     bubbles,
     cancelable,

--- a/test/specs/wrapper/trigger.spec.js
+++ b/test/specs/wrapper/trigger.spec.js
@@ -102,6 +102,26 @@ describeWithShallowAndMount('trigger', mountingMethod => {
     expect(clickHandler.calledOnce).to.equal(true)
   })
 
+  it('adds custom data to events', () => {
+    const stub = sinon.stub()
+    const TestComponent = {
+      template: '<div @update="callStub" />',
+      methods: {
+        callStub (event) {
+          stub(event.customData)
+        }
+      }
+    }
+
+    const wrapper = mountingMethod(TestComponent)
+
+    wrapper.trigger('update', {
+      customData: 123
+    })
+
+    expect(stub).calledWith(123)
+  })
+
   it('does not fire on disabled elements', () => {
     const clickHandler = sinon.stub()
     const TestComponent = {


### PR DESCRIPTION
- Add custom data to events

In https://github.com/vuejs/vue-test-utils/pull/977 event options were passed as the event was instantiated, but this doesn't work for custom data. Custom data must be added to an event after the event has been constructed.

Fixes #1064