### PR TITLE
Fixed syntax mistake (`shallowMount` => `mount`)

### DIFF
--- a/docs/guides/common-tips.md
+++ b/docs/guides/common-tips.md
@@ -95,13 +95,13 @@ You can emit a custom event from a child component by accessing the instance.
 **Test**
 
 ```js
-import { shallowMount } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 import ParentComponent from '@/components/ParentComponent'
 import ChildComponent from '@/components/ChildComponent'
 
 describe('ParentComponent', () => {
   it("displays 'Emitted!' when custom event is emitted", () => {
-    const wrapper = shallowMount(ParentComponent)
+    const wrapper = mount(ParentComponent)
     wrapper.find(ChildComponent).vm.$emit('custom')
     expect(wrapper.html()).toContain('Emitted!')
   })


### PR DESCRIPTION
`shallowMount` doesn't render children components so the example would not have worked. I changed it to `mount`