### PR TITLE
docs: mounting options is `attachToDocument`

### DIFF
--- a/docs/api/wrapper/README.md
+++ b/docs/api/wrapper/README.md
@@ -18,7 +18,7 @@ A `Wrapper` is an object that contains a mounted component or vnode and methods 
 
 #### `options.attachedToDocument`
 
-`Boolean` (read-only): True if `attachedToDocument` in mounting options was `true`
+`Boolean` (read-only): True if `attachToDocument` in mounting options was `true`
 
 #### `options.sync`
 

--- a/docs/ja/api/wrapper/README.md
+++ b/docs/ja/api/wrapper/README.md
@@ -18,7 +18,7 @@ vue-test-utils はラッパベースの API です。
 
 #### `options.attachedToDocument`
 
-`Boolean` (読み込み専用): マウンティングオプションで `attachedToDocument` が `true` だった場合は True です。
+`Boolean` (読み込み専用): マウンティングオプションで `attachToDocument` が `true` だった場合は True です。
 
 #### `options.sync`
 

--- a/docs/ru/api/wrapper/README.md
+++ b/docs/ru/api/wrapper/README.md
@@ -18,7 +18,7 @@ Vue Test Utils — это API основанное на использовани
 
 #### `options.attachedToDocument`
 
-`Boolean` (только для чтения): True, если `attachedToDocument` в опциях монтирования было `true`
+`Boolean` (только для чтения): True, если `attachToDocument` в опциях монтирования было `true`
 
 #### `options.sync`
 

--- a/docs/zh/api/wrapper/README.md
+++ b/docs/zh/api/wrapper/README.md
@@ -16,9 +16,9 @@ Vue Test Utils 是一个基于包裹器的 API。
 
 ### `options`
 
-#### `options.attachedToDom`
+#### `options.attachedToDocument`
 
-`Boolean` (只读)：如果 `attachToDom` 传递给了 `mount` 或 `shallowMount` 则为真
+`Boolean` (只读)：如果 `attachToDocument` 传递给了 `mount` 或 `shallowMount` 则为真
 
 #### `options.sync`
 


### PR DESCRIPTION
mounting options in wrapper is `attachToDocument`