### PR TITLE
Docs: added example usage for localVue

### DIFF
--- a/docs/api/createLocalVue.md
+++ b/docs/api/createLocalVue.md
@@ -12,9 +12,11 @@ Use it with `options.localVue`:
 
 ```js
 import { createLocalVue, shallowMount } from '@vue/test-utils'
+import MyPlugin from 'my-plugin'
 import Foo from './Foo.vue'
 
 const localVue = createLocalVue()
+localVue.use(MyPlugin)
 const wrapper = shallowMount(Foo, {
   localVue,
   mocks: { foo: true }


### PR DESCRIPTION
## What does this PR do?

I've extended an example for `createLocalVue` API, adding `localVue.use` call.

## Why this is important?

People tend to take examples very literally, copy-pasting them to their codebase without any additions. Results could be really dramatic: I've just found out 120 files of GitLab codebase create `localVue` instances and inject them via `shallowMount` for no reason. This PR is trying to show the real need for creating `localVue` in the test case