### PR TITLE
Trigger options key code fix (fix #1285)

### DIFF
--- a/test/specs/wrapper/trigger.spec.js
+++ b/test/specs/wrapper/trigger.spec.js
@@ -11,6 +11,10 @@ import { itDoNotRunIf } from 'conditional-specs'
 describeWithShallowAndMount('trigger', mountingMethod => {
   const sandbox = sinon.createSandbox()
 
+  beforeEach(() => {
+    sandbox.stub(console, 'error').callThrough()
+  })
+
   afterEach(() => {
     sandbox.reset()
     sandbox.restore()
@@ -72,6 +76,20 @@ describeWithShallowAndMount('trigger', mountingMethod => {
     for (const keyName in modifiers) {
       const keyCode = modifiers[keyName]
       wrapper.find('.keydown').trigger(`keyup.${keyName}`)
+      expect(keyupHandler.lastCall.args[0].keyCode).to.equal(keyCode)
+    }
+  })
+
+  it('adds key code to event', () => {
+    const keyupHandler = sandbox.stub()
+    const wrapper = mountingMethod(ComponentWithEvents, {
+      propsData: { keyupHandler }
+    })
+    // All printable keys
+    for (let keyCode = 49; keyCode <= 90; keyCode++) {
+      wrapper.find('.keydown').trigger(`keyup`, {
+        keyCode: keyCode
+      })
       expect(keyupHandler.lastCall.args[0].keyCode).to.equal(keyCode)
     }
   })
@@ -162,6 +180,14 @@ describeWithShallowAndMount('trigger', mountingMethod => {
       wrapper.findAll('button').trigger('click')
     }
   )
+
+  it('throws Vue warning when both modifier and keyCode are specified in event', () => {
+    const wrapper = mountingMethod(ComponentWithEvents)
+    wrapper.find('.keydown').trigger(`keyup.enter`, {
+      keyCode: 49
+    })
+    expect(console.error).calledWith(sandbox.match('[vue-test-utils]'))
+  })
 
   it('throws error if options contains a target value', () => {
     const wrapper = mountingMethod({ render: h => h('div') })


### PR DESCRIPTION
Allowing to specify keyCode option while calling trigger method, throwing warning if both keyCode option and event modifier are specified (keyCode has higher priority so modifier will be ignored in this case).

Related issue #1285 

P.S. Failed CI test is my fault, commit with tests must not be tested separately from the first one.