### PR TITLE
vue-test-utils: allow `false` as a component stub value

### DIFF
--- a/packages/server-test-utils/types/index.d.ts
+++ b/packages/server-test-utils/types/index.d.ts
@@ -10,7 +10,7 @@ type VueClass<V extends Vue> = (new (...args: any[]) => V) & typeof Vue
  * If it is an array of string, the specified children are replaced by blank components
  */
 type Stubs = {
-  [key: string]: Component | string | true
+  [key: string]: Component | string | boolean
 } | string[]
 
 /**

--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -22,7 +22,7 @@ type Slots = {
  * If it is an array of string, the specified children are replaced by blank components
  */
 type Stubs = {
-  [key: string]: Component | string | true
+  [key: string]: Component | string | boolean
 } | string[]
 
 /**


### PR DESCRIPTION
Updated types/index.d.ts to allow false to be passed as a component stub value
in mount or shallowMount. `false` in this case means don't use a stub for the
given component.