### PR TITLE
chore: add `repository.directory` field to each `package.json`

### DIFF
--- a/packages/server-test-utils/package.json
+++ b/packages/server-test-utils/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-test-utils.git"
+    "url": "git+https://github.com/vuejs/vue-test-utils.git",
+    "directory": "packages/server-test-utils"
   },
   "author": "vuejs",
   "license": "MIT",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-test-utils.git"
+    "url": "git+https://github.com/vuejs/vue-test-utils.git",
+    "directory": "packages/test-utils"
   },
   "author": "vuejs",
   "license": "MIT",


### PR DESCRIPTION
Like in a few monorepos in `vuejs` GH org, I wanted to introduce the same changes here related to the new `package.json` field that lets you define a path to each package that will be available on their pages on `npmjs.com`. Here is the RFC with a few more details:
https://github.com/npm/rfcs/blob/latest/accepted/0010-monorepo-subdirectory-declaration.md