### PR TITLE
feat(wrapper): allow destroy() method to work with functional components

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -207,7 +207,7 @@ expect(wrapper.vm.$route).toBeInstanceOf(Object)
 Component will be attached to DOM when rendered if set to `true`.
 
 When attaching to the DOM, you should call `wrapper.destroy()` at the end of your test to
-remove the rendered elements from the document and destroy the component insatance.
+remove the rendered elements from the document and destroy the component instance.
 
 ## attrs
 

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -206,6 +206,9 @@ expect(wrapper.vm.$route).toBeInstanceOf(Object)
 
 Component will be attached to DOM when rendered if set to `true`.
 
+When attaching to the DOM, you should call `wrapper.destroy()` at the end of your test to
+remove the rendered elements from the document and destroy the component insatance.
+
 ## attrs
 
 - type: `Object`

--- a/docs/api/wrapper/destroy.md
+++ b/docs/api/wrapper/destroy.md
@@ -17,3 +17,8 @@ mount({
 }).destroy()
 expect(spy.calledOnce).toBe(true)
 ```
+
+if `attachToDocument` was set to `true` when mounted, the component dom elements will
+also be removed from the document.
+
+For functional components, `destroy` only removes the rendered dom elements from the document.

--- a/docs/api/wrapper/destroy.md
+++ b/docs/api/wrapper/destroy.md
@@ -21,4 +21,4 @@ expect(spy.calledOnce).toBe(true)
 if `attachToDocument` was set to `true` when mounted, the component DOM elements will
 also be removed from the document.
 
-For functional components, `destroy` only removes the rendered dom elements from the document.
+For functional components, `destroy` only removes the rendered DOM elements from the document.

--- a/docs/api/wrapper/destroy.md
+++ b/docs/api/wrapper/destroy.md
@@ -18,7 +18,7 @@ mount({
 expect(spy.calledOnce).toBe(true)
 ```
 
-if `attachToDocument` was set to `true` when mounted, the component dom elements will
+if `attachToDocument` was set to `true` when mounted, the component DOM elements will
 also be removed from the document.
 
 For functional components, `destroy` only removes the rendered dom elements from the document.

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -124,16 +124,19 @@ export default class Wrapper implements BaseWrapper {
    * Calls destroy on vm
    */
   destroy(): void {
-    if (!this.isVueInstance()) {
-      throwError(`wrapper.destroy() can only be called on a Vue instance`)
+    if (!this.isVueInstance() || !this.isFunctionalComponent) {
+      throwError(`wrapper.destroy() can only be called on a Vue instance or functional component`)
     }
 
     if (this.element.parentNode) {
       this.element.parentNode.removeChild(this.element)
     }
-    // $FlowIgnore
-    this.vm.$destroy()
-    throwIfInstancesThrew(this.vm)
+
+    if (!this.isFunctionalComponent) {
+      // $FlowIgnore
+      this.vm.$destroy()
+      throwIfInstancesThrew(this.vm)
+    }
   }
 
   /**

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -132,7 +132,7 @@ export default class Wrapper implements BaseWrapper {
       this.element.parentNode.removeChild(this.element)
     }
 
-    if (!this.isFunctionalComponent) {
+    if (this.isVueInstance()) {
       // $FlowIgnore
       this.vm.$destroy()
       throwIfInstancesThrew(this.vm)

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -125,7 +125,10 @@ export default class Wrapper implements BaseWrapper {
    */
   destroy(): void {
     if (!this.isVueInstance() && !this.isFunctionalComponent) {
-      throwError(`wrapper.destroy() can only be called on a Vue instance or functional component`)
+      throwError(
+        `wrapper.destroy() can only be called on a Vue instance or ` +
+          `functional component.`
+      )
     }
 
     if (this.element.parentNode) {

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -124,7 +124,7 @@ export default class Wrapper implements BaseWrapper {
    * Calls destroy on vm
    */
   destroy(): void {
-    if (!this.isVueInstance() || !this.isFunctionalComponent) {
+    if (!this.isVueInstance() && !this.isFunctionalComponent) {
       throwError(`wrapper.destroy() can only be called on a Vue instance or functional component`)
     }
 

--- a/test/specs/wrapper/destroy.spec.js
+++ b/test/specs/wrapper/destroy.spec.js
@@ -40,6 +40,16 @@ describeWithShallowAndMount('destroy', mountingMethod => {
     expect(wrapper.vm.$el.parentNode).to.be.null
   })
 
+  it('removes functional component element from document.body', () => {
+    const wrapper = mountingMethod(
+      { template: '<div />', functional: true },
+      { attachToDocument: true }
+    )
+    expect(wrapper.element.parentNode).to.equal(document.body)
+    wrapper.destroy()
+    expect(wrapper.element.parentNode).to.be.null
+  })
+
   it('throws if component throws during destroy', () => {
     const TestComponent = {
       template: '<div :p="a" />',

--- a/test/specs/wrapper/destroy.spec.js
+++ b/test/specs/wrapper/destroy.spec.js
@@ -42,7 +42,12 @@ describeWithShallowAndMount('destroy', mountingMethod => {
 
   it('removes functional component element from document.body', () => {
     const wrapper = mountingMethod(
-      { template: '<div />', functional: true },
+      {
+        functional: true,
+        render: h => {
+          return h('div', {}, [])
+        }
+      },
       { attachToDocument: true }
     )
     expect(wrapper.element.parentNode).to.equal(document.body)


### PR DESCRIPTION
Currently when calling `wrapper.destroy()`, only non-functional components are removed from the DOM.

This PR allows functional components to be removed from the DOM as well.

xref #1185 https://github.com/vuejs/vue-test-utils/issues/1185#issuecomment-473569291
