### PR TITLE
Use `mount()` consistently in Wrapper documentation

### DIFF
--- a/docs/api/wrapper/setSelected.md
+++ b/docs/api/wrapper/setSelected.md
@@ -8,7 +8,7 @@ Selects an option element and updates `v-model` bound data.
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = shallowMount(Foo)
+const wrapper = mount(Foo)
 const options = wrapper.find('select').findAll('option')
 
 options.at(1).setSelected()

--- a/docs/ja/api/wrapper/setSelected.md
+++ b/docs/ja/api/wrapper/setSelected.md
@@ -8,7 +8,7 @@ option 要素を選択します。そして、 `v-model` に束縛されてい�
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = shallowMount(Foo)
+const wrapper = mount(Foo)
 const options = wrapper.find('select').findAll('option')
 
 options.at(1).setSelected()

--- a/docs/ru/api/wrapper/setSelected.md
+++ b/docs/ru/api/wrapper/setSelected.md
@@ -8,7 +8,7 @@
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = shallowMount(Foo)
+const wrapper = mount(Foo)
 const options = wrapper.find('select').findAll('option')
 
 options.at(1).setSelected()

--- a/docs/zh/api/wrapper/setSelected.md
+++ b/docs/zh/api/wrapper/setSelected.md
@@ -8,7 +8,7 @@
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = shallowMount(Foo)
+const wrapper = mount(Foo)
 const options = wrapper.find('select').findAll('option')
 
 options.at(1).setSelected()


### PR DESCRIPTION
The `setSelected()` documentation examples imported `mount`, but called `shallowMount()`.