### PR TITLE
FIX #1253 setValue triggering `"ReferenceError: $set is not defined"`

### DIFF
--- a/packages/create-instance/create-scoped-slots.js
+++ b/packages/create-instance/create-scoped-slots.js
@@ -36,6 +36,7 @@ function getVueTemplateCompilerHelpers(
     helpers[name] = vue._renderProxy[name]
   })
   helpers.$createElement = vue._renderProxy.$createElement
+  helpers.$set = vue._renderProxy.$set
   return helpers
 }
 

--- a/test/specs/mounting-options/scopedSlots.spec.js
+++ b/test/specs/mounting-options/scopedSlots.spec.js
@@ -305,4 +305,25 @@ describeWithShallowAndMount('scopedSlots', mountingMethod => {
       expect(wrapper.html()).to.contain('span')
     }
   )
+
+  itDoNotRunIf(
+    vueVersion < 2.5 || mountingMethod.name !== 'mount',
+    'resolves v-model directive',
+    () => {
+      const wrapper = mountingMethod(
+        {
+          template: '<div><slot name="single" :text="text"></slot></div>',
+          data() { return { text: 'text' } }
+        },
+        {
+          scopedSlots: {
+            single: '<input v-model="props.text" type="text" />'
+          }
+        }
+      )
+
+      wrapper.find('input').setValue('abc')
+      expect(wrapper.find('input').element.value).to.equal('abc')
+    }
+  )
 })

--- a/test/specs/mounting-options/scopedSlots.spec.js
+++ b/test/specs/mounting-options/scopedSlots.spec.js
@@ -313,7 +313,9 @@ describeWithShallowAndMount('scopedSlots', mountingMethod => {
       const wrapper = mountingMethod(
         {
           template: '<div><slot name="single" :text="text"></slot></div>',
-          data() { return { text: 'text' } }
+          data() {
+            return { text: 'text' }
+          }
         },
         {
           scopedSlots: {


### PR DESCRIPTION
This PR adds assigns vm.$set reference to scoped slot helpers, avoiding ReferenceError described in #1253 