### PR TITLE
Ensure setChecked() and setSelected() only trigger DOM events when state is changed (fix #1339)

### DIFF
--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -375,6 +375,10 @@ export default class Wrapper implements BaseWrapper {
         )
       }
 
+      if (this.element.checked === checked) {
+        return
+      }
+
       if (event !== 'click' || isPhantomJS) {
         // $FlowIgnore
         this.element.selected = true

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -404,6 +404,10 @@ export default class Wrapper implements BaseWrapper {
     }
 
     if (tagName === 'OPTION') {
+      if (this.element.selected) {
+        return
+      }
+
       // $FlowIgnore
       this.element.selected = true
       // $FlowIgnore

--- a/test/specs/wrapper/setChecked.spec.js
+++ b/test/specs/wrapper/setChecked.spec.js
@@ -57,22 +57,22 @@ describeWithShallowAndMount('setChecked', mountingMethod => {
 
   it('should trigger a change event when called on a checkbox', () => {
     const listeners = { change: sinon.spy() }
-    const input = mountingMethod({
-      template: `<input type="checkbox" v-on="$listeners">`,
-    }, { listeners })
 
-    input.setChecked()
+    mountingMethod(
+      { template: `<input type="checkbox" v-on="$listeners">` },
+      { listeners },
+    ).setChecked()
 
     expect(listeners.change).to.have.been.called
   });
 
   it('should not trigger a change event if the checkbox is already checked', () => {
     const listeners = { change: sinon.spy() }
-    const input = mountingMethod({
-      template: `<input type="checkbox" checked v-on="$listeners">`,
-    }, { listeners })
 
-    input.setChecked()
+    mountingMethod(
+      { template: `<input type="checkbox" checked v-on="$listeners">` },
+      { listeners },
+    ).setChecked()
 
     expect(listeners.change).not.to.have.been.called
   });
@@ -110,6 +110,28 @@ describeWithShallowAndMount('setChecked', mountingMethod => {
     await Vue.nextTick()
     expect(wrapper.find('.counter').text()).to.equal('4')
   })
+
+  it('should trigger a change event when called on a radio button', () => {
+    const listeners = { change: sinon.spy() }
+
+    mountingMethod(
+      { template: `<input type="radio" v-on="$listeners">` },
+      { listeners },
+    ).setChecked()
+
+    expect(listeners.change).to.have.been.called
+  });
+
+  it('should not trigger a change event if the radio button is already selected', () => {
+    const listeners = { change: sinon.spy() }
+
+    mountingMethod(
+      { template: `<input type="radio" checked v-on="$listeners">` },
+      { listeners },
+    ).setChecked()
+
+    expect(listeners.change).not.to.have.been.called
+  });
 
   it('throws error if checked param is not boolean', () => {
     const message = 'wrapper.setChecked() must be passed a boolean'

--- a/test/specs/wrapper/setChecked.spec.js
+++ b/test/specs/wrapper/setChecked.spec.js
@@ -68,7 +68,7 @@ describeWithShallowAndMount('setChecked', mountingMethod => {
           @click="listener"
         >
       `,
-      methods: { listener },
+      methods: { listener }
     }).setChecked()
 
     expect(listener).to.have.been.called
@@ -86,7 +86,7 @@ describeWithShallowAndMount('setChecked', mountingMethod => {
           @click="listener"
         >
       `,
-      methods: { listener },
+      methods: { listener }
     }).setChecked()
 
     expect(listener).not.to.have.been.called
@@ -137,7 +137,7 @@ describeWithShallowAndMount('setChecked', mountingMethod => {
           @click="listener"
         >
       `,
-      methods: { listener },
+      methods: { listener }
     }).setChecked()
 
     expect(listener).to.have.been.called
@@ -155,7 +155,7 @@ describeWithShallowAndMount('setChecked', mountingMethod => {
           @click="listener"
         >
       `,
-      methods: { listener },
+      methods: { listener }
     }).setChecked()
 
     expect(listener).not.to.have.been.called

--- a/test/specs/wrapper/setChecked.spec.js
+++ b/test/specs/wrapper/setChecked.spec.js
@@ -55,6 +55,28 @@ describeWithShallowAndMount('setChecked', mountingMethod => {
     expect(wrapper.find('.counter').text()).to.equal('4')
   })
 
+  it('should trigger a change event when called on a checkbox', () => {
+    const listeners = { change: sinon.spy() }
+    const input = mountingMethod({
+      template: `<input type="checkbox" v-on="$listeners">`,
+    }, { listeners })
+
+    input.setChecked()
+
+    expect(listeners.change).to.have.been.called
+  });
+
+  it('should not trigger a change event if the checkbox is already checked', () => {
+    const listeners = { change: sinon.spy() }
+    const input = mountingMethod({
+      template: `<input type="checkbox" checked v-on="$listeners">`,
+    }, { listeners })
+
+    input.setChecked()
+
+    expect(listeners.change).not.to.have.been.called
+  });
+
   it('updates dom with radio v-model', async () => {
     const wrapper = mountingMethod(ComponentWithInput)
 
@@ -67,7 +89,7 @@ describeWithShallowAndMount('setChecked', mountingMethod => {
     expect(wrapper.text()).to.contain('radioFooResult')
   })
 
-  it('changes state the right amount of times with checkbox v-model', async () => {
+  it('changes state the right amount of times with radio v-model', async () => {
     const wrapper = mountingMethod(ComponentWithInput)
     const radioBar = wrapper.find('#radioBar')
     const radioFoo = wrapper.find('#radioFoo')

--- a/test/specs/wrapper/setChecked.spec.js
+++ b/test/specs/wrapper/setChecked.spec.js
@@ -55,7 +55,7 @@ describeWithShallowAndMount('setChecked', mountingMethod => {
     expect(wrapper.find('.counter').text()).to.equal('4')
   })
 
-  it('should trigger a change event when called on a checkbox', () => {
+  it('triggers a change event when called on a checkbox', () => {
     const listener = sinon.spy()
 
     mountingMethod({
@@ -74,7 +74,7 @@ describeWithShallowAndMount('setChecked', mountingMethod => {
     expect(listener).to.have.been.called
   })
 
-  it('should not trigger a change event if the checkbox is already checked', () => {
+  it('does not trigger a change event if the checkbox is already checked', () => {
     const listener = sinon.spy()
 
     mountingMethod({
@@ -126,7 +126,7 @@ describeWithShallowAndMount('setChecked', mountingMethod => {
     expect(wrapper.find('.counter').text()).to.equal('4')
   })
 
-  it('should trigger a change event when called on a radio button', () => {
+  it('triggers a change event when called on a radio button', () => {
     const listener = sinon.spy()
 
     mountingMethod({
@@ -143,7 +143,7 @@ describeWithShallowAndMount('setChecked', mountingMethod => {
     expect(listener).to.have.been.called
   })
 
-  it('should not trigger a change event if the radio button is already checked', () => {
+  it('does not trigger a change event if the radio button is already checked', () => {
     const listener = sinon.spy()
 
     mountingMethod({

--- a/test/specs/wrapper/setChecked.spec.js
+++ b/test/specs/wrapper/setChecked.spec.js
@@ -56,26 +56,41 @@ describeWithShallowAndMount('setChecked', mountingMethod => {
   })
 
   it('should trigger a change event when called on a checkbox', () => {
-    const listeners = { change: sinon.spy() }
+    const listener = sinon.spy()
 
-    mountingMethod(
-      { template: `<input type="checkbox" v-on="$listeners">` },
-      { listeners },
-    ).setChecked()
+    mountingMethod({
+      // For compatibility with earlier versions of Vue that use the `click`
+      // event for updating `v-model`.
+      template: `
+        <input
+          type="checkbox"
+          @change="listener"
+          @click="listener"
+        >
+      `,
+      methods: { listener },
+    }).setChecked()
 
-    expect(listeners.change).to.have.been.called
-  });
+    expect(listener).to.have.been.called
+  })
 
   it('should not trigger a change event if the checkbox is already checked', () => {
-    const listeners = { change: sinon.spy() }
+    const listener = sinon.spy()
 
-    mountingMethod(
-      { template: `<input type="checkbox" checked v-on="$listeners">` },
-      { listeners },
-    ).setChecked()
+    mountingMethod({
+      template: `
+        <input
+          type="checkbox"
+          checked
+          @change="listener"
+          @click="listener"
+        >
+      `,
+      methods: { listener },
+    }).setChecked()
 
-    expect(listeners.change).not.to.have.been.called
-  });
+    expect(listener).not.to.have.been.called
+  })
 
   it('updates dom with radio v-model', async () => {
     const wrapper = mountingMethod(ComponentWithInput)
@@ -112,26 +127,39 @@ describeWithShallowAndMount('setChecked', mountingMethod => {
   })
 
   it('should trigger a change event when called on a radio button', () => {
-    const listeners = { change: sinon.spy() }
+    const listener = sinon.spy()
 
-    mountingMethod(
-      { template: `<input type="radio" v-on="$listeners">` },
-      { listeners },
-    ).setChecked()
+    mountingMethod({
+      template: `
+        <input
+          type="radio"
+          @change="listener"
+          @click="listener"
+        >
+      `,
+      methods: { listener },
+    }).setChecked()
 
-    expect(listeners.change).to.have.been.called
-  });
+    expect(listener).to.have.been.called
+  })
 
-  it('should not trigger a change event if the radio button is already selected', () => {
-    const listeners = { change: sinon.spy() }
+  it('should not trigger a change event if the radio button is already checked', () => {
+    const listener = sinon.spy()
 
-    mountingMethod(
-      { template: `<input type="radio" checked v-on="$listeners">` },
-      { listeners },
-    ).setChecked()
+    mountingMethod({
+      template: `
+        <input
+          type="radio"
+          checked
+          @change="listener"
+          @click="listener"
+        >
+      `,
+      methods: { listener },
+    }).setChecked()
 
-    expect(listeners.change).not.to.have.been.called
-  });
+    expect(listener).not.to.have.been.called
+  })
 
   it('throws error if checked param is not boolean', () => {
     const message = 'wrapper.setChecked() must be passed a boolean'

--- a/test/specs/wrapper/setSelected.spec.js
+++ b/test/specs/wrapper/setSelected.spec.js
@@ -49,11 +49,14 @@ describeWithShallowAndMount('setSelected', mountingMethod => {
           <option value="foo" />
         </select>
       `,
-      methods: { change },
-    }).findAll('option').at(1).setSelected()
+      methods: { change }
+    })
+      .findAll('option')
+      .at(1)
+      .setSelected()
 
     expect(change).to.have.been.called
-  });
+  })
 
   it('should not trigger an event if already selected', () => {
     const change = sinon.spy()
@@ -65,11 +68,14 @@ describeWithShallowAndMount('setSelected', mountingMethod => {
           <option selected value="foo" />
         </select>
       `,
-      methods: { change },
-    }).findAll('option').at(1).setSelected()
+      methods: { change }
+    })
+      .findAll('option')
+      .at(1)
+      .setSelected()
 
     expect(change).not.to.have.been.called
-  });
+  })
 
   it('throws error if element is not valid', () => {
     const message = 'wrapper.setSelected() cannot be called on this element'

--- a/test/specs/wrapper/setSelected.spec.js
+++ b/test/specs/wrapper/setSelected.spec.js
@@ -39,6 +39,38 @@ describeWithShallowAndMount('setSelected', mountingMethod => {
     expect(wrapper.text()).to.contain('selectA')
   })
 
+  it('should trigger a change event on the parent <select>', () => {
+    const change = sinon.spy()
+
+    mountingMethod({
+      template: `
+        <select @change="change">
+          <option />
+          <option value="foo" />
+        </select>
+      `,
+      methods: { change },
+    }).findAll('option').at(1).setSelected()
+
+    expect(change).to.have.been.called
+  });
+
+  it('should not trigger an event if already selected', () => {
+    const change = sinon.spy()
+
+    mountingMethod({
+      template: `
+        <select @change="change">
+          <option />
+          <option selected value="foo" />
+        </select>
+      `,
+      methods: { change },
+    }).findAll('option').at(1).setSelected()
+
+    expect(change).not.to.have.been.called
+  });
+
   it('throws error if element is not valid', () => {
     const message = 'wrapper.setSelected() cannot be called on this element'
 

--- a/test/specs/wrapper/setSelected.spec.js
+++ b/test/specs/wrapper/setSelected.spec.js
@@ -39,7 +39,7 @@ describeWithShallowAndMount('setSelected', mountingMethod => {
     expect(wrapper.text()).to.contain('selectA')
   })
 
-  it('should trigger a change event on the parent <select>', () => {
+  it('triggers a change event on the parent select', () => {
     const change = sinon.spy()
 
     mountingMethod({
@@ -58,7 +58,7 @@ describeWithShallowAndMount('setSelected', mountingMethod => {
     expect(change).to.have.been.called
   })
 
-  it('should not trigger an event if already selected', () => {
+  it('does not trigger an event if called on already selected option', () => {
     const change = sinon.spy()
 
     mountingMethod({


### PR DESCRIPTION
`Wrapper.setChecked()` and `Wrapper.setSelected()` should not trigger DOM events when called on already checked or selected elements.

Closes #1339