### PR TITLE
fix: use correct event type for checkbox v-model handler

### DIFF
--- a/flow/modules.flow.js
+++ b/flow/modules.flow.js
@@ -23,3 +23,7 @@ declare module 'vue-server-renderer' {
 declare module 'cheerio' {
   declare module.exports: any;
 }
+
+declare module 'semver' {
+  declare module.exports: any;
+}

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -4,7 +4,8 @@ import { createSlotVNodes } from './create-slot-vnodes'
 import addMocks from './add-mocks'
 import { addEventLogger } from './log-events'
 import { addStubs } from './add-stubs'
-import { throwError, vueVersion } from 'shared/util'
+import { throwError } from 'shared/util'
+import { VUE_VERSION } from 'shared/consts'
 import {
   compileTemplate,
   compileTemplateForSlots
@@ -42,7 +43,7 @@ export default function createInstance (
   _Vue.options._base = _Vue
 
   if (
-    vueVersion < 2.3 &&
+    VUE_VERSION < 2.3 &&
     typeof component === 'function' &&
     component.options
   ) {
@@ -110,7 +111,7 @@ export default function createInstance (
   if (
     options.provide &&
     typeof options.provide === 'object' &&
-    vueVersion < 2.5
+    VUE_VERSION < 2.5
   ) {
     const obj = { ...options.provide }
     options.provide = () => obj

--- a/packages/create-instance/create-scoped-slots.js
+++ b/packages/create-instance/create-scoped-slots.js
@@ -1,7 +1,8 @@
 // @flow
 
 import { compileToFunctions } from 'vue-template-compiler'
-import { throwError, vueVersion } from 'shared/util'
+import { throwError } from 'shared/util'
+import { VUE_VERSION } from 'shared/consts'
 
 function isDestructuringSlotScope (slotScope: string): boolean {
   return slotScope[0] === '{' && slotScope[slotScope.length - 1] === '}'
@@ -39,7 +40,7 @@ function getVueTemplateCompilerHelpers (
 }
 
 function validateEnvironment (): void {
-  if (vueVersion < 2.1) {
+  if (VUE_VERSION < 2.1) {
     throwError(`the scopedSlots option is only supported in vue@2.1+.`)
   }
 }

--- a/packages/create-instance/patch-render.js
+++ b/packages/create-instance/patch-render.js
@@ -1,16 +1,14 @@
 import { createStubFromComponent } from './create-component-stubs'
-import { resolveComponent, semVerGreaterThan } from 'shared/util'
+import { resolveComponent } from 'shared/util'
 import { isReservedTag } from 'shared/validators'
-import Vue from 'vue'
-import { BEFORE_RENDER_LIFECYCLE_HOOK } from 'shared/consts'
+import {
+  BEFORE_RENDER_LIFECYCLE_HOOK,
+  CREATE_ELEMENT_ALIAS
+} from 'shared/consts'
 
 const isWhitelisted = (el, whitelist) => resolveComponent(el, whitelist)
 const isAlreadyStubbed = (el, stubs) => stubs.has(el)
 const isDynamicComponent = cmp => typeof cmp === 'function' && !cmp.cid
-
-const CREATE_ELEMENT_ALIAS = semVerGreaterThan(Vue.version, '2.1.5')
-  ? '_c'
-  : '_h'
 
 function shouldExtend (component, _Vue) {
   return (

--- a/packages/shared/consts.js
+++ b/packages/shared/consts.js
@@ -1,18 +1,24 @@
 import Vue from 'vue'
-import { semVerGreaterThan } from './util'
+import semver from 'semver'
 
 export const NAME_SELECTOR = 'NAME_SELECTOR'
 export const COMPONENT_SELECTOR = 'COMPONENT_SELECTOR'
 export const REF_SELECTOR = 'REF_SELECTOR'
 export const DOM_SELECTOR = 'DOM_SELECTOR'
 export const INVALID_SELECTOR = 'INVALID_SELECTOR'
+
 export const VUE_VERSION = Number(
   `${Vue.version.split('.')[0]}.${Vue.version.split('.')[1]}`
 )
+
 export const FUNCTIONAL_OPTIONS =
   VUE_VERSION >= 2.5 ? 'fnOptions' : 'functionalOptions'
 
 export const BEFORE_RENDER_LIFECYCLE_HOOK =
-  semVerGreaterThan(Vue.version, '2.1.8')
+  semver.gt(Vue.version, '2.1.8')
     ? 'beforeCreate'
     : 'beforeMount'
+
+export const CREATE_ELEMENT_ALIAS = semver.gt(Vue.version, '2.1.5')
+  ? '_c'
+  : '_h'

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,6 +2,9 @@
   "name": "shared",
   "version": "1.0.0-beta.27",
   "private": true,
+  "dependencies": {
+    "semver": "^5.6.0"
+  },
   "peerDependencies": {
     "vue": "2.x",
     "vue-template-compiler": "^2.x"

--- a/packages/shared/util.js
+++ b/packages/shared/util.js
@@ -66,12 +66,9 @@ export const isPhantomJS = UA && UA.includes &&
 export const isEdge = UA && UA.indexOf('edge/') > 0
 export const isChrome = UA && /chrome\/\d+/.test(UA) && !isEdge
 
+// get the event used to trigger v-model handler that updates bound data
 export function getCheckedEvent () {
   const version = Vue.version
-
-  if (semver.satisfies(version, '2.0 - 2.1.8')) {
-    return 'change'
-  }
 
   if (semver.satisfies(version, '2.1.9 - 2.1.10')) {
     return 'click'
@@ -81,5 +78,6 @@ export function getCheckedEvent () {
     return isChrome ? 'click' : 'change'
   }
 
+  // change is handler for version 2.0 - 2.1.8, and 2.5+
   return 'change'
 }

--- a/packages/shared/util.js
+++ b/packages/shared/util.js
@@ -1,5 +1,6 @@
 // @flow
 import Vue from 'vue'
+import semver from 'semver'
 
 export function throwError (msg: string): void {
   throw new Error(`[vue-test-utils]: ${msg}`)
@@ -31,10 +32,6 @@ const hyphenateRE = /\B([A-Z])/g
 export const hyphenate = (str: string): string =>
   str.replace(hyphenateRE, '-$1').toLowerCase()
 
-export const vueVersion = Number(
-  `${Vue.version.split('.')[0]}.${Vue.version.split('.')[1]}`
-)
-
 function hasOwnProperty (obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop)
 }
@@ -59,16 +56,30 @@ export function resolveComponent (id: string, components: Object) {
   return components[id] || components[camelizedId] || components[PascalCaseId]
 }
 
-export function semVerGreaterThan (a: string, b: string) {
-  const pa = a.split('.')
-  const pb = b.split('.')
-  for (let i = 0; i < 3; i++) {
-    var na = Number(pa[i])
-    var nb = Number(pb[i])
-    if (na > nb) return true
-    if (nb > na) return false
-    if (!isNaN(na) && isNaN(nb)) return true
-    if (isNaN(na) && !isNaN(nb)) return false
+const UA = typeof window !== 'undefined' &&
+  'navigator' in window &&
+  navigator.userAgent.toLowerCase()
+
+export const isPhantomJS = UA && UA.includes &&
+  UA.match(/phantomjs/i)
+
+export const isEdge = UA && UA.indexOf('edge/') > 0
+export const isChrome = UA && /chrome\/\d+/.test(UA) && !isEdge
+
+export function getCheckedEvent () {
+  const version = Vue.version
+
+  if (semver.satisfies(version, '2.0 - 2.1.8')) {
+    return 'change'
   }
-  return false
+
+  if (semver.satisfies(version, '2.1.9 - 2.1.10')) {
+    return 'click'
+  }
+
+  if (semver.satisfies(version, '2.2 - 2.4')) {
+    return isChrome ? 'click' : 'change'
+  }
+
+  return 'change'
 }

--- a/packages/test-utils/src/find.js
+++ b/packages/test-utils/src/find.js
@@ -4,9 +4,10 @@ import findDOMNodes from './find-dom-nodes'
 import {
   DOM_SELECTOR,
   REF_SELECTOR,
-  COMPONENT_SELECTOR
+  COMPONENT_SELECTOR,
+  VUE_VERSION
 } from 'shared/consts'
-import { throwError, vueVersion } from 'shared/util'
+import { throwError } from 'shared/util'
 import { matches } from './matches'
 
 export function findAllInstances (rootVm: any) {
@@ -74,7 +75,7 @@ export default function find (
       (selector.value.options &&
       selector.value.options.functional)
     ) &&
-    vueVersion < 2.3
+    VUE_VERSION < 2.3
   ) {
     throwError(
       `find for functional components is not supported ` +

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -521,47 +521,32 @@ export default class Wrapper implements BaseWrapper {
    */
   setSelected (): void {
     const tagName = this.element.tagName
-    // $FlowIgnore
-    const type = this.attributes().type
+
+    if (tagName === 'SELECT') {
+      throwError(
+        `wrapper.setSelected() cannot be called on select. ` +
+        `Call it on one of its options`
+      )
+    }
 
     if (tagName === 'OPTION') {
       // $FlowIgnore
       this.element.selected = true
       // $FlowIgnore
-      if (this.element.parentElement.tagName === 'OPTGROUP') {
+      let parentElement = this.element.parentElement
+
+      // $FlowIgnore
+      if (parentElement.tagName === 'OPTGROUP') {
         // $FlowIgnore
-        createWrapper(this.element.parentElement.parentElement, this.options)
-          .trigger('change')
-      } else {
-        // $FlowIgnore
-        createWrapper(this.element.parentElement, this.options)
-          .trigger('change')
+        parentElement = parentElement.parentElement
       }
-    } else if (tagName === 'SELECT') {
-      throwError(
-        `wrapper.setSelected() cannot be called on select. ` +
-          `Call it on one of its options`
-      )
-    } else if (tagName === 'INPUT' && type === 'checkbox') {
-      throwError(
-        `wrapper.setSelected() cannot be called on a <input ` +
-          `type="checkbox" /> element. Use ` +
-          `wrapper.setChecked() instead`
-      )
-    } else if (tagName === 'INPUT' && type === 'radio') {
-      throwError(
-        `wrapper.setSelected() cannot be called on a <input ` +
-          `type="radio" /> element. Use wrapper.setChecked() ` +
-          `instead`
-      )
-    } else if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
-      throwError(
-        `wrapper.setSelected() cannot be called on "text" ` +
-          `inputs. Use wrapper.setValue() instead`
-      )
-    } else {
-      throwError(`wrapper.setSelected() cannot be called on this element`)
+
+      // $FlowIgnore
+      createWrapper(parentElement, this.options).trigger('change')
+      return
     }
+
+    throwError(`wrapper.setSelected() cannot be called on this element`)
   }
 
   /**

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -40,7 +40,7 @@ export default class Wrapper implements BaseWrapper {
       // $FlowIgnore : issue with defineProperty
       Object.defineProperty(this, 'rootNode', {
         get: () => vnode || element,
-        set: () => throwError('wrapper.vnode is read-only')
+        set: () => throwError('wrapper.rootNode is read-only')
       })
       // $FlowIgnore
       Object.defineProperty(this, 'vnode', {
@@ -488,23 +488,14 @@ export default class Wrapper implements BaseWrapper {
     // $FlowIgnore
     const type = this.attributes().type
 
-    if (tagName === 'SELECT') {
-      throwError(
-        `wrapper.setChecked() cannot be called on a ` +
-          `<select> element. Use wrapper.setSelected() ` +
-          `instead`
-      )
-    } else if (tagName === 'INPUT' && type === 'checkbox') {
+    if (tagName === 'INPUT' && type === 'checkbox') {
       // $FlowIgnore
-      if (this.element.checked !== checked) {
-        if (!navigator.userAgent.includes('jsdom')) {
-          // $FlowIgnore
-          this.element.checked = checked
-        }
-        this.trigger('click')
-        this.trigger('change')
-      }
-    } else if (tagName === 'INPUT' && type === 'radio') {
+      this.element.checked = checked
+      this.trigger('change')
+      return
+    }
+
+    if (tagName === 'INPUT' && type === 'radio') {
       if (!checked) {
         throwError(
           `wrapper.setChecked() cannot be called with ` +
@@ -514,18 +505,15 @@ export default class Wrapper implements BaseWrapper {
       } else {
         // $FlowIgnore
         if (!this.element.checked) {
-          this.trigger('click')
+          // $FlowIgnore
+          this.element.checked = true
           this.trigger('change')
         }
       }
-    } else if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
-      throwError(
-        `wrapper.setChecked() cannot be called on "text" ` +
-          `inputs. Use wrapper.setValue() instead`
-      )
-    } else {
-      throwError(`wrapper.setChecked() cannot be called on this element`)
+      return
     }
+
+    throwError(`wrapper.setChecked() cannot be called on this element`)
   }
 
   /**

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -744,11 +744,7 @@ export default class Wrapper implements BaseWrapper {
     // $FlowIgnore
     const type = this.attributes().type
 
-    if (tagName === 'SELECT') {
-      // $FlowIgnore
-      this.element.value = value
-      this.trigger('change')
-    } else if (tagName === 'OPTION') {
+    if (tagName === 'OPTION') {
       throwError(
         `wrapper.setValue() cannot be called on an <option> ` +
           `element. Use wrapper.setSelected() instead`
@@ -765,10 +761,16 @@ export default class Wrapper implements BaseWrapper {
           `type="radio" /> element. Use wrapper.setChecked() ` +
           `instead`
       )
-    } else if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
+    } else if (
+      tagName === 'INPUT' ||
+      tagName === 'TEXTAREA' ||
+      tagName === 'SELECT'
+    ) {
+      // $FlowIgnore
+      const event = tagName === 'SELECT' ? 'change' : 'input'
       // $FlowIgnore
       this.element.value = value
-      this.trigger('input')
+      this.trigger(event)
     } else {
       throwError(`wrapper.setValue() cannot be called on this element`)
     }

--- a/test/specs/wrapper/setChecked.spec.js
+++ b/test/specs/wrapper/setChecked.spec.js
@@ -74,40 +74,22 @@ describeWithShallowAndMount('setChecked', mountingMethod => {
 
   it('throws error if checked param is not boolean', () => {
     const message = 'wrapper.setChecked() must be passed a boolean'
-    shouldThrowErrorOnElement('input[type="checkbox"]', message, 'asd')
+    const wrapper = mountingMethod(ComponentWithInput)
+    const input = wrapper.find('input[type="checkbox"]')
+    const fn = () => input.setChecked('asd')
+    expect(fn)
+      .to.throw()
+      .with.property('message', '[vue-test-utils]: ' + message)
   })
 
   it('throws error if checked param is false on radio element', () => {
     const message =
       'wrapper.setChecked() cannot be called with parameter false on a <input type="radio" /> element.'
-    shouldThrowErrorOnElement('#radioFoo', message, false)
-  })
-
-  it('throws error if element is select', () => {
-    const message =
-      'wrapper.setChecked() cannot be called on a <select> element. Use wrapper.setSelected() instead'
-    shouldThrowErrorOnElement('select', message)
-  })
-
-  it('throws error if element is text like', () => {
-    const message =
-      'wrapper.setChecked() cannot be called on "text" inputs. Use wrapper.setValue() instead'
-    shouldThrowErrorOnElement('input[type="text"]', message)
-    shouldThrowErrorOnElement('textarea', message)
-  })
-
-  it('throws error if element is not valid', () => {
-    const message = 'wrapper.setChecked() cannot be called on this element'
-    shouldThrowErrorOnElement('#label-el', message)
-  })
-
-  function shouldThrowErrorOnElement (selector, message, value) {
     const wrapper = mountingMethod(ComponentWithInput)
-    const input = wrapper.find(selector)
-
-    const fn = () => input.setChecked(value)
+    const input = wrapper.find('#radioFoo')
+    const fn = () => input.setChecked(false)
     expect(fn)
       .to.throw()
       .with.property('message', '[vue-test-utils]: ' + message)
-  }
+  })
 })

--- a/test/specs/wrapper/setSelected.spec.js
+++ b/test/specs/wrapper/setSelected.spec.js
@@ -1,7 +1,7 @@
 import ComponentWithInput from '~resources/components/component-with-input.vue'
 import { describeWithShallowAndMount } from '~resources/utils'
 
-describeWithShallowAndMount.only('setSelected', mountingMethod => {
+describeWithShallowAndMount('setSelected', mountingMethod => {
   it('sets element selected true', () => {
     const wrapper = mountingMethod(ComponentWithInput)
     const options = wrapper.find('select').findAll('option')

--- a/test/specs/wrapper/setSelected.spec.js
+++ b/test/specs/wrapper/setSelected.spec.js
@@ -1,7 +1,7 @@
 import ComponentWithInput from '~resources/components/component-with-input.vue'
 import { describeWithShallowAndMount } from '~resources/utils'
 
-describeWithShallowAndMount('setSelected', mountingMethod => {
+describeWithShallowAndMount.only('setSelected', mountingMethod => {
   it('sets element selected true', () => {
     const wrapper = mountingMethod(ComponentWithInput)
     const options = wrapper.find('select').findAll('option')
@@ -33,37 +33,15 @@ describeWithShallowAndMount('setSelected', mountingMethod => {
     expect(wrapper.text()).to.contain('selectA')
   })
 
-  it('throws error if element is radio', () => {
-    const message =
-      'wrapper.setSelected() cannot be called on a <input type="radio" /> element. Use wrapper.setChecked() instead'
-    shouldThrowErrorOnElement('input[type="radio"]', message)
-  })
-
-  it('throws error if element is radio', () => {
-    const message =
-      'wrapper.setSelected() cannot be called on a <input type="checkbox" /> element. Use wrapper.setChecked() instead'
-    shouldThrowErrorOnElement('input[type="checkbox"]', message)
-  })
-
-  it('throws error if element is text like', () => {
-    const message =
-      'wrapper.setSelected() cannot be called on "text" inputs. Use wrapper.setValue() instead'
-    shouldThrowErrorOnElement('input[type="text"]', message)
-    shouldThrowErrorOnElement('textarea', message)
-  })
-
   it('throws error if element is not valid', () => {
     const message = 'wrapper.setSelected() cannot be called on this element'
-    shouldThrowErrorOnElement('#label-el', message)
-  })
 
-  function shouldThrowErrorOnElement (selector, message, value) {
     const wrapper = mountingMethod(ComponentWithInput)
-    const input = wrapper.find(selector)
+    const input = wrapper.find('#label-el')
 
-    const fn = () => input.setSelected(value)
+    const fn = () => input.setSelected('value')
     expect(fn)
       .to.throw()
       .with.property('message', '[vue-test-utils]: ' + message)
-  }
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8592,6 +8592,11 @@ semver-diff@^2.0.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
+semver@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
 semver@~4.3.3:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"


### PR DESCRIPTION
- Use appropriate event to trigger v-model in `setChecked`
- Remove warnings from `setValue` and `setChecked`
- Use semver library to determine correct event

Fixes https://github.com/vuejs/vue-test-utils/issues/1071