### PR TITLE
feat: allow setData with dot strings as nested paths

### DIFF
--- a/docs/api/wrapper/props.md
+++ b/docs/api/wrapper/props.md
@@ -2,7 +2,7 @@
 
 Return `Wrapper` `vm` props object. If `key` is provided, the value for the `key` will be returned.
 
-**Note the Wrapper must contain a Vue instance.**
+**Note: the Wrapper must contain a Vue instance.**
 
 - **Arguments:**
 

--- a/docs/api/wrapper/setData.md
+++ b/docs/api/wrapper/setData.md
@@ -4,7 +4,9 @@ Sets `Wrapper` `vm` data.
 
 setData works by recursively calling Vue.set.
 
-**Note the Wrapper must contain a Vue instance.**
+The key of the `data` in the argument can also be a path to the component's nested data.
+
+**Note: the Wrapper must contain a Vue instance.**
 
 - **Arguments:**
 
@@ -19,4 +21,7 @@ import Foo from './Foo.vue'
 const wrapper = mount(Foo)
 wrapper.setData({ foo: 'bar' })
 expect(wrapper.vm.foo).toBe('bar')
+
+wrapper.setData({ 'baz.baq': 'qux' })
+expect(wrapper.vm.baz.baq).toBe('qux')
 ```

--- a/docs/api/wrapper/setMethods.md
+++ b/docs/api/wrapper/setMethods.md
@@ -2,7 +2,7 @@
 
 Sets `Wrapper` `vm` methods and forces update.
 
-**Note the Wrapper must contain a Vue instance.**
+**Note: the Wrapper must contain a Vue instance.**
 
 - **Arguments:**
 

--- a/docs/api/wrapper/setProps.md
+++ b/docs/api/wrapper/setProps.md
@@ -8,7 +8,7 @@
 
 Sets `Wrapper` `vm` props and forces update.
 
-**Note the Wrapper must contain a Vue instance.**
+**Note: the Wrapper must contain a Vue instance.**
 
 ```js
 import { mount } from '@vue/test-utils'

--- a/packages/test-utils/src/recursively-set-data.js
+++ b/packages/test-utils/src/recursively-set-data.js
@@ -3,31 +3,29 @@ import { throwError } from 'shared/util'
 
 export function recursivelySetData(vm, target, data) {
   for (const key in data) {
+    let val
+    let targetVal
+
     const dotIndex = key.indexOf('.')
     if (dotIndex === 0) {
       throwError(`Data key cannot start with a period (evaluating '${key}').`)
     }
 
     if (dotIndex < 0) {
-      const val = data[key]
-      const targetVal = target[key]
-
-      if (isPlainObject(val) && isPlainObject(targetVal)) {
-        recursivelySetData(vm, targetVal, val)
-      } else {
-        vm.$set(target, key, val)
-      }
+      val = data[key]
+      targetVal = target[key]
     } else {
       const firstKey = key.slice(0, dotIndex)
       const remainingKey = key.slice(dotIndex + 1, key.length)
-      const val = { [remainingKey]: data[key] }
-      const targetVal = target[firstKey]
 
-      if (isPlainObject(targetVal)) {
-        recursivelySetData(vm, targetVal, val)
-      } else {
-        vm.$set(target, firstKey, data)
-      }
+      val = { [remainingKey]: data[key] }
+      targetVal = target[firstKey]
+    }
+
+    if (isPlainObject(val) && isPlainObject(targetVal)) {
+      recursivelySetData(vm, targetVal, val)
+    } else {
+      vm.$set(target, key, val)
     }
   }
 }

--- a/packages/test-utils/src/recursively-set-data.js
+++ b/packages/test-utils/src/recursively-set-data.js
@@ -1,14 +1,33 @@
 import { isPlainObject } from 'shared/validators'
+import { throwError } from 'shared/util'
 
 export function recursivelySetData(vm, target, data) {
-  Object.keys(data).forEach(key => {
-    const val = data[key]
-    const targetVal = target[key]
-
-    if (isPlainObject(val) && isPlainObject(targetVal)) {
-      recursivelySetData(vm, targetVal, val)
-    } else {
-      vm.$set(target, key, val)
+  for (const key in data) {
+    const dotIndex = key.indexOf('.')
+    if (dotIndex === 0) {
+      throwError(`Data key cannot start with a period (evaluating '${key}').`)
     }
-  })
+
+    if (dotIndex < 0) {
+      const val = data[key]
+      const targetVal = target[key]
+
+      if (isPlainObject(val) && isPlainObject(targetVal)) {
+        recursivelySetData(vm, targetVal, val)
+      } else {
+        vm.$set(target, key, val)
+      }
+    } else {
+      const firstKey = key.slice(0, dotIndex)
+      const remainingKey = key.slice(dotIndex + 1, key.length)
+      const val = { [remainingKey]: data[key] }
+      const targetVal = target[firstKey]
+
+      if (isPlainObject(targetVal)) {
+        recursivelySetData(vm, targetVal, val)
+      } else {
+        vm.$set(target, firstKey, data)
+      }
+    }
+  }
 }

--- a/test/specs/wrapper/setData.spec.js
+++ b/test/specs/wrapper/setData.spec.js
@@ -340,18 +340,23 @@ describeWithShallowAndMount('setData', mountingMethod => {
     }
 
     const wrapper = mountingMethod(TestComponent)
+
+    // Make sure that the initial values are as intended
     expect(wrapper.vm.foo.bar.baz).to.equal('baq')
     expect(wrapper.vm.foo.bar.qux).to.equal('quz')
     expect(wrapper.vm.foo.bar2.baz2).to.equal('baq2')
 
+    // Using entirely dot strings should work
     wrapper.setData({ 'foo.bar.baz': 'puq', 'foo.bar.qux': 'qup' })
     expect(wrapper.vm.foo.bar.baz).to.equal('puq')
     expect(wrapper.vm.foo.bar.qux).to.equal('qup')
 
+    // Using a mix of dot strings and an object should work as well
     wrapper.setData({ 'foo.bar': { baz: 'pux' }, 'foo.bar2': { baz2: 'pux2' } })
     expect(wrapper.vm.foo.bar.baz).to.equal('pux')
     expect(wrapper.vm.foo.bar2.baz2).to.equal('pux2')
 
+    // Invalid dot strings as path should throw an error
     expect(() => {
       wrapper.setData({ 'foo..bar.baz': 'pug' })
     }).throw(Error, '[vue-test-utils]: Data key cannot start with a period (evaluating \'.bar.baz\').')

--- a/test/specs/wrapper/setData.spec.js
+++ b/test/specs/wrapper/setData.spec.js
@@ -356,6 +356,11 @@ describeWithShallowAndMount('setData', mountingMethod => {
     expect(wrapper.vm.foo.bar.baz).to.equal('pux')
     expect(wrapper.vm.foo.bar2.baz2).to.equal('pux2')
 
+    // Updating multiple values with dot strings should work as well
+    wrapper.setData({ foo: { 'bar.baz': 'pup', 'bar2.baz2': 'pup2' } })
+    expect(wrapper.vm.foo.bar.baz).to.equal('pup')
+    expect(wrapper.vm.foo.bar2.baz2).to.equal('pup2')
+
     // Invalid dot strings as path should throw an error
     expect(() => {
       wrapper.setData({ 'foo..bar.baz': 'pug' })

--- a/test/specs/wrapper/setData.spec.js
+++ b/test/specs/wrapper/setData.spec.js
@@ -321,4 +321,39 @@ describeWithShallowAndMount('setData', mountingMethod => {
     wrapper.setData({ selectedDate: testDate })
     expect(wrapper.vm.selectedDate).to.equal(testDate)
   })
+
+  it('allows setting data with dot strings as nested path', () => {
+    const TestComponent = {
+      template: `<div/>`,
+      data: () => ({
+        foo: {
+          bar: {
+            baz: 'baq',
+            qux: 'quz'
+          },
+          bar2: {
+            baz2: 'baq2',
+            qux2: 'quz2'
+          }
+        }
+      })
+    }
+
+    const wrapper = mountingMethod(TestComponent)
+    expect(wrapper.vm.foo.bar.baz).to.equal('baq')
+    expect(wrapper.vm.foo.bar.qux).to.equal('quz')
+    expect(wrapper.vm.foo.bar2.baz2).to.equal('baq2')
+
+    wrapper.setData({ 'foo.bar.baz': 'puq', 'foo.bar.qux': 'qup' })
+    expect(wrapper.vm.foo.bar.baz).to.equal('puq')
+    expect(wrapper.vm.foo.bar.qux).to.equal('qup')
+
+    wrapper.setData({ 'foo.bar': { baz: 'pux' }, 'foo.bar2': { baz2: 'pux2' } })
+    expect(wrapper.vm.foo.bar.baz).to.equal('pux')
+    expect(wrapper.vm.foo.bar2.baz2).to.equal('pux2')
+
+    expect(() => {
+      wrapper.setData({ 'foo..bar.baz': 'pug' })
+    }).throw(Error, '[vue-test-utils]: Data key cannot start with a period (evaluating \'.bar.baz\').')
+  })
 })

--- a/test/specs/wrapper/setData.spec.js
+++ b/test/specs/wrapper/setData.spec.js
@@ -359,6 +359,9 @@ describeWithShallowAndMount('setData', mountingMethod => {
     // Invalid dot strings as path should throw an error
     expect(() => {
       wrapper.setData({ 'foo..bar.baz': 'pug' })
-    }).throw(Error, '[vue-test-utils]: Data key cannot start with a period (evaluating \'.bar.baz\').')
+    }).throw(
+      Error,
+      "[vue-test-utils]: Data key cannot start with a period (evaluating '.bar.baz')."
+    )
   })
 })


### PR DESCRIPTION
This closes #1184.

There is already a way to update nested data with `.setData`, albeit more verbose.
```javascript
console.log(wrapper.vm.$data)
// { foo: { bar: 'baz' } }

wrapper.setData({ foo: {  bar: 'baq' } })
// { foo: { bar: 'baq' } }  
```  

This PR proposes a less verbose way to do it:
```javascript
wrapper.setData({ 'foo.bar': 'baq2' } })
// { foo: { bar: 'baq2' } }
```
This resembles how nested data is being referenced when `watch`-ing values.

Both ways should still work fine, since passing in object as data is not just to update nested data, but to also update multiple data values at once.

What do you guys think? Thank you.