### PR TITLE
[Manual] Amending commands to install the testing frameworks

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -10,6 +10,22 @@ cd vue-test-utils-getting-started
 npm install
 ```
 
+If you already have a project and want to add testing capabilities you may run:
+
+```bash
+# unit testing
+vue add @vue/unit-jest 
+
+#or:
+vue add @vue/unit-mocha
+
+# end-to-end
+vue add @vue/e2e-cypress 
+
+#or:
+vue add @vue/e2e-nightwatch
+```
+
 You will see that the project includes a simple component, `counter.js`:
 
 ```js

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -10,19 +10,19 @@ cd vue-test-utils-getting-started
 npm install
 ```
 
-If you already have a project and want to add testing capabilities you may run:
+If you already have a project that was craeted with the [Vue CLI](https://cli.vuejs.org/) and want to add testing capabilities you may run:
 
 ```bash
 # unit testing
-vue add @vue/unit-jest 
+vue add @vue/unit-jest
 
-#or:
+# or:
 vue add @vue/unit-mocha
 
 # end-to-end
-vue add @vue/e2e-cypress 
+vue add @vue/e2e-cypress
 
-#or:
+# or:
 vue add @vue/e2e-nightwatch
 ```
 


### PR DESCRIPTION
If you want to add testing to an already working project, the search for the  command to install the correct plugins can be tedious, thus the request to add this in the "getting started" paragraph.