### PR TITLE
fix: add stub without modifying

### DIFF
--- a/packages/create-instance/create-component-stubs.js
+++ b/packages/create-instance/create-component-stubs.js
@@ -167,13 +167,8 @@ export function createStubsFromStubsObject (
     if (componentNeedsCompiling(stub)) {
       compileTemplate(stub)
     }
-    const name = originalComponents[stubName] &&
-    originalComponents[stubName].name
 
-    acc[stubName] = {
-      name,
-      ...stub
-    }
+    acc[stubName] = stub
 
     return acc
   }, {})

--- a/test/specs/mounting-options/stubs.spec.js
+++ b/test/specs/mounting-options/stubs.spec.js
@@ -572,24 +572,24 @@ describeWithMountingMethods('options.stub', mountingMethod => {
   itDoNotRunIf(
     mountingMethod.name === 'renderToString',
     'uses original component stub', () => {
-    const Stub = {
-      template: '<div />'
-    }
-    const ToStub = {
-      template: '<div />'
-    }
-    const TestComponent = {
-      template: '<div><to-stub /></div>',
-      components: {
-        ToStub
+      const Stub = {
+        template: '<div />'
       }
-    }
-    const wrapper = mountingMethod(TestComponent, {
-      stubs: {
-        ToStub: Stub
+      const ToStub = {
+        template: '<div />'
       }
+      const TestComponent = {
+        template: '<div><to-stub /></div>',
+        components: {
+          ToStub
+        }
+      }
+      const wrapper = mountingMethod(TestComponent, {
+        stubs: {
+          ToStub: Stub
+        }
+      })
+      expect(wrapper.find(ToStub).exists()).to.be.false
+      expect(wrapper.find(Stub).exists()).to.be.true
     })
-    expect(wrapper.find(ToStub).exists()).to.be.false
-    expect(wrapper.find(Stub).exists()).to.be.true
-  })
 })

--- a/test/specs/mounting-options/stubs.spec.js
+++ b/test/specs/mounting-options/stubs.spec.js
@@ -64,11 +64,10 @@ describeWithMountingMethods('options.stub', mountingMethod => {
     mountingMethod.name === 'renderToString',
     'replaces component with a component',
     () => {
+      const mounted = sinon.stub()
       const Stub = {
-        render: h => h('time'),
-        mounted () {
-          console.info('stubbed')
-        }
+        template: '<div />',
+        mounted
       }
       const wrapper = mountingMethod(ComponentWithChild, {
         stubs: {
@@ -76,7 +75,7 @@ describeWithMountingMethods('options.stub', mountingMethod => {
         }
       })
       expect(wrapper.findAll(Stub).length).to.equal(1)
-      expect(info.calledWith('stubbed')).to.equal(true)
+      expect(mounted).calledOnce
     }
   )
 

--- a/test/specs/mounting-options/stubs.spec.js
+++ b/test/specs/mounting-options/stubs.spec.js
@@ -569,7 +569,9 @@ describeWithMountingMethods('options.stub', mountingMethod => {
     expect(HTML).to.contain('h1')
   })
 
-  it('uses original component stub', () => {
+  itDoNotRunIf(
+    mountingMethod.name === 'renderToString',
+    'uses original component stub', () => {
     const Stub = {
       template: '<div />'
     }
@@ -582,12 +584,12 @@ describeWithMountingMethods('options.stub', mountingMethod => {
         ToStub
       }
     }
-    const w = mountingMethod(TestComponent, {
+    const wrapper = mountingMethod(TestComponent, {
       stubs: {
         ToStub: Stub
       }
     })
-    expect(w.find(ToStub).exists()).to.be.false
-    expect(w.find(Stub).exists()).to.be.true
+    expect(wrapper.find(ToStub).exists()).to.be.false
+    expect(wrapper.find(Stub).exists()).to.be.true
   })
 })

--- a/test/specs/mounting-options/stubs.spec.js
+++ b/test/specs/mounting-options/stubs.spec.js
@@ -64,17 +64,18 @@ describeWithMountingMethods('options.stub', mountingMethod => {
     mountingMethod.name === 'renderToString',
     'replaces component with a component',
     () => {
+      const Stub = {
+        render: h => h('time'),
+        mounted () {
+          console.info('stubbed')
+        }
+      }
       const wrapper = mountingMethod(ComponentWithChild, {
         stubs: {
-          ChildComponent: {
-            render: h => h('time'),
-            mounted () {
-              console.info('stubbed')
-            }
-          }
+          ChildComponent: Stub
         }
       })
-      expect(wrapper.findAll(Component).length).to.equal(1)
+      expect(wrapper.findAll(Stub).length).to.equal(1)
       expect(info.calledWith('stubbed')).to.equal(true)
     }
   )
@@ -566,5 +567,27 @@ describeWithMountingMethods('options.stub', mountingMethod => {
         : 'dynamichello2-stub'
     )
     expect(HTML).to.contain('h1')
+  })
+
+  it('uses original component stub', () => {
+    const Stub = {
+      template: '<div />'
+    }
+    const ToStub = {
+      template: '<div />'
+    }
+    const TestComponent = {
+      template: '<div><to-stub /></div>',
+      components: {
+        ToStub
+      }
+    }
+    const w = mountingMethod(TestComponent, {
+      stubs: {
+        ToStub: Stub
+      }
+    })
+    expect(w.find(ToStub).exists()).to.be.false
+    expect(w.find(Stub).exists()).to.be.true
   })
 })


### PR DESCRIPTION
- add stub without modification

This is needed to select components passed in the `stubs` option