### PR TITLE
docs: add an example for slots components with props

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -68,7 +68,7 @@ const yourComponent = {
       required: true
     }
   },
-  render (h) {
+  render(h) {
     return h('p', this.foo)
   }
 }
@@ -83,11 +83,13 @@ const wrapper = shallowMount(Component, {
     qux: '<my-component />',
     quux: '<your-component foo="lorem"/><your-component :foo="yourProperty"/>'
   },
-  stubs: { // used to register custom components
+  stubs: {
+    // used to register custom components
     'my-component': MyComponent,
     'your-component': yourComponent
   },
-  mocks: { // used to add properties to the rendering context
+  mocks: {
+    // used to add properties to the rendering context
     yourProperty: 'ipsum'
   }
 })

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -74,6 +74,37 @@ const wrapper = shallowMount(Component, {
 expect(wrapper.find('div')).toBe(true)
 ```
 
+You can also provide slots components with props.
+Example:
+
+```js
+const wrapper = mount(Component, {
+  slots: {
+    default: `<child foo="bar"/><child :foo="val"/>`
+  },
+  mocks: {
+    val: 'qux'
+  },
+  stubs: {
+    child: {
+      props: {
+        foo: {
+          type: String,
+          required: true
+        }
+      },
+      render(h) {
+        return h('p', this.foo)
+      }
+    }
+  }
+})
+
+expect(wrapper.findAll('p').length).toBe(2)
+expect(wrapper.text()).toMatch(/bar/)
+expect(wrapper.text()).toMatch(/qux/)
+```
+
 ## scopedSlots
 
 - type: `{ [name: string]: string|Function }`

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -54,10 +54,23 @@ Example:
 
 ```js
 import Foo from './Foo.vue'
+import MyComponent from './MyComponent.vue'
 
 const bazComponent = {
   name: 'baz-component',
   template: '<p>baz</p>'
+}
+
+const yourComponent = {
+  props: {
+    foo: {
+      type: String,
+      required: true
+    }
+  },
+  render (h) {
+    return h('p', this.foo)
+  }
 }
 
 const wrapper = shallowMount(Component, {
@@ -67,42 +80,19 @@ const wrapper = shallowMount(Component, {
     foo: '<div />',
     bar: 'bar',
     baz: bazComponent,
-    qux: '<my-component />'
+    qux: '<my-component />',
+    quux: '<your-component foo="lorem"/><your-component :foo="yourProperty"/>'
+  },
+  stubs: { // used to register custom components
+    'my-component': MyComponent,
+    'your-component': yourComponent
+  },
+  mocks: { // used to add properties to the rendering context
+    yourProperty: 'ipsum'
   }
 })
 
 expect(wrapper.find('div')).toBe(true)
-```
-
-You can also provide slots components with props.
-Example:
-
-```js
-const wrapper = mount(Component, {
-  slots: {
-    default: `<child foo="bar"/><child :foo="val"/>`
-  },
-  mocks: {
-    val: 'qux'
-  },
-  stubs: {
-    child: {
-      props: {
-        foo: {
-          type: String,
-          required: true
-        }
-      },
-      render(h) {
-        return h('p', this.foo)
-      }
-    }
-  }
-})
-
-expect(wrapper.findAll('p').length).toBe(2)
-expect(wrapper.text()).toMatch(/bar/)
-expect(wrapper.text()).toMatch(/qux/)
 ```
 
 ## scopedSlots


### PR DESCRIPTION
Because many people including me (:rofl:) were [struggling to mount slots components with props](https://github.com/vuejs/vue-test-utils/issues/41#issuecomment-343901582), this PR introduces an example for the case.
Example:
```vue
<!-- Component.vue -->
<template>
  <div><slot/></div>
</template>

<!-- Child.vue -->
<template>
  <p>{{ foo }}</p>
</template>
<script>
export default {
  props: {
    foo: {
      type: String,
      required: true
    }
  }
}
</script>

<!-- Expected mounting -->
<component>
  <child foo="bar"></child>
  <child foo="qux"></child>
</component>
```
Btw, I don't really know if this fits into the `api` docs or common tips.