### PR TITLE
Override component watcher with mounting options

### DIFF
--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -71,12 +71,6 @@ export default function createInstance(
   // used to identify extended component using constructor
   componentOptions.$_vueTestUtils_original = component
 
-  // make sure all extends are based on this instance
-
-  if (instanceOptions.watch) {
-    console.log(instanceOptions.watch)
-  }
-
   // watchers provided in mounting options should override preexisting ones
   if (componentOptions.watch && instanceOptions.watch) {
     const componentWatchers = Object.keys(componentOptions.watch)
@@ -91,6 +85,7 @@ export default function createInstance(
     }
   }
 
+  // make sure all extends are based on this instance
   const Constructor = _Vue.extend(componentOptions).extend(instanceOptions)
   componentOptions._Ctor = {}
   Constructor.options._base = _Vue

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -73,6 +73,24 @@ export default function createInstance(
 
   // make sure all extends are based on this instance
 
+  if (instanceOptions.watch) {
+    console.log(instanceOptions.watch)
+  }
+
+  // watchers provided in mounting options should override preexisting ones
+  if (componentOptions.watch && instanceOptions.watch) {
+    const componentWatchers = Object.keys(componentOptions.watch)
+    const instanceWatchers = Object.keys(instanceOptions.watch)
+
+    for (let i = 0; i < instanceWatchers.length; i++) {
+      const k = instanceWatchers[i]
+      // override the componentOptions with the one provided in mounting options
+      if (componentWatchers.includes(k)) {
+        componentOptions.watch[k] = instanceOptions.watch[k]
+      }
+    }
+  }
+
   const Constructor = _Vue.extend(componentOptions).extend(instanceOptions)
   componentOptions._Ctor = {}
   Constructor.options._base = _Vue

--- a/test/specs/mounting-options/watch.spec.js
+++ b/test/specs/mounting-options/watch.spec.js
@@ -1,5 +1,4 @@
 import { describeWithShallowAndMount } from '~resources/utils'
-import { itSkipIf, itDoNotRunIf } from 'conditional-specs'
 
 describeWithShallowAndMount('options.watch', mountingMethod => {
   it('overrides a default watch handler', async () => {

--- a/test/specs/mounting-options/watch.spec.js
+++ b/test/specs/mounting-options/watch.spec.js
@@ -1,0 +1,41 @@
+import {
+  describeWithShallowAndMount,
+  isRunningPhantomJS,
+  vueVersion
+} from '~resources/utils'
+import { itSkipIf, itDoNotRunIf } from 'conditional-specs'
+
+describeWithShallowAndMount('options.watch', mountingMethod => {
+  it('overrides a default watch handler', async () => {
+    const TestComponent = {
+      props: ['someProp'],
+      template: '<div>{{ foo }}</div>',
+      data() {
+        return {
+          foo: 'bar'
+        }
+      },
+      watch: {
+        someProp: {
+          handler() {
+            this.foo = 'updated-bar'
+          }
+        }
+      }
+    }
+    const wrapper = mountingMethod(TestComponent, {
+      watch: {
+        someProp: {
+          handler() {
+            // do nothing
+          }
+        }
+      }
+    })
+
+    wrapper.setProps({ someProp: 'some-new-val' })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).to.equal('bar')
+  })
+})

--- a/test/specs/mounting-options/watch.spec.js
+++ b/test/specs/mounting-options/watch.spec.js
@@ -1,14 +1,10 @@
-import {
-  describeWithShallowAndMount,
-  isRunningPhantomJS,
-  vueVersion
-} from '~resources/utils'
+import { describeWithShallowAndMount } from '~resources/utils'
 import { itSkipIf, itDoNotRunIf } from 'conditional-specs'
 
 describeWithShallowAndMount('options.watch', mountingMethod => {
   it('overrides a default watch handler', async () => {
     const TestComponent = {
-      props: ['someProp'],
+      props: ['someProp', 'anotherProp'],
       template: '<div>{{ foo }}</div>',
       data() {
         return {
@@ -16,6 +12,11 @@ describeWithShallowAndMount('options.watch', mountingMethod => {
         }
       },
       watch: {
+        anotherProp: {
+          handler() {
+            // placeholder
+          }
+        },
         someProp: {
           handler() {
             this.foo = 'updated-bar'

--- a/test/specs/mounting-options/watch.spec.js
+++ b/test/specs/mounting-options/watch.spec.js
@@ -3,7 +3,7 @@ import { describeWithShallowAndMount } from '~resources/utils'
 describeWithShallowAndMount('options.watch', mountingMethod => {
   it('overrides a default watch handler', async () => {
     const TestComponent = {
-      props: ['someProp', 'anotherProp'],
+      props: ['someProp'],
       template: '<div>{{ foo }}</div>',
       data() {
         return {
@@ -11,11 +11,6 @@ describeWithShallowAndMount('options.watch', mountingMethod => {
         }
       },
       watch: {
-        anotherProp: {
-          handler() {
-            // placeholder
-          }
-        },
         someProp: {
           handler() {
             this.foo = 'updated-bar'


### PR DESCRIPTION
resolves #1391 . We should override a component's watcher if one is provided in the mounting options. The issue explains the bug a bit better and provides an example.