### PR TITLE
fix: whitelist tags to be ignored with `disabled` attribute

### DIFF
--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -574,8 +574,25 @@ export default class Wrapper implements BaseWrapper {
       )
     }
 
-    // Don't fire event on a disabled element
-    if (this.attributes().disabled) {
+    /**
+     * Avoids firing events on specific disabled elements
+     * See more: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled
+     */
+
+    const supportedTags = [
+      'BUTTON',
+      'COMMAND',
+      'FIELDSET',
+      'KEYGEN',
+      'OPTGROUP',
+      'OPTION',
+      'SELECT',
+      'TEXTAREA',
+      'INPUT'
+    ]
+    const tagName = this.element.tagName
+
+    if (this.attributes().disabled && supportedTags.indexOf(tagName) > -1) {
       return
     }
 

--- a/test/specs/wrapper/trigger.spec.js
+++ b/test/specs/wrapper/trigger.spec.js
@@ -120,23 +120,46 @@ describeWithShallowAndMount('trigger', mountingMethod => {
     expect(stub).calledWith(123)
   })
 
-  it('does not fire on disabled elements', () => {
+  it('does not fire on valid disabled elements', () => {
     const clickHandler = sandbox.stub()
-    const TestComponent = {
-      template:
-        '<div><button disabled @click="clickHandler"/><a href="#" disabled @click="clickHandler"/></div>',
+    const ButtonComponent = {
+      template: '<button disabled @click="clickHandler">Button</button>',
       props: ['clickHandler']
     }
-    const wrapper = mountingMethod(TestComponent, {
+    const buttonWrapper = mountingMethod(ButtonComponent, {
       propsData: {
         clickHandler
       }
     })
-
-    wrapper.find('button').trigger('click')
+    buttonWrapper.trigger('click')
     expect(clickHandler.called).to.equal(false)
 
-    wrapper.find('a').trigger('click')
+    const changeHandler = sandbox.stub()
+    const InputComponent = {
+      template: '<input disabled @change="changeHandler"/>',
+      props: ['changeHandler']
+    }
+    const inputWrapper = mountingMethod(InputComponent, {
+      propsData: {
+        changeHandler
+      }
+    })
+    inputWrapper.trigger('change')
+    expect(changeHandler.called).to.equal(false)
+  })
+
+  it('fires on invalid disabled elements', () => {
+    const clickHandler = sandbox.stub()
+    const LinkComponent = {
+      template: '<a disabled href="#" @click="clickHandler">Link</a>',
+      props: ['clickHandler']
+    }
+    const linkWrapper = mountingMethod(LinkComponent, {
+      propsData: {
+        clickHandler
+      }
+    })
+    linkWrapper.trigger('click')
     expect(clickHandler.called).to.equal(true)
   })
 

--- a/test/specs/wrapper/trigger.spec.js
+++ b/test/specs/wrapper/trigger.spec.js
@@ -123,7 +123,8 @@ describeWithShallowAndMount('trigger', mountingMethod => {
   it('does not fire on disabled elements', () => {
     const clickHandler = sandbox.stub()
     const TestComponent = {
-      template: '<button disabled @click="clickHandler"/>',
+      template:
+        '<div><button disabled @click="clickHandler"/><a href="#" disabled @click="clickHandler"/></div>',
       props: ['clickHandler']
     }
     const wrapper = mountingMethod(TestComponent, {
@@ -131,8 +132,12 @@ describeWithShallowAndMount('trigger', mountingMethod => {
         clickHandler
       }
     })
-    wrapper.trigger('click')
+
+    wrapper.find('button').trigger('click')
     expect(clickHandler.called).to.equal(false)
+
+    wrapper.find('a').trigger('click')
+    expect(clickHandler.called).to.equal(true)
   })
 
   it('handles .prevent', () => {


### PR DESCRIPTION
This PR resolves #1321.
The list follows [W3C Recommendation](https://www.w3.org/TR/2014/REC-html5-20141028/disabled-elements.html#disabled-elements) with the addition of `<command>` and `<keygen>` as listed by [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled).