### PR TITLE
Template querySelector support

### DIFF
--- a/packages/shared/compile-template.js
+++ b/packages/shared/compile-template.js
@@ -17,6 +17,16 @@ export function compileFromString(str: string) {
 
 export function compileTemplate(component: Component): void {
   if (component.template) {
+    if (component.template.charAt('#') === '#') {
+      var el = document.querySelector(component.template)
+      if (!el) {
+        throwError('Cannot find element' + component.template)
+
+        el = document.createElement('div')
+      }
+      component.template = el.innerHTML
+    }
+
     Object.assign(component, compileToFunctions(component.template))
   }
 

--- a/test/specs/mount.spec.js
+++ b/test/specs/mount.spec.js
@@ -162,9 +162,8 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'mount', () => {
   })
 
   itDoNotRunIf(
-    process.env.TEST_ENV === 'node',
-    'compiles templates from querySelector',
-    () => {
+    !(navigator.userAgent.includes && navigator.userAgent.includes('node.js')),
+  'compiles templates from querySelector', () => {
       const template = window.createElement('div')
       template.setAttribute('id', 'foo')
       template.innerHTML = '<div>foo</div>'

--- a/test/specs/mount.spec.js
+++ b/test/specs/mount.spec.js
@@ -161,6 +161,26 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'mount', () => {
     expect(wrapper.html()).to.equal(`<div>foo</div>`)
   })
 
+  it('compiles templates from querySelector', () => {
+    if (
+      !(navigator.userAgent.includes && navigator.userAgent.includes('node.js'))
+    ) {
+      return
+    }
+    const template = window.createElement('div')
+    template.setAttribute('id', 'foo')
+    template.innerHTML = '<div>foo</div>'
+    window.document.body.appendChild(template)
+
+    const wrapper = mount({
+      template: '#foo'
+    })
+    expect(wrapper.vm).to.be.an('object')
+    expect(wrapper.html()).to.equal(`<div>foo</div>`)
+
+    window.body.removeChild(template)
+  })
+
   itDoNotRunIf(vueVersion < 2.3, 'overrides methods', () => {
     const stub = sandbox.stub()
     const TestComponent = Vue.extend({

--- a/test/specs/mount.spec.js
+++ b/test/specs/mount.spec.js
@@ -163,7 +163,8 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'mount', () => {
 
   itDoNotRunIf(
     !(navigator.userAgent.includes && navigator.userAgent.includes('node.js')),
-  'compiles templates from querySelector', () => {
+    'compiles templates from querySelector',
+    () => {
       const template = window.createElement('div')
       template.setAttribute('id', 'foo')
       template.innerHTML = '<div>foo</div>'

--- a/test/specs/mount.spec.js
+++ b/test/specs/mount.spec.js
@@ -161,12 +161,7 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'mount', () => {
     expect(wrapper.html()).to.equal(`<div>foo</div>`)
   })
 
-  it('compiles templates from querySelector', () => {
-    if (
-      !(navigator.userAgent.includes && navigator.userAgent.includes('node.js'))
-    ) {
-      return
-    }
+  itDoNotRunIf(process.env.TEST_ENV === 'node', 'compiles templates from querySelector', () => {
     const template = window.createElement('div')
     template.setAttribute('id', 'foo')
     template.innerHTML = '<div>foo</div>'

--- a/test/specs/mount.spec.js
+++ b/test/specs/mount.spec.js
@@ -161,20 +161,24 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'mount', () => {
     expect(wrapper.html()).to.equal(`<div>foo</div>`)
   })
 
-  itDoNotRunIf(process.env.TEST_ENV === 'node', 'compiles templates from querySelector', () => {
-    const template = window.createElement('div')
-    template.setAttribute('id', 'foo')
-    template.innerHTML = '<div>foo</div>'
-    window.document.body.appendChild(template)
+  itDoNotRunIf(
+    process.env.TEST_ENV === 'node',
+    'compiles templates from querySelector',
+    () => {
+      const template = window.createElement('div')
+      template.setAttribute('id', 'foo')
+      template.innerHTML = '<div>foo</div>'
+      window.document.body.appendChild(template)
 
-    const wrapper = mount({
-      template: '#foo'
-    })
-    expect(wrapper.vm).to.be.an('object')
-    expect(wrapper.html()).to.equal(`<div>foo</div>`)
+      const wrapper = mount({
+        template: '#foo'
+      })
+      expect(wrapper.vm).to.be.an('object')
+      expect(wrapper.html()).to.equal(`<div>foo</div>`)
 
-    window.body.removeChild(template)
-  })
+      window.body.removeChild(template)
+    }
+  )
 
   itDoNotRunIf(vueVersion < 2.3, 'overrides methods', () => {
     const stub = sandbox.stub()


### PR DESCRIPTION
Handle selectors passed in the `template` option of the Vue instance (https://vuejs.org/v2/api/#template), currently test-utils gives an unfriendly error as the selector is passed as a template string:

```
browser.js:954 [Vue warn]: Error compiling template:

#foo

- Component template requires a root element, rather than just text.
```

Repro here: https://jsfiddle.net/earnubs/c5d2mea7/
