### PR TITLE
feat: Store selector in Wrapper.find() / .findAll()

### DIFF
--- a/docs/api/wrapper/README.md
+++ b/docs/api/wrapper/README.md
@@ -20,6 +20,10 @@ A `Wrapper` is an object that contains a mounted component or vnode and methods 
 
 `Boolean` (read-only): True if component is attached to document when rendered.
 
+### `selector`
+
+`Selector`: the selector that was used by [`find()`](./find.md) or [`findAll()`](./findAll.md) to create this wrapper
+
 ## Methods
 
 !!!include(docs/api/wrapper/attributes.md)!!!

--- a/flow/wrapper.flow.js
+++ b/flow/wrapper.flow.js
@@ -28,6 +28,7 @@ declare interface BaseWrapper {
   name(): string | void;
   props(key?: string): { [name: string]: any } | any | void;
   text(): string | void;
+  selector: Selector | void;
   setData(data: Object): void;
   setMethods(methods: Object): void;
   setValue(value: any): void;

--- a/packages/test-utils/src/error-wrapper.js
+++ b/packages/test-utils/src/error-wrapper.js
@@ -17,9 +17,11 @@ const buildSelectorString = (selector: Selector) => {
 }
 
 export default class ErrorWrapper implements BaseWrapper {
+  selector: Selector
   selectorString: string
 
   constructor(selector: Selector) {
+    this.selector = selector
     this.selectorString = buildSelectorString(selector)
   }
 

--- a/packages/test-utils/src/error-wrapper.js
+++ b/packages/test-utils/src/error-wrapper.js
@@ -18,60 +18,56 @@ const buildSelectorString = (selector: Selector) => {
 
 export default class ErrorWrapper implements BaseWrapper {
   selector: Selector
-  selectorString: string
 
   constructor(selector: Selector) {
     this.selector = selector
-    this.selectorString = buildSelectorString(selector)
   }
 
   at(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call at() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call at() on empty Wrapper`
     )
   }
 
   attributes(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call attributes() on empty Wrapper`
-
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call attributes() on empty Wrapper`
     )
   }
 
   classes(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call classes() on empty Wrapper`
-
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call classes() on empty Wrapper`
     )
   }
 
   contains(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call contains() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call contains() on empty Wrapper`
     )
   }
 
   emitted(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call emitted() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call emitted() on empty Wrapper`
     )
   }
 
   emittedByOrder(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call emittedByOrder() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call emittedByOrder() on empty Wrapper`
     )
   }
 
@@ -81,201 +77,201 @@ export default class ErrorWrapper implements BaseWrapper {
 
   filter(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call filter() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call filter() on empty Wrapper`
     )
   }
 
   visible(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call visible() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call visible() on empty Wrapper`
     )
   }
 
   hasAttribute(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call hasAttribute() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call hasAttribute() on empty Wrapper`
     )
   }
 
   hasClass(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call hasClass() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call hasClass() on empty Wrapper`
     )
   }
 
   hasProp(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call hasProp() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call hasProp() on empty Wrapper`
     )
   }
 
   hasStyle(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call hasStyle() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call hasStyle() on empty Wrapper`
     )
   }
 
   findAll(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call findAll() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call findAll() on empty Wrapper`
     )
   }
 
   find(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call find() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call find() on empty Wrapper`
     )
   }
 
   html(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call html() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call html() on empty Wrapper`
     )
   }
 
   is(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call is() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call is() on empty Wrapper`
     )
   }
 
   isEmpty(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call isEmpty() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call isEmpty() on empty Wrapper`
     )
   }
 
   isVisible(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call isVisible() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call isVisible() on empty Wrapper`
     )
   }
 
   isVueInstance(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call isVueInstance() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call isVueInstance() on empty Wrapper`
     )
   }
 
   name(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call name() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call name() on empty Wrapper`
     )
   }
 
   props(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call props() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call props() on empty Wrapper`
     )
   }
 
   text(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call text() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call text() on empty Wrapper`
     )
   }
 
   setComputed(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call setComputed() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call setComputed() on empty Wrapper`
     )
   }
 
   setData(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call setData() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call setData() on empty Wrapper`
     )
   }
 
   setMethods(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call setMethods() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call setMethods() on empty Wrapper`
     )
   }
 
   setProps(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call setProps() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call setProps() on empty Wrapper`
     )
   }
 
   setValue(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call setValue() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call setValue() on empty Wrapper`
     )
   }
 
   setChecked(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call setChecked() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call setChecked() on empty Wrapper`
     )
   }
 
   setSelected(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call setSelected() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call setSelected() on empty Wrapper`
     )
   }
 
   trigger(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call trigger() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call trigger() on empty Wrapper`
     )
   }
 
   destroy(): void {
     throwError(
-      `find did not return ${
-        this.selectorString
-      }, cannot call destroy() on empty Wrapper`
+      `find did not return ${buildSelectorString(
+        this.selector
+      )}, cannot call destroy() on empty Wrapper`
     )
   }
 }

--- a/packages/test-utils/src/error-wrapper.js
+++ b/packages/test-utils/src/error-wrapper.js
@@ -3,45 +3,59 @@
 import { throwError } from 'shared/util'
 
 export default class ErrorWrapper implements BaseWrapper {
-  selector: string
+  selectorString: string
 
-  constructor(selector: string) {
-    this.selector = selector
+  constructor(selectorString: string) {
+    this.selectorString = selectorString
   }
 
   at(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call at() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call at() on empty Wrapper`
     )
   }
 
   attributes(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call attributes() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call attributes() on empty Wrapper`
+
     )
   }
 
   classes(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call classes() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call classes() on empty Wrapper`
+
     )
   }
 
   contains(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call contains() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call contains() on empty Wrapper`
     )
   }
 
   emitted(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call emitted() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call emitted() on empty Wrapper`
     )
   }
 
   emittedByOrder(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call emittedByOrder() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call emittedByOrder() on empty Wrapper`
     )
   }
 
@@ -51,151 +65,201 @@ export default class ErrorWrapper implements BaseWrapper {
 
   filter(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call filter() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call filter() on empty Wrapper`
     )
   }
 
   visible(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call visible() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call visible() on empty Wrapper`
     )
   }
 
   hasAttribute(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call hasAttribute() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call hasAttribute() on empty Wrapper`
     )
   }
 
   hasClass(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call hasClass() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call hasClass() on empty Wrapper`
     )
   }
 
   hasProp(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call hasProp() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call hasProp() on empty Wrapper`
     )
   }
 
   hasStyle(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call hasStyle() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call hasStyle() on empty Wrapper`
     )
   }
 
   findAll(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call findAll() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call findAll() on empty Wrapper`
     )
   }
 
   find(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call find() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call find() on empty Wrapper`
     )
   }
 
   html(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call html() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call html() on empty Wrapper`
     )
   }
 
   is(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call is() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call is() on empty Wrapper`
     )
   }
 
   isEmpty(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call isEmpty() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call isEmpty() on empty Wrapper`
     )
   }
 
   isVisible(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call isVisible() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call isVisible() on empty Wrapper`
     )
   }
 
   isVueInstance(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call isVueInstance() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call isVueInstance() on empty Wrapper`
     )
   }
 
   name(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call name() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call name() on empty Wrapper`
     )
   }
 
   props(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call props() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call props() on empty Wrapper`
     )
   }
 
   text(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call text() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call text() on empty Wrapper`
     )
   }
 
   setComputed(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call setComputed() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call setComputed() on empty Wrapper`
     )
   }
 
   setData(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call setData() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call setData() on empty Wrapper`
     )
   }
 
   setMethods(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call setMethods() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call setMethods() on empty Wrapper`
     )
   }
 
   setProps(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call setProps() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call setProps() on empty Wrapper`
     )
   }
 
   setValue(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call setValue() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call setValue() on empty Wrapper`
     )
   }
 
   setChecked(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call setChecked() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call setChecked() on empty Wrapper`
     )
   }
 
   setSelected(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call setSelected() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call setSelected() on empty Wrapper`
     )
   }
 
   trigger(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call trigger() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call trigger() on empty Wrapper`
     )
   }
 
   destroy(): void {
     throwError(
-      `find did not return ${this.selector}, cannot call destroy() on empty Wrapper`
+      `find did not return ${
+        this.selectorString
+      }, cannot call destroy() on empty Wrapper`
     )
   }
 }

--- a/packages/test-utils/src/error-wrapper.js
+++ b/packages/test-utils/src/error-wrapper.js
@@ -1,12 +1,26 @@
 // @flow
 
 import { throwError } from 'shared/util'
+import { REF_SELECTOR } from 'shared/consts'
+import { getSelectorType } from './get-selector'
+
+const buildSelectorString = (selector: Selector) => {
+  if (getSelectorType(selector) === REF_SELECTOR) {
+    return `ref="${selector.value.ref}"`
+  }
+
+  if (typeof selector === 'string') {
+    return selector
+  }
+
+  return 'Component'
+}
 
 export default class ErrorWrapper implements BaseWrapper {
   selectorString: string
 
-  constructor(selectorString: string) {
-    this.selectorString = selectorString
+  constructor(selector: Selector) {
+    this.selectorString = buildSelectorString(selector)
   }
 
   at(): void {

--- a/packages/test-utils/src/get-selector.js
+++ b/packages/test-utils/src/get-selector.js
@@ -15,7 +15,7 @@ import {
   INVALID_SELECTOR
 } from 'shared/consts'
 
-function getSelectorType(selector: Selector): string {
+export function getSelectorType(selector: Selector): string {
   if (isDomSelector(selector)) return DOM_SELECTOR
   if (isVueComponent(selector)) return COMPONENT_SELECTOR
   if (isNameSelector(selector)) return NAME_SELECTOR

--- a/packages/test-utils/src/wrapper-array.js
+++ b/packages/test-utils/src/wrapper-array.js
@@ -7,6 +7,7 @@ import { throwError } from 'shared/util'
 export default class WrapperArray implements BaseWrapper {
   +wrappers: Array<Wrapper | VueWrapper>
   +length: number
+  selector: Selector | void
 
   constructor(wrappers: Array<Wrapper | VueWrapper>) {
     const length = wrappers.length

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -197,7 +197,9 @@ export default class Wrapper implements BaseWrapper {
       return new ErrorWrapper(rawSelector)
     }
 
-    return createWrapper(node, this.options)
+    const wrapper = createWrapper(node, this.options)
+    wrapper.selector = rawSelector
+    return wrapper
   }
 
   /**
@@ -210,9 +212,14 @@ export default class Wrapper implements BaseWrapper {
     const wrappers = nodes.map(node => {
       // Using CSS Selector, returns a VueWrapper instance if the root element
       // binds a Vue instance.
-      return createWrapper(node, this.options)
+      const wrapper = createWrapper(node, this.options)
+      wrapper.selector = rawSelector
+      return wrapper
     })
-    return new WrapperArray(wrappers)
+
+    const wrapperArray = new WrapperArray(wrappers)
+    wrapperArray.selector = rawSelector
+    return wrapperArray
   }
 
   /**

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -193,12 +193,7 @@ export default class Wrapper implements BaseWrapper {
     const node = find(this.rootNode, this.vm, selector)[0]
 
     if (!node) {
-      if (selector.type === REF_SELECTOR) {
-        return new ErrorWrapper(`ref="${selector.value.ref}"`)
-      }
-      return new ErrorWrapper(
-        typeof selector.value === 'string' ? selector.value : 'Component'
-      )
+      return new ErrorWrapper(rawSelector)
     }
 
     return createWrapper(node, this.options)

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -24,6 +24,7 @@ export default class Wrapper implements BaseWrapper {
   +options: WrapperOptions
   isFunctionalComponent: boolean
   rootNode: VNode | Element
+  selector: Selector | void
 
   constructor(
     node: VNode | Element,

--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -69,6 +69,7 @@ interface BaseWrapper {
 
   trigger (eventName: string, options?: object): void
   destroy (): void
+  selector: Selector | void
 }
 
 export interface Wrapper<V extends Vue | null> extends BaseWrapper {

--- a/packages/test-utils/types/test/wrapper.ts
+++ b/packages/test-utils/types/test/wrapper.ts
@@ -1,4 +1,4 @@
-import { mount, createWrapper } from '../'
+import { mount, createWrapper, Selector } from '../'
 import { normalOptions, functionalOptions, ClassComponent } from './resources'
 import Vue from 'vue'
 
@@ -44,19 +44,33 @@ wrapper.vm.$emit('event', 'arg')
 
 let el: HTMLElement = wrapper.element
 
+let selector: Selector | void
+
 let found = wrapper.find('.foo')
+selector = found.selector
 found = wrapper.find(normalOptions)
+selector = found.selector
 found = wrapper.find(functionalOptions)
+selector = found.selector
 found = wrapper.find(ClassComponent)
+selector = found.selector
 found = wrapper.find({ ref: 'myButton' })
+selector = found.selector
 found = wrapper.find({ name: 'my-button' })
+selector = found.selector
 
 let array = wrapper.findAll('.bar')
+selector = array.selector
 array = wrapper.findAll(normalOptions)
+selector = array.selector
 array = wrapper.findAll(functionalOptions)
+selector = array.selector
 array = wrapper.findAll(ClassComponent)
+selector = array.selector
 array = wrapper.findAll({ ref: 'myButton' })
+selector = array.selector
 array = wrapper.findAll({ name: 'my-button' })
+selector = array.selector
 
 wrapper.setChecked()
 wrapper.setChecked(true)

--- a/test/specs/wrapper/find.spec.js
+++ b/test/specs/wrapper/find.spec.js
@@ -363,14 +363,14 @@ describeWithShallowAndMount('find', mountingMethod => {
     const selector = 'pre'
     const error = wrapper.find(selector)
     expect(error.exists()).to.equal(false)
-    expect(error.selectorString).to.equal(selector)
+    expect(error.selector).to.equal(selector)
   })
 
   it('returns empty Wrapper with error if no nodes are found when passed a component', () => {
     const wrapper = mountingMethod(Component)
     const error = wrapper.find(ComponentWithChild)
     expect(error.exists()).to.equal(false)
-    expect(error.selectorString).to.equal('Component')
+    expect(error.selector).to.equal(ComponentWithChild)
   })
 
   it('returns Wrapper of elements matching the ref in options object', () => {
@@ -458,9 +458,10 @@ describeWithShallowAndMount('find', mountingMethod => {
 
   it('returns empty Wrapper with error if no nodes are found via ref in options object', () => {
     const wrapper = mountingMethod(Component)
-    const error = wrapper.find({ ref: 'foo' })
+    const selector = { ref: 'foo' }
+    const error = wrapper.find(selector)
     expect(error.exists()).to.equal(false)
-    expect(error.selectorString).to.equal('ref="foo"')
+    expect(error.selector).to.equal(selector)
   })
 
   it('returns Wrapper matching component that has no name property', () => {

--- a/test/specs/wrapper/find.spec.js
+++ b/test/specs/wrapper/find.spec.js
@@ -542,4 +542,34 @@ describeWithShallowAndMount('find', mountingMethod => {
       expect(wrapper.find('p').vm.$options.name).to.equal('bar')
     }
   )
+
+  it('stores CSS selector', () => {
+    const compiled = compileToFunctions('<div><p></p><p></p></div>')
+    const wrapper = mountingMethod(compiled)
+    const selector = 'p'
+    const result = wrapper.find(selector)
+    expect(result.selector).to.equal(selector)
+  })
+
+  it('stores ref selector', () => {
+    const compiled = compileToFunctions('<div><p ref="foo"></p></div>')
+    const wrapper = mountingMethod(compiled)
+    const selector = { ref: 'foo' }
+    const result = wrapper.find(selector)
+    expect(result.selector).to.equal(selector)
+  })
+
+  it('stores component selector', () => {
+    const wrapper = mountingMethod(ComponentWithChild)
+    const selector = Component
+    const result = wrapper.find(selector)
+    expect(result.selector).to.equal(selector)
+  })
+
+  it('stores name selector', () => {
+    const wrapper = mountingMethod(ComponentWithChild)
+    const selector = { name: 'test-component' }
+    const result = wrapper.find(selector)
+    expect(result.selector).to.equal(selector)
+  })
 })

--- a/test/specs/wrapper/find.spec.js
+++ b/test/specs/wrapper/find.spec.js
@@ -363,14 +363,14 @@ describeWithShallowAndMount('find', mountingMethod => {
     const selector = 'pre'
     const error = wrapper.find(selector)
     expect(error.exists()).to.equal(false)
-    expect(error.selector).to.equal(selector)
+    expect(error.selectorString).to.equal(selector)
   })
 
   it('returns empty Wrapper with error if no nodes are found when passed a component', () => {
     const wrapper = mountingMethod(Component)
     const error = wrapper.find(ComponentWithChild)
     expect(error.exists()).to.equal(false)
-    expect(error.selector).to.equal('Component')
+    expect(error.selectorString).to.equal('Component')
   })
 
   it('returns Wrapper of elements matching the ref in options object', () => {
@@ -460,7 +460,7 @@ describeWithShallowAndMount('find', mountingMethod => {
     const wrapper = mountingMethod(Component)
     const error = wrapper.find({ ref: 'foo' })
     expect(error.exists()).to.equal(false)
-    expect(error.selector).to.equal('ref="foo"')
+    expect(error.selectorString).to.equal('ref="foo"')
   })
 
   it('returns Wrapper matching component that has no name property', () => {

--- a/test/specs/wrapper/findAll.spec.js
+++ b/test/specs/wrapper/findAll.spec.js
@@ -343,4 +343,38 @@ describeWithShallowAndMount('findAll', mountingMethod => {
       expect(wrappers.at(2).vm.$options.name).to.equal('bar')
     }
   )
+
+  it('stores CSS selector', () => {
+    const compiled = compileToFunctions('<div><p></p><p></p></div>')
+    const wrapper = mountingMethod(compiled)
+    const selector = 'p'
+    const result = wrapper.findAll('p')
+    expect(result.selector).to.equal(selector)
+    expect(result.at(0).selector).to.equal(selector)
+  })
+
+  it('stores ref selector', () => {
+    const compiled = compileToFunctions('<div><div ref="foo" /></div>')
+    const wrapper = mountingMethod(compiled)
+    const selector = { ref: 'foo' }
+    const result = wrapper.findAll(selector)
+    expect(result.selector).to.equal(selector)
+    expect(result.at(0).selector).to.equal(selector)
+  })
+
+  it('stores component selector', () => {
+    const wrapper = mountingMethod(ComponentWithChild)
+    const selector = Component
+    const result = wrapper.findAll(selector)
+    expect(result.selector).to.equal(selector)
+    expect(result.at(0).selector).to.equal(selector)
+  })
+
+  it('stores name selector', () => {
+    const wrapper = mountingMethod(ComponentWithChild)
+    const selector = { name: 'test-component' }
+    const result = wrapper.findAll(selector)
+    expect(result.selector).to.equal(selector)
+    expect(result.at(0).selector).to.equal(selector)
+  })
 })


### PR DESCRIPTION
Stores the selector that is passed to `Wrapper.find()` / `Wrapper.findAll()` as a property in the newly created `Wrapper` / `WrapperArray` instance.

closes https://github.com/vuejs/vue-test-utils/issues/1135