### PR TITLE
Update testing-single-file-components-with-mocha-webpack.md

### DIFF
--- a/docs/guides/testing-single-file-components-with-mocha-webpack.md
+++ b/docs/guides/testing-single-file-components-with-mocha-webpack.md
@@ -22,7 +22,7 @@ Next we need to define a test script in our `package.json`.
 // package.json
 {
   "scripts": {
-    "test": "mocha-webpack --webpack-config webpack.config.js --require test/setup.js test/**/*.spec.js"
+    "test": "mocha-webpack --webpack-config webpack.config.js --recursive --require test/setup.js test/"
   }
 }
 ```


### PR DESCRIPTION
原写法当存在完全匹配的一层结构时如：test/folder1/a.spec.js，会忽略其它层级的文件，如：test/folder2/folder2-2/b.spec.js

Original writing, when there is a completely matching layer structure, such as "test/folder1/a.spec.js", it will ignore other files of the other layer, such as "test/folder2/folder2-2/b.spec.js".