### PR TITLE
More prominent mention of allowed additional options

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -1,6 +1,11 @@
 # Mounting Options
 
-Options for `mount` and `shallowMount`. The options object can contain both Vue Test Utils mounting options and other options.
+Options for `mount` and `shallowMount`.
+
+:::tip
+Aside form the options documented below, the `options` object can contain any option that would be valid in a call to `new Vue ({ /*options here*/ })`.
+These options will be merged with the component's existing options when mounted with `mount` / `shallowMount`
+:::
 
 - [`context`](#context)
 - [`slots`](#slots)

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -5,6 +5,8 @@ Options for `mount` and `shallowMount`.
 :::tip
 Aside form the options documented below, the `options` object can contain any option that would be valid in a call to `new Vue ({ /*options here*/ })`.
 These options will be merged with the component's existing options when mounted with `mount` / `shallowMount`
+
+[See other options for examples](#other-options)
 :::
 
 - [`context`](#context)


### PR DESCRIPTION
The small sentence in the first paragraph isn't specific enough, and the "other options" section at the end of the options list can be easily missed.