### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/.vuepress/_redirects
+++ b/docs/.vuepress/_redirects
@@ -5,29 +5,44 @@
 /api/createLocalVue /api/#createlocalvue
 /api/config /api/#config
 
-/api/wrapper/*  /api/wrapper.html/#:splat
-/api/wrapper-array/*  /api/wrapper-array.html/#:splat
+/api/wrapper/isvisible  /api/wrapper/#isvisible
+/api/wrapper/emitted  /api/wrapper/#emitted
+/api/wrapper/html  /api/wrapper/#html
+/api/wrapper/name  /api/wrapper/#name
+/api/wrapper/setProps  /api/wrapper/#setprops
+/api/wrapper/attributes  /api/wrapper/#attributes
+/api/wrapper/emittedByOrder  /api/wrapper/#emittedbyorder
+/api/wrapper/is  /api/wrapper/#is
+/api/wrapper/props  /api/wrapper/#props
+/api/wrapper/setSelected  /api/wrapper/#setselected
+/api/wrapper/classes  /api/wrapper/#classes
+/api/wrapper/exists  /api/wrapper/#exists
+/api/wrapper/isEmpty  /api/wrapper/#isempty
+/api/wrapper/setChecked  /api/wrapper/#setchecked
+/api/wrapper/setValue  /api/wrapper/#setvalue
+/api/wrapper/contains  /api/wrapper/#contains
+/api/wrapper/find  /api/wrapper/#find
+/api/wrapper/isVisible  /api/wrapper/#isvisible
+/api/wrapper/setData  /api/wrapper/#setdata
+/api/wrapper/text  /api/wrapper/#text
+/api/wrapper/destroy  /api/wrapper/#destroy
+/api/wrapper/findAll  /api/wrapper/#findall
+/api/wrapper/isVueInstance  /api/wrapper/#isvueinstance
+/api/wrapper/setMethods  /api/wrapper/#setmethods
+/api/wrapper/trigger  /api/wrapper/#trigger
 
-/ja/api/mount /ja/api/#mount
-/ja/api/shallowMount /ja/api/#shallowmount
-/ja/api/createLocalVue /ja/api/#createlocalvue
-/ja/api/config /ja/api/#config
+/api/wrapper-array/destroy  /api/wrapper-array/#destroy
+/api/wrapper-array/isEmpty  /api/wrapper-array/#isempty
+/api/wrapper-array/setChecked  /api/wrapper-array/#setchecked
+/api/wrapper-array/setProps  /api/wrapper-array/#setprops
+/api/wrapper-array/at  /api/wrapper-array/#at
+/api/wrapper-array/filter  /api/wrapper-array/#filter
+/api/wrapper-array/isVisible  /api/wrapper-array/#isvisible
+/api/wrapper-array/setData  /api/wrapper-array/#setdata
+/api/wrapper-array/setValue  /api/wrapper-array/#setvalue
+/api/wrapper-array/contains  /api/wrapper-array/#contains
+/api/wrapper-array/is  /api/wrapper-array/#is
+/api/wrapper-array/isVueInstance  /api/wrapper-array/#isvueinstance
+/api/wrapper-array/setMethods  /api/wrapper-array/#setmethods
+/api/wrapper-array/trigger  /api/wrapper-array/#trigger
 
-/ja/api/wrapper/* /ja/api/wrapper.html/#:splat
-/ja/api/wrapper-array/*  /ja/api/wrapper-array.html/#:splat
-
-/zh/api/mount /zh/api/#mount
-/zh/api/shallowMount /zh/api/#shallowmount
-/zh/api/createLocalVue /zh/api/#createlocalvue
-/zh/api/config /zh/api/#config
-
-/zh/api/wrapper/* /zh/api/wrapper.html/#:splat
-/zh/api/wrapper-array/*  /zh/api/wrapper-array.html/#:splat
-
-/ru/api/mount /ru/api/#mount
-/ru/api/shallowMount /ru/api/#shallowmount
-/ru/api/createLocalVue /ru/api/#createlocalvue
-/ru/api/config /ru/api/#config
-
-/ru/api/wrapper/* /ru/api/wrapper.html/#:splat
-/ru/api/wrapper-array/* /ru/api/wrapper-array.html/#:splat

--- a/docs/api/wrapper-array/at.md
+++ b/docs/api/wrapper-array/at.md
@@ -1,4 +1,4 @@
-## at(index)
+## at
 
 Returns `Wrapper` at `index` passed. Uses zero based numbering (i.e. first item is at index 0).
 

--- a/docs/api/wrapper-array/contains.md
+++ b/docs/api/wrapper-array/contains.md
@@ -1,4 +1,4 @@
-### contains(selector)
+### contains
 
 Assert every wrapper in `WrapperArray` contains selector.
 

--- a/docs/api/wrapper-array/destroy.md
+++ b/docs/api/wrapper-array/destroy.md
@@ -1,4 +1,4 @@
-## destroy()
+## destroy
 
 Destroys each Vue `Wrapper` in `WrapperArray`.
 

--- a/docs/api/wrapper-array/filter.md
+++ b/docs/api/wrapper-array/filter.md
@@ -1,4 +1,4 @@
-## filter(predicate)
+## filter
 
 Filter `WrapperArray` with a predicate function on `Wrapper` objects.
 

--- a/docs/api/wrapper-array/is.md
+++ b/docs/api/wrapper-array/is.md
@@ -1,4 +1,4 @@
-## is(selector)
+## is
 
 Assert every `Wrapper` in `WrapperArray` DOM node or `vm` matches [selector](../selectors.md).
 

--- a/docs/api/wrapper-array/isEmpty.md
+++ b/docs/api/wrapper-array/isEmpty.md
@@ -1,4 +1,4 @@
-## isEmpty()
+## isEmpty
 
 Assert every `Wrapper` in `WrapperArray` does not contain child node.
 

--- a/docs/api/wrapper-array/isVisible.md
+++ b/docs/api/wrapper-array/isVisible.md
@@ -1,4 +1,4 @@
-## isVisible()
+## isVisible
 
 Assert every `Wrapper` in `WrapperArray` is visible.
 

--- a/docs/api/wrapper-array/isVueInstance.md
+++ b/docs/api/wrapper-array/isVueInstance.md
@@ -1,4 +1,4 @@
-## isVueInstance()
+## isVueInstance
 
 Assert every `Wrapper` in `WrapperArray` is Vue instance.
 

--- a/docs/api/wrapper-array/setChecked.md
+++ b/docs/api/wrapper-array/setChecked.md
@@ -1,4 +1,4 @@
-## setChecked(checked)
+## setChecked
 
 This method is an alias of the following code.
 

--- a/docs/api/wrapper-array/setData.md
+++ b/docs/api/wrapper-array/setData.md
@@ -1,4 +1,4 @@
-## setData(data)
+## setData
 
 Sets `Wrapper` `vm` data on each `Wrapper` in `WrapperArray`.
 

--- a/docs/api/wrapper-array/setMethods.md
+++ b/docs/api/wrapper-array/setMethods.md
@@ -1,4 +1,4 @@
-## setMethods(methods)
+## setMethods
 
 Sets `Wrapper` `vm` methods and forces update on each `Wrapper` in `WrapperArray`.
 

--- a/docs/api/wrapper-array/setProps.md
+++ b/docs/api/wrapper-array/setProps.md
@@ -1,4 +1,4 @@
-## setProps(props)
+## setProps
 
 Sets `Wrapper` `vm` props and forces update on each `Wrapper` in `WrapperArray`.
 

--- a/docs/api/wrapper-array/setValue.md
+++ b/docs/api/wrapper-array/setValue.md
@@ -1,4 +1,4 @@
-## setValue(value)
+## setValue
 
 This method is an alias of the following code.
 

--- a/docs/api/wrapper-array/trigger.md
+++ b/docs/api/wrapper-array/trigger.md
@@ -1,4 +1,4 @@
-## trigger(eventType [, options ])
+## trigger
 
 Triggers an event on every `Wrapper` in the `WrapperArray` DOM node.
 

--- a/docs/api/wrapper/attributes.md
+++ b/docs/api/wrapper/attributes.md
@@ -1,4 +1,4 @@
-## attributes([key])
+## attributes
 
 Returns `Wrapper` DOM node attribute object. If `key` is provided, the value for the `key` will be returned.
 

--- a/docs/api/wrapper/classes.md
+++ b/docs/api/wrapper/classes.md
@@ -1,4 +1,4 @@
-## classes([className])
+## classes
 
 Return `Wrapper` DOM node classes.
 

--- a/docs/api/wrapper/contains.md
+++ b/docs/api/wrapper/contains.md
@@ -1,4 +1,4 @@
-## contains(selector)
+## contains
 
 Assert `Wrapper` contains an element or component matching [selector](../selectors.md).
 

--- a/docs/api/wrapper/destroy.md
+++ b/docs/api/wrapper/destroy.md
@@ -1,4 +1,4 @@
-## destroy()
+## destroy
 
 Destroys a Vue component instance.
 

--- a/docs/api/wrapper/emitted.md
+++ b/docs/api/wrapper/emitted.md
@@ -1,4 +1,4 @@
-## emitted()
+## emitted
 
 Return an object containing custom events emitted by the `Wrapper` `vm`.
 

--- a/docs/api/wrapper/emittedByOrder.md
+++ b/docs/api/wrapper/emittedByOrder.md
@@ -1,4 +1,4 @@
-## emittedByOrder()
+## emittedByOrder
 
 Return an Array containing custom events emitted by the `Wrapper` `vm`.
 

--- a/docs/api/wrapper/exists.md
+++ b/docs/api/wrapper/exists.md
@@ -1,4 +1,4 @@
-## exists()
+## exists
 
 Assert `Wrapper` or `WrapperArray` exists.
 

--- a/docs/api/wrapper/find.md
+++ b/docs/api/wrapper/find.md
@@ -1,4 +1,4 @@
-## find(selector)
+## find
 
 Returns `Wrapper` of first DOM node or Vue component matching selector.
 

--- a/docs/api/wrapper/findAll.md
+++ b/docs/api/wrapper/findAll.md
@@ -1,4 +1,4 @@
-## findAll(selector)
+## findAll
 
 Returns a [`WrapperArray`](../wrapper-array/).
 

--- a/docs/api/wrapper/html.md
+++ b/docs/api/wrapper/html.md
@@ -1,4 +1,4 @@
-## html()
+## html
 
 Returns HTML of `Wrapper` DOM node as a string.
 

--- a/docs/api/wrapper/is.md
+++ b/docs/api/wrapper/is.md
@@ -1,4 +1,4 @@
-## is(selector)
+## is
 
 Assert `Wrapper` DOM node or `vm` matches [selector](../selectors.md).
 

--- a/docs/api/wrapper/isEmpty.md
+++ b/docs/api/wrapper/isEmpty.md
@@ -1,4 +1,4 @@
-## isEmpty()
+## isEmpty
 
 Assert `Wrapper` does not contain child node.
 

--- a/docs/api/wrapper/isVisible.md
+++ b/docs/api/wrapper/isVisible.md
@@ -1,4 +1,4 @@
-## isVisible()
+## isVisible
 
 Assert `Wrapper` is visible.
 

--- a/docs/api/wrapper/isVueInstance.md
+++ b/docs/api/wrapper/isVueInstance.md
@@ -1,4 +1,4 @@
-## isVueInstance()
+## isVueInstance
 
 Assert `Wrapper` is Vue instance.
 

--- a/docs/api/wrapper/name.md
+++ b/docs/api/wrapper/name.md
@@ -1,4 +1,4 @@
-## name()
+## name
 
 Returns component name if `Wrapper` contains a Vue instance, or the tag name of `Wrapper` DOM node if `Wrapper` does not contain a Vue instance.
 

--- a/docs/api/wrapper/props.md
+++ b/docs/api/wrapper/props.md
@@ -1,4 +1,4 @@
-## props([key])
+## props
 
 Return `Wrapper` `vm` props object. If `key` is provided, the value for the `key` will be returned.
 

--- a/docs/api/wrapper/setChecked.md
+++ b/docs/api/wrapper/setChecked.md
@@ -1,4 +1,4 @@
-## setChecked(checked)
+## setChecked
 
 Sets checked value for input element of type checkbox or radio and updates `v-model` bound data.
 

--- a/docs/api/wrapper/setData.md
+++ b/docs/api/wrapper/setData.md
@@ -1,4 +1,4 @@
-## setData(data)
+## setData
 
 Sets `Wrapper` `vm` data.
 

--- a/docs/api/wrapper/setMethods.md
+++ b/docs/api/wrapper/setMethods.md
@@ -1,4 +1,4 @@
-## setMethods(methods)
+## setMethods
 
 Sets `Wrapper` `vm` methods and forces update.
 

--- a/docs/api/wrapper/setProps.md
+++ b/docs/api/wrapper/setProps.md
@@ -1,4 +1,4 @@
-## setProps(props)
+## setProps
 
 - **Arguments:**
   - `{Object} props`

--- a/docs/api/wrapper/setSelected.md
+++ b/docs/api/wrapper/setSelected.md
@@ -1,4 +1,4 @@
-## setSelected()
+## setSelected
 
 Selects an option element and updates `v-model` bound data.
 

--- a/docs/api/wrapper/setValue.md
+++ b/docs/api/wrapper/setValue.md
@@ -1,4 +1,4 @@
-## setValue(value)
+## setValue
 
 Sets value of a text-control input or select element and updates `v-model` bound data.
 

--- a/docs/api/wrapper/text.md
+++ b/docs/api/wrapper/text.md
@@ -1,4 +1,4 @@
-## text()
+## text
 
 Returns text content of `Wrapper`.
 

--- a/docs/api/wrapper/trigger.md
+++ b/docs/api/wrapper/trigger.md
@@ -1,4 +1,4 @@
-## trigger(eventType [, options ])
+## trigger
 
 Triggers an event on the `Wrapper` DOM node.
 


### PR DESCRIPTION
- Remove parameters from auto generated names
- Move _redirects to public

There are some broken links on Google that will be redirected correctly using these rules.