### PR TITLE
Update common-tips.md

### DIFF
--- a/docs/zh/guides/common-tips.md
+++ b/docs/zh/guides/common-tips.md
@@ -103,7 +103,7 @@ describe('ParentComponent', () => {
   it("displays 'Emitted!' when custom event is emitted", () => {
     const wrapper = shallowMount(ParentComponent)
     wrapper.find(ChildComponent).vm.$emit('custom')
-    expect(wrapper.html()).toContain('Emitted!')
+    expect(wrapper.html()).toContain('触发！')
   })
 })
 ```


### PR DESCRIPTION
汉化不完整，导致用例会产生歧义。