### PR TITLE
fix(stubs): function in props should be rendered as a deterministic string

### DIFF
--- a/packages/create-instance/create-component-stubs.js
+++ b/packages/create-instance/create-component-stubs.js
@@ -142,7 +142,7 @@ function validateStub(stub) {
 }
 
 function shapeStubProps(props) {
-  const shapedProps: Record<string, any> = {}
+  const shapedProps: Object = {}
   for (const propName in props) {
     if (!props.hasOwnProperty(propName)) {
       continue

--- a/packages/create-instance/create-component-stubs.js
+++ b/packages/create-instance/create-component-stubs.js
@@ -144,10 +144,6 @@ function validateStub(stub) {
 function shapeStubProps(props) {
   const shapedProps: Object = {}
   for (const propName in props) {
-    if (!props.hasOwnProperty(propName)) {
-      continue
-    }
-
     if (typeof props[propName] === 'function') {
       shapedProps[propName] = FUNCTION_PLACEHOLDER
       continue

--- a/packages/create-instance/create-component-stubs.js
+++ b/packages/create-instance/create-component-stubs.js
@@ -154,7 +154,7 @@ function shapeStubProps(props) {
     }
 
     if (Array.isArray(props[propName])) {
-      shapedProps[propName] = props[propName].map((value) => {
+      shapedProps[propName] = props[propName].map(value => {
         return typeof value === 'function' ? FUNCTION_PLACEHOLDER : value
       })
       continue

--- a/test/specs/mounting-options/stubs.spec.js
+++ b/test/specs/mounting-options/stubs.spec.js
@@ -591,7 +591,7 @@ describeWithShallowAndMount('options.stub', mountingMethod => {
             :qux="qux" />
         </div>
       `,
-      data () {
+      data() {
         return {
           foo: () => 42,
           bar: [1, 'string', () => true],
@@ -606,9 +606,9 @@ describeWithShallowAndMount('options.stub', mountingMethod => {
 
     expect(wrapper.html()).to.equal(
       `<div>\n` +
-      `  <child-component-stub foo="[Function]" bar="1,string,[Function]" qux="qux"></child-component-stub>\n` +
-      `  <functional-child-component-stub foo="[Function]" bar="1,string,[Function]" qux="qux"></functional-child-component-stub>\n` +
-      `</div>`
+        `  <child-component-stub foo="[Function]" bar="1,string,[Function]" qux="qux"></child-component-stub>\n` +
+        `  <functional-child-component-stub foo="[Function]" bar="1,string,[Function]" qux="qux"></functional-child-component-stub>\n` +
+        `</div>`
     )
   })
 })

--- a/test/specs/mounting-options/stubs.spec.js
+++ b/test/specs/mounting-options/stubs.spec.js
@@ -546,4 +546,69 @@ describeWithShallowAndMount('options.stub', mountingMethod => {
     expect(wrapper.find(ToStub).exists()).to.be.false
     expect(wrapper.find(Stub).exists()).to.be.true
   })
+
+  it('should render functions in props as a deterministic string', () => {
+    const ChildComponent = {
+      name: 'child-component',
+      props: {
+        foo: {
+          type: Function,
+          required: true
+        },
+        bar: {
+          type: Array,
+          required: true
+        },
+        qux: {
+          type: String,
+          required: true
+        }
+      },
+      template: '<div />'
+    }
+
+    const FunctionalChildComponent = {
+      ...ChildComponent,
+      name: 'functional-child-component',
+      functional: true
+    }
+
+    const ParentComponent = {
+      components: {
+        ChildComponent,
+        FunctionalChildComponent
+      },
+      name: 'parent-component',
+      template: `
+        <div>
+          <child-component
+            :foo="foo"
+            :bar="bar"
+            :qux="qux" />
+          <functional-child-component
+            :foo="foo"
+            :bar="bar"
+            :qux="qux" />
+        </div>
+      `,
+      data () {
+        return {
+          foo: () => 42,
+          bar: [1, 'string', () => true],
+          qux: 'qux'
+        }
+      }
+    }
+
+    const wrapper = mountingMethod(ParentComponent, {
+      stubs: ['child-component', 'functional-child-component']
+    })
+
+    expect(wrapper.html()).to.equal(
+      `<div>\n` +
+      `  <child-component-stub foo="[Function]" bar="1,string,[Function]" qux="qux"></child-component-stub>\n` +
+      `  <functional-child-component-stub foo="[Function]" bar="1,string,[Function]" qux="qux"></functional-child-component-stub>\n` +
+      `</div>`
+    )
+  })
 })


### PR DESCRIPTION
This closes #975 and #1209.

I figured that the root cause was the stubs rendering function as it is, while it should just have been a string placeholder. My idea is to override all functions in props to a placeholder, and since it's stubbed, the actual function implementation doesn't really matter (CMIIW).

Let me know if this is good enough, or if you have any feedback. Thanks.