### PR TITLE
Respect "hidden" attributes when testing Wrapper.isVisible()

### DIFF
--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -273,8 +273,7 @@ export default class Wrapper implements BaseWrapper {
         element.hidden ||
         (element.style &&
           (element.style.visibility === 'hidden' ||
-            element.style.display === 'none')
-        )
+            element.style.display === 'none'))
       ) {
         return false
       }

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -270,9 +270,11 @@ export default class Wrapper implements BaseWrapper {
     let element = this.element
     while (element) {
       if (
-        element.style &&
-        (element.style.visibility === 'hidden' ||
-          element.style.display === 'none')
+        element.hidden ||
+        (element.style &&
+          (element.style.visibility === 'hidden' ||
+            element.style.display === 'none')
+        )
       ) {
         return false
       }

--- a/test/specs/wrapper/isVisible.spec.js
+++ b/test/specs/wrapper/isVisible.spec.js
@@ -32,6 +32,15 @@ describeWithShallowAndMount('isVisible', mountingMethod => {
     expect(element.isVisible()).to.equal(false)
   })
 
+  it('returns false if element has hidden attribute', () => {
+    const compiled = compileToFunctions(
+      '<div><div><span class="visible" hidden></span></div></div>'
+    )
+    const wrapper = mountingMethod(compiled)
+    const element = wrapper.find('.visible')
+    expect(element.isVisible()).to.equal(false)
+  })
+
   it('returns true if element has v-show true', async () => {
     const wrapper = mountingMethod(ComponentWithVShow)
     wrapper.vm.$set(wrapper.vm, 'ready', true)


### PR DESCRIPTION
Elements that are hidden via the HTML `hidden` attribute were erroneously being reported as being visible by the `isVisible()` method, even though they were not actually visible in the DOM.