### PR TITLE
docs: update key event example

### DIFF
--- a/docs/guides/dom-events.md
+++ b/docs/guides/dom-events.md
@@ -101,7 +101,6 @@ This component allows to increment/decrement the quantity using various keys.
   const KEY_DOWN = 40
   const KEY_UP = 38
   const ESCAPE = 27
-  const CHAR_A = 65
 
   export default {
     data() {
@@ -130,7 +129,7 @@ This component allows to increment/decrement the quantity using various keys.
         if (e.keyCode === KEY_UP) {
           this.increment()
         }
-        if (e.which === CHAR_A) {
+        if (e.key === 'a') {
           this.quantity = 13
         }
       }
@@ -180,7 +179,7 @@ describe('Key event tests', () => {
   it('Magic character "a" sets quantity to 13', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.trigger('keydown', {
-      which: 65
+      key: 'a'
     })
     expect(wrapper.vm.quantity).toBe(13)
   })

--- a/docs/ja/guides/dom-events.md
+++ b/docs/ja/guides/dom-events.md
@@ -97,7 +97,6 @@ describe('Click event', () => {
   const KEY_DOWN = 40
   const KEY_UP = 38
   const ESCAPE = 27
-  const CHAR_A = 65
 
   export default {
     data() {
@@ -125,7 +124,7 @@ describe('Click event', () => {
         if (e.keyCode === KEY_UP) {
           this.increment()
         }
-        if (e.which === CHAR_A) {
+        if (e.key === 'a') {
           this.quantity = 13
         }
       }
@@ -174,7 +173,7 @@ describe('Key event tests', () => {
   it('Magic character "a" sets quantity to 13', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.trigger('keydown', {
-      which: 65
+      key: 'a'
     })
     expect(wrapper.vm.quantity).toBe(13)
   })

--- a/docs/ru/guides/dom-events.md
+++ b/docs/ru/guides/dom-events.md
@@ -97,7 +97,6 @@ describe('Click event', () => {
   const KEY_DOWN = 40
   const KEY_UP = 38
   const ESCAPE = 27
-  const CHAR_A = 65
 
   export default {
     data() {
@@ -125,7 +124,7 @@ describe('Click event', () => {
         if (e.keyCode === KEY_UP) {
           this.increment()
         }
-        if (e.which === CHAR_A) {
+        if (e.key === 'a') {
           this.quantity = 13
         }
       }
@@ -174,7 +173,7 @@ describe('Тестирование событий клавиш', () => {
   it('Магический символ "a" устанавливает quantity равным 13', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.trigger('keydown', {
-      which: 65
+      key: 'a'
     })
     expect(wrapper.vm.quantity).toBe(13)
   })

--- a/docs/zh/guides/dom-events.md
+++ b/docs/zh/guides/dom-events.md
@@ -101,7 +101,6 @@ describe('点击事件', () => {
   const KEY_DOWN = 40
   const KEY_UP = 38
   const ESCAPE = 27
-  const CHAR_A = 65
 
   export default {
     data() {
@@ -130,7 +129,7 @@ describe('点击事件', () => {
         if (e.keyCode === KEY_UP) {
           this.increment()
         }
-        if (e.which === CHAR_A) {
+        if (e.key === 'a') {
           this.quantity = 13
         }
       }
@@ -180,7 +179,7 @@ describe('键盘事件测试', () => {
   it('魔术字符 "a" 键将数量设置为 13', () => {
     const wrapper = mount(QuantityComponent)
     wrapper.trigger('keydown', {
-      which: 65
+      key: 'a'
     })
     expect(wrapper.vm.quantity).toBe(13)
   })


### PR DESCRIPTION
`event.which` is deprecated and (at least in recent Chrome) can't be set, which made the example test fail. `event.key` works.

Closes #1162.