### PR TITLE
refactor(types): use Component definition from Vue core

### DIFF
--- a/packages/server-test-utils/types/index.d.ts
+++ b/packages/server-test-utils/types/index.d.ts
@@ -1,10 +1,4 @@
-import Vue, { VNodeData, ComponentOptions, FunctionalComponentOptions } from 'vue'
-
-// TODO: use core repo's Component type after https://github.com/vuejs/vue/pull/7369 is released
-export type Component =
-  | typeof Vue
-  | FunctionalComponentOptions<{}>
-  | ComponentOptions<never, {}, {}, {}, {}>
+import Vue, { VNodeData, ComponentOptions, FunctionalComponentOptions, Component } from 'vue'
 
 /**
  * Utility type to declare an extended Vue constructor

--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -1,10 +1,4 @@
-import Vue, { VNodeData, ComponentOptions, FunctionalComponentOptions } from 'vue'
-
-// TODO: use core repo's Component type after https://github.com/vuejs/vue/pull/7369 is released
-export type Component =
-  | typeof Vue
-  | FunctionalComponentOptions<{}>
-  | ComponentOptions<never, {}, {}, {}, {}>
+import Vue, { VNodeData, ComponentOptions, FunctionalComponentOptions, Component } from 'vue'
 
 /**
  * Utility type to declare an extended Vue constructor


### PR DESCRIPTION
Reason: TODO to replace types, looks like it's already merged in Vue.