### PR TITLE
docs: Add example for 'listeners' mount option

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -248,6 +248,23 @@ Please see [Other options](#other-options).
 
 Set the component instance's `$listeners` object.
 
+Example:
+
+```js
+const Component = {
+  template: '<div v-on:click="$emit('click')"><slot></slot></div>'
+}
+const onClick = jest.fn()
+const wrapper = mount(Component, {
+  listeners: {
+    click: onClick
+  }
+})
+
+wrapper.trigger('click')
+expect(onClick).toHaveBeenCalled();
+```
+
 ## parentComponent
 
 - type: `Object`

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -252,7 +252,7 @@ Example:
 
 ```js
 const Component = {
-  template: '<div v-on:click="$emit(\'click\')"><slot></slot></div>'
+  template: '<button v-on:click="$emit(\'click\')"></button>'
 }
 const onClick = jest.fn()
 const wrapper = mount(Component, {

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -262,7 +262,7 @@ const wrapper = mount(Component, {
 })
 
 wrapper.trigger('click')
-expect(onClick).toHaveBeenCalled();
+expect(onClick).toHaveBeenCalled()
 ```
 
 ## parentComponent

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -252,7 +252,7 @@ Example:
 
 ```js
 const Component = {
-  template: '<div v-on:click="$emit('click')"><slot></slot></div>'
+  template: '<div v-on:click="$emit(\'click\')"><slot></slot></div>'
 }
 const onClick = jest.fn()
 const wrapper = mount(Component, {


### PR DESCRIPTION
I thought an example to understand usage of 'listeners'  would be useful & make it more obvious.