### PR TITLE
Change the way of setting props

### DIFF
--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -11,7 +11,7 @@ import createScopedSlots from './create-scoped-slots'
 import { createStubsFromStubsObject } from './create-component-stubs'
 import { patchCreateElement } from './patch-create-element'
 
-function createContext(options, scopedSlots) {
+function createContext(options, scopedSlots, currentProps) {
   const on = {
     ...(options.context && options.context.on),
     ...options.listeners
@@ -21,7 +21,7 @@ function createContext(options, scopedSlots) {
       ...options.attrs,
       // pass as attrs so that inheritAttrs works correctly
       // propsData should take precedence over attrs
-      ...options.propsData
+      ...currentProps
     },
     ...(options.context || {}),
     on,
@@ -98,10 +98,16 @@ export default function createInstance(
   parentComponentOptions._provided = options.provide
   parentComponentOptions.$_doNotStubChildren = true
   parentComponentOptions._isFunctionalContainer = componentOptions.functional
+  const originalDataFn = parentComponentOptions.data
+  parentComponentOptions.data = function() {
+    const originalData = originalDataFn ? originalDataFn() : {}
+    originalData.vueTestUtils_childProps = { ...options.propsData }
+    return originalData
+  }
   parentComponentOptions.render = function(h) {
     return h(
       Constructor,
-      createContext(options, scopedSlots),
+      createContext(options, scopedSlots, this.vueTestUtils_childProps),
       createChildren(this, h, options)
     )
   }

--- a/test/resources/components/component-with-watch-immediate.vue
+++ b/test/resources/components/component-with-watch-immediate.vue
@@ -1,0 +1,22 @@
+<script>
+export default {
+  props: ['prop1'],
+  data: function() {
+    return {
+      data1: null
+    }
+  },
+
+  watch: {
+    prop1: {
+      handler() {
+        this.data1 = this.prop1
+      },
+      immediate: true
+    }
+  }
+}
+</script>
+<template>
+  <h1>test</h1>
+</template>

--- a/test/specs/config.spec.js
+++ b/test/specs/config.spec.js
@@ -85,9 +85,7 @@ describeWithShallowAndMount('config', mountingMethod => {
       localVue
     })
     expect(wrapper.vm.prop1).to.equal('example')
-    wrapper.setProps({
-      prop1: 'new value'
-    })
+    wrapper.vm.prop1 = 'new value'
     expect(console.error).calledWith(sandbox.match('[Vue warn]'))
   })
 })

--- a/test/specs/wrapper/setProps.spec.js
+++ b/test/specs/wrapper/setProps.spec.js
@@ -1,6 +1,7 @@
 import { compileToFunctions } from 'vue-template-compiler'
 import ComponentWithProps from '~resources/components/component-with-props.vue'
 import ComponentWithWatch from '~resources/components/component-with-watch.vue'
+import ComponentWithWatchImmediate from '~resources/components/component-with-watch-immediate.vue'
 import { describeWithShallowAndMount, vueVersion } from '~resources/utils'
 import { itDoNotRunIf } from 'conditional-specs'
 import Vue from 'vue'
@@ -242,6 +243,17 @@ describeWithShallowAndMount('setProps', mountingMethod => {
     wrapper.setProps({ propA: 'value' })
     expect(wrapper.props().propA).to.equal('value')
     expect(wrapper.vm.propA).to.equal('value')
+  })
+
+  it('correctly sets props in async mode when component has immediate watchers', async () => {
+    const wrapper = mountingMethod(ComponentWithWatchImmediate, {
+      sync: false
+    })
+
+    const prop1 = 'testest'
+    wrapper.setProps({ prop1 })
+    await Vue.nextTick()
+    expect(wrapper.vm.prop1).to.equal(prop1)
   })
 
   it('throws an error if node is not a Vue instance', () => {


### PR DESCRIPTION
Since we're already wrapping a component into a parent one we can get rid of explicitly setting props on component, instead modifying them being passed from parent component instead.

This fixes weird behaviors in async mode, when prop is immediately reset  to it's original value
Fixes #1140