### PR TITLE
fix(stubs): allows stubbing by component name as well

### DIFF
--- a/packages/create-instance/create-component-stubs.js
+++ b/packages/create-instance/create-component-stubs.js
@@ -146,13 +146,9 @@ export function createStubsFromStubsObject(
 ): Components {
   const originalComponentsWithName = {}
   for (const childKey in originalComponents) {
-    if (!originalComponents.hasOwnProperty(childKey)) {
-      continue
-    }
-
     const component = originalComponents[childKey]
-    // Have the name as an alias so it can be both the name
-    // and the `components` key
+    // Have the name as an alias so it can be referred to
+    // by both the name and the `components` key
     if (component.name !== childKey) {
       originalComponentsWithName[component.name] = component
     } else {

--- a/packages/create-instance/create-component-stubs.js
+++ b/packages/create-instance/create-component-stubs.js
@@ -144,6 +144,22 @@ export function createStubsFromStubsObject(
   stubs: Object,
   _Vue: Component
 ): Components {
+  const originalComponentsWithName = {}
+  for (const childKey in originalComponents) {
+    if (!originalComponents.hasOwnProperty(childKey)) {
+      continue
+    }
+
+    const component = originalComponents[childKey]
+    // Have the name as an alias so it can be both the name
+    // and the `components` key
+    if (component.name !== childKey) {
+      originalComponentsWithName[component.name] = component
+    } else {
+      originalComponentsWithName[childKey] = component
+    }
+  }
+
   return Object.keys(stubs || {}).reduce((acc, stubName) => {
     const stub = stubs[stubName]
 
@@ -154,13 +170,13 @@ export function createStubsFromStubsObject(
     }
 
     if (stub === true) {
-      const component = resolveComponent(originalComponents, stubName)
+      const component = resolveComponent(originalComponentsWithName, stubName)
       acc[stubName] = createStubFromComponent(component, stubName, _Vue)
       return acc
     }
 
     if (typeof stub === 'string') {
-      const component = resolveComponent(originalComponents, stubName)
+      const component = resolveComponent(originalComponentsWithName, stubName)
       acc[stubName] = createStubFromString(stub, component, stubName, _Vue)
       return acc
     }

--- a/test/specs/mounting-options/stubs.spec.js
+++ b/test/specs/mounting-options/stubs.spec.js
@@ -546,4 +546,21 @@ describeWithShallowAndMount('options.stub', mountingMethod => {
     expect(wrapper.find(ToStub).exists()).to.be.false
     expect(wrapper.find(Stub).exists()).to.be.true
   })
+
+  it('should be able to stub with the component name', () => {
+    const StubComponent = {
+      name: 'stub',
+      template: '<div />'
+    }
+    const TestComponent = {
+      template: '<div><stub /></div>',
+      components: {
+        StubComponent
+      }
+    }
+    const wrapper = mountingMethod(TestComponent, {
+      stubs: ['stub']
+    })
+    expect(wrapper.find(StubComponent).exists()).to.be.true
+  })
 })

--- a/test/specs/mounting-options/stubs.spec.js
+++ b/test/specs/mounting-options/stubs.spec.js
@@ -548,19 +548,19 @@ describeWithShallowAndMount('options.stub', mountingMethod => {
   })
 
   it('should be able to stub with the component name', () => {
-    const StubComponent = {
-      name: 'stub',
+    const FooComponent = {
+      name: 'foo',
       template: '<div />'
     }
     const TestComponent = {
-      template: '<div><stub /></div>',
+      template: '<div><foo /></div>',
       components: {
-        StubComponent
+        FooComponent
       }
     }
     const wrapper = mountingMethod(TestComponent, {
-      stubs: ['stub']
+      stubs: ['foo']
     })
-    expect(wrapper.find(StubComponent).exists()).to.be.true
+    expect(wrapper.find(FooComponent).exists()).to.be.true
   })
 })


### PR DESCRIPTION
There are times when we assign a component as a child with a different name than the registered name. Consider this example:

```typescript
// timeline/index.ts
@Component
export default Timeline extends Vue {
...
}
```

```typescript
// parent/index.ts
import TimelineComponent from './timeline/index.vue'
import TimelineClass from './timeline/index'

@Component({
  components: { TimelineComponent }
})
export default Parent extends Vue {
  $refs: {
    timeline: TimelineClass
  }
  ...
}
```

```typescript
// parent/__tests__/index.ts
...

const wrapper = mount<ParentClass>(ParentComponent, {
  stubs: ['timeline']
})

expect(wrapper.find(TimelineComponent).exists()).toBe(true) // This would fail

const wrapper2 = mount<ParentClass>(ParentComponent, {
  stubs: ['TimelineComponent']
})

expect(wrapper2.find(TimelineComponent).exists()).toBe(true) // This would pass
```

I found out that resolving components for stubs is using the keys of `$options.components` instead of the component name, as seen [here](https://github.com/vuejs/vue-test-utils/blob/v1.0.0-beta.29/packages/create-instance/create-component-stubs.js#L138). In my opinion, it should be able to be resolved using the component name as well. See the test for details.

Since I'm not looking for a breaking change, I modified the code such that it can now be resolved by both the component name and the keys of `$options.components`. Let me know what you think.