### PR TITLE
polyfill Element.matches (fixes #1223)

### DIFF
--- a/packages/test-utils/src/matches.js
+++ b/packages/test-utils/src/matches.js
@@ -5,14 +5,6 @@ import {
 } from 'shared/consts'
 import { isConstructor } from 'shared/validators'
 
-// Polyfill `Element.matches()` for IE and older versions of Chrome:
-// https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill
-if (!Element.prototype.matches) {
-  Element.prototype.matches =
-    Element.prototype.msMatchesSelector ||
-    Element.prototype.webkitMatchesSelector
-}
-
 export function vmMatchesName(vm, name) {
   return (
     !!name && (vm.name === name || (vm.$options && vm.$options.name === name))

--- a/packages/test-utils/src/matches.js
+++ b/packages/test-utils/src/matches.js
@@ -5,6 +5,14 @@ import {
 } from 'shared/consts'
 import { isConstructor } from 'shared/validators'
 
+// Polyfill `Element.matches()` for IE and older versions of Chrome:
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill
+if (!Element.prototype.matches) {
+  Element.prototype.matches =
+    Element.prototype.msMatchesSelector ||
+    Element.prototype.webkitMatchesSelector
+}
+
 export function vmMatchesName(vm, name) {
   return (
     !!name && (vm.name === name || (vm.$options && vm.$options.name === name))

--- a/packages/test-utils/src/mount.js
+++ b/packages/test-utils/src/mount.js
@@ -5,6 +5,7 @@ import { throwIfInstancesThrew, addGlobalErrorHandler } from './error'
 import { mergeOptions } from 'shared/merge-options'
 import config from './config'
 import warnIfNoWindow from './warn-if-no-window'
+import polyfill from './polyfill'
 import createWrapper from './create-wrapper'
 import createLocalVue from './create-local-vue'
 import { validateOptions } from 'shared/validate-options'
@@ -14,6 +15,8 @@ Vue.config.devtools = false
 
 export default function mount(component, options = {}) {
   warnIfNoWindow()
+
+  polyfill()
 
   addGlobalErrorHandler(Vue)
 

--- a/packages/test-utils/src/polyfill.js
+++ b/packages/test-utils/src/polyfill.js
@@ -1,0 +1,9 @@
+export default function polyfill() {
+  // Polyfill `Element.matches()` for IE and older versions of Chrome:
+  // https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill
+  if (!Element.prototype.matches) {
+    Element.prototype.matches =
+      Element.prototype.msMatchesSelector ||
+      Element.prototype.webkitMatchesSelector
+  }
+}


### PR DESCRIPTION
This fixes a bug (#1223) in IE and older versions of Chrome that use a non-standard name for `Element.matches()` by implementing a [polyfill](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill).

Please advise if there is a more appropriate place to implement this polyfill.