### PR TITLE
server-test-utils: render() returns Cheerio not string

### DIFF
--- a/packages/server-test-utils/package.json
+++ b/packages/server-test-utils/package.json
@@ -24,7 +24,8 @@
   },
   "homepage": "https://github.com/vuejs/vue-test-utils#readme",
   "dependencies": {
-    "cheerio": "^1.0.0-rc.2"
+    "cheerio": "^1.0.0-rc.2",
+    "@types/cheerio": "^0.22.10"
   },
   "devDependencies": {
     "chalk": "^2.1.0",

--- a/packages/server-test-utils/types/index.d.ts
+++ b/packages/server-test-utils/types/index.d.ts
@@ -54,9 +54,9 @@ interface VueTestUtilsConfigOptions {
 
 export declare let config: VueTestUtilsConfigOptions
 
-export declare function render<V extends Vue> (component: VueClass<V>, options?: ThisTypedMountOptions<V>): string
-export declare function render<V extends Vue> (component: ComponentOptions<V>, options?: ThisTypedMountOptions<V>): string
-export declare function render (component: FunctionalComponentOptions, options?: MountOptions<Vue>): string
+export declare function render<V extends Vue> (component: VueClass<V>, options?: ThisTypedMountOptions<V>): Cheerio
+export declare function render<V extends Vue> (component: ComponentOptions<V>, options?: ThisTypedMountOptions<V>): Cheerio
+export declare function render (component: FunctionalComponentOptions, options?: MountOptions<Vue>): Cheerio
 
 export declare function renderToString<V extends Vue> (component: VueClass<V>, options?: ThisTypedMountOptions<V>): string
 export declare function renderToString<V extends Vue> (component: ComponentOptions<V>, options?: ThisTypedMountOptions<V>): string

--- a/packages/server-test-utils/types/test/renderToString.ts
+++ b/packages/server-test-utils/types/test/renderToString.ts
@@ -4,7 +4,7 @@ import { normalOptions, functionalOptions, Normal, ClassComponent } from './reso
 
 const store = new Vuex.Store({})
 
-render(
+const renderResult: Cheerio = render(
   {
     template: '<p>foo</p>'
   },

--- a/test/specs/render.spec.js
+++ b/test/specs/render.spec.js
@@ -1,4 +1,5 @@
 import { render } from '~vue/server-test-utils'
+import Cheerio from 'cheerio'
 
 describe('render', () => {
   it('returns a cheerio wrapper of the rendered component', () => {
@@ -6,6 +7,7 @@ describe('render', () => {
       template: '<div><h2>Test</h2><p></p><p></p></div>'
     }
     const wrapper = render(TestComponent)
+    expect(wrapper).to.be.an.instanceof(Cheerio)
     expect(wrapper.find('h2').text()).to.equal('Test')
     expect(wrapper.find('p').length).to.equal(2)
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -767,6 +767,11 @@
   dependencies:
     "@types/estree" "*"
 
+"@types/cheerio@^0.22.10":
+  version "0.22.10"
+  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.10.tgz#780d552467824be4a241b29510a7873a7432c4a6"
+  integrity sha512-fOM/Jhv51iyugY7KOBZz2ThfT1gwvsGCfWxpLpZDgkGjpEO4Le9cld07OdskikLjDUQJ43dzDaVRSFwQlpdqVg==
+
 "@types/estree@*", "@types/estree@0.0.38":
   version "0.0.38"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.38.tgz#c1be40aa933723c608820a99a373a16d215a1ca2"


### PR DESCRIPTION
The documentation (https://vue-test-utils.vuejs.org/api/render.html#render)
as well as the implementation state render()'s return type as `Cheerio`,
the type definition should consequently do the same.

~Please take a good look at the dist files - there is quite a bit of iffy change, possibly due to different versions of tools being used. I could not find infrastructure instructions (e.g. `Dockerfile`) however. Please advise / rebuild.~

Introduced during #618
Fixes #1131