### PR TITLE
Allow find to work on both Pascal case and camel case 

### DIFF
--- a/packages/test-utils/src/matches.js
+++ b/packages/test-utils/src/matches.js
@@ -6,12 +6,12 @@ import {
 import { isConstructor } from 'shared/validators'
 
 function vmMatchesName(vm, name) {
-  const normalize = (name = '') => name.replace(/-/gi, '').toLowerCase()
-  const normalizedName = normalize(name)
+  const lc = (name = '') => name.toLowerCase()
+  const lowerCaseName = lc(name)
   return (
     !!name &&
-    (normalize(vm.name) === normalizedName ||
-      (vm.$options && normalize(vm.$options.name) === normalizedName))
+    (lc(vm.name) === lowerCaseName ||
+      (vm.$options && lc(vm.$options.name) === lowerCaseName))
   )
 }
 

--- a/packages/test-utils/src/matches.js
+++ b/packages/test-utils/src/matches.js
@@ -4,15 +4,19 @@ import {
   FUNCTIONAL_OPTIONS
 } from 'shared/consts'
 import { isConstructor } from 'shared/validators'
-import { capitalize } from 'shared/util'
+import { capitalize, camelize } from 'shared/util'
 
 function vmMatchesName(vm, name) {
+  console.log(name)
+  console.log(vm.$options.name)
   return (
     !!name && (
-      vm.name === name || 
+      vm.name === name ||
       (vm.$options && vm.$options.name === name) ||
       vm.name === capitalize(name) ||
-      vm.$options && vm.$options.name === capitalize(name)
+      vm.$options && vm.$options.name === capitalize(name) ||
+      vm.$options && vm.$options.name && vm.$options.name === capitalize(camelize(name)) ||
+      vm.$options && vm.$options.name && capitalize(camelize(vm.$options.name)) === name
     )
   )
 }

--- a/packages/test-utils/src/matches.js
+++ b/packages/test-utils/src/matches.js
@@ -7,14 +7,19 @@ import { isConstructor } from 'shared/validators'
 import { capitalize, camelize } from 'shared/util'
 
 function vmMatchesName(vm, name) {
-  const componentName = vm.$options && vm.$options.name || ''
+  // We want to mirror how Vue resolves component names in SFCs:
+  // For example, <test-component />, <TestComponent /> and `<testComponent />
+  // all resolve to the same component
+  const componentName = (vm.$options && vm.$options.name) || ''
   return (
-    !!name && (
-      componentName === name || 
+    !!name &&
+    (componentName === name ||
+      // testComponent -> TestComponent
       componentName === capitalize(name) ||
+      // testcomponent -> TestComponent
       componentName === capitalize(camelize(name)) ||
-      capitalize(camelize(componentName)) === name
-    )
+      // same match as above, but the component name vs query
+      capitalize(camelize(componentName)) === name)
   )
 }
 

--- a/packages/test-utils/src/matches.js
+++ b/packages/test-utils/src/matches.js
@@ -16,7 +16,7 @@ function vmMatchesName(vm, name) {
     (componentName === name ||
       // testComponent -> TestComponent
       componentName === capitalize(name) ||
-      // testcomponent -> TestComponent
+      // test-component -> TestComponent
       componentName === capitalize(camelize(name)) ||
       // same match as above, but the component name vs query
       capitalize(camelize(componentName)) === name)

--- a/packages/test-utils/src/matches.js
+++ b/packages/test-utils/src/matches.js
@@ -4,14 +4,16 @@ import {
   FUNCTIONAL_OPTIONS
 } from 'shared/consts'
 import { isConstructor } from 'shared/validators'
+import { capitalize } from 'shared/util'
 
 function vmMatchesName(vm, name) {
-  const lc = (name = '') => name.toLowerCase()
-  const lowerCaseName = lc(name)
   return (
-    !!name &&
-    (lc(vm.name) === lowerCaseName ||
-      (vm.$options && lc(vm.$options.name) === lowerCaseName))
+    !!name && (
+      vm.name === name || 
+      (vm.$options && vm.$options.name === name) ||
+      vm.name === capitalize(name) ||
+      vm.$options && vm.$options.name === capitalize(name)
+    )
   )
 }
 

--- a/packages/test-utils/src/matches.js
+++ b/packages/test-utils/src/matches.js
@@ -6,8 +6,12 @@ import {
 import { isConstructor } from 'shared/validators'
 
 export function vmMatchesName(vm, name) {
+  const normalize = (name = '') => name.replace(/-/gi, '').toLowerCase()
+  const normalizedName = normalize(name)
   return (
-    !!name && (vm.name === name || (vm.$options && vm.$options.name === name))
+    !!name &&
+    (normalize(vm.name) === normalizedName ||
+      (vm.$options && normalize(vm.$options.name) === normalizedName))
   )
 }
 

--- a/packages/test-utils/src/matches.js
+++ b/packages/test-utils/src/matches.js
@@ -5,7 +5,7 @@ import {
 } from 'shared/consts'
 import { isConstructor } from 'shared/validators'
 
-export function vmMatchesName(vm, name) {
+function vmMatchesName(vm, name) {
   const normalize = (name = '') => name.replace(/-/gi, '').toLowerCase()
   const normalizedName = normalize(name)
   return (

--- a/packages/test-utils/src/matches.js
+++ b/packages/test-utils/src/matches.js
@@ -7,16 +7,13 @@ import { isConstructor } from 'shared/validators'
 import { capitalize, camelize } from 'shared/util'
 
 function vmMatchesName(vm, name) {
-  console.log(name)
-  console.log(vm.$options.name)
+  const componentName = vm.$options && vm.$options.name || ''
   return (
     !!name && (
-      vm.name === name ||
-      (vm.$options && vm.$options.name === name) ||
-      vm.name === capitalize(name) ||
-      vm.$options && vm.$options.name === capitalize(name) ||
-      vm.$options && vm.$options.name && vm.$options.name === capitalize(camelize(name)) ||
-      vm.$options && vm.$options.name && capitalize(camelize(vm.$options.name)) === name
+      componentName === name || 
+      componentName === capitalize(name) ||
+      componentName === capitalize(camelize(name)) ||
+      capitalize(camelize(componentName)) === name
     )
   )
 }

--- a/test/specs/wrapper/find.spec.js
+++ b/test/specs/wrapper/find.spec.js
@@ -431,6 +431,20 @@ describeWithShallowAndMount('find', mountingMethod => {
     )
   })
 
+  it('returns a Wrapper matching a component pascal case name in options object', () => {
+    const wrapper = mountingMethod(ComponentWithChild)
+    expect(wrapper.find({ name: 'TestComponent' }).name()).to.equal(
+      'test-component'
+    )
+  })
+
+  it('returns a Wrapper matching a component camel case name in options object', () => {
+    const wrapper = mountingMethod(ComponentWithChild)
+    expect(wrapper.find({ name: 'testComponent' }).name()).to.equal(
+      'test-component'
+    )
+  })
+
   it('returns Wrapper of Vue Component matching the ref in options object', () => {
     const wrapper = mountingMethod(ComponentWithChild)
     expect(wrapper.find({ ref: 'child' }).isVueInstance()).to.equal(true)

--- a/test/specs/wrapper/find.spec.js
+++ b/test/specs/wrapper/find.spec.js
@@ -468,7 +468,7 @@ describeWithShallowAndMount('find', mountingMethod => {
     const wrapper = mountingMethod(compiled)
     const a = wrapper.find('a')
     const message =
-      '[vue-test-utils]: $ref selectors can used on Vue component wrappers'
+      '[vue-test-utils]: $ref selectors can only be used on Vue component wrappers'
     const fn = () => a.find({ ref: 'foo' })
     expect(fn)
       .to.throw()

--- a/test/specs/wrapper/find.spec.js
+++ b/test/specs/wrapper/find.spec.js
@@ -431,14 +431,7 @@ describeWithShallowAndMount('find', mountingMethod => {
     )
   })
 
-  it('returns a Wrapper matching a component camel case name in options object', () => {
-    const wrapper = mountingMethod(ComponentWithChild)
-    expect(wrapper.find({ name: 'test-Component' }).name()).to.equal(
-      'test-component'
-    )
-  })
-
-  it('returns a Wrapper matching a name disregarding case in options object', () => {
+  it('returns a Wrapper matching a camelCase name option and a Pascal Case component name ', () => {
     const component = {
       name: 'CamelCase',
       render: h => h('div')

--- a/test/specs/wrapper/find.spec.js
+++ b/test/specs/wrapper/find.spec.js
@@ -431,18 +431,20 @@ describeWithShallowAndMount('find', mountingMethod => {
     )
   })
 
-  it('returns a Wrapper matching a component pascal case name in options object', () => {
+  it('returns a Wrapper matching a component camel case name in options object', () => {
     const wrapper = mountingMethod(ComponentWithChild)
-    expect(wrapper.find({ name: 'TestComponent' }).name()).to.equal(
+    expect(wrapper.find({ name: 'test-Component' }).name()).to.equal(
       'test-component'
     )
   })
 
-  it('returns a Wrapper matching a component camel case name in options object', () => {
-    const wrapper = mountingMethod(ComponentWithChild)
-    expect(wrapper.find({ name: 'testComponent' }).name()).to.equal(
-      'test-component'
-    )
+  it('returns a Wrapper matching a name disregarding case in options object', () => {
+    const component = {
+      name: 'CamelCase',
+      render: h => h('div')
+    }
+    const wrapper = mountingMethod(component)
+    expect(wrapper.find({ name: 'camelCase' }).name()).to.equal('CamelCase')
   })
 
   it('returns Wrapper of Vue Component matching the ref in options object', () => {

--- a/test/specs/wrapper/find.spec.js
+++ b/test/specs/wrapper/find.spec.js
@@ -440,6 +440,24 @@ describeWithShallowAndMount('find', mountingMethod => {
     expect(wrapper.find({ name: 'camelCase' }).name()).to.equal('CamelCase')
   })
 
+  it('returns a Wrapper matching a kebab-case name option and a Pascal Case component name ', () => {
+    const component = {
+      name: 'CamelCase',
+      render: h => h('div')
+    }
+    const wrapper = mountingMethod(component)
+    expect(wrapper.find({ name: 'camel-case' }).name()).to.equal('CamelCase')
+  })
+
+  it('returns a Wrapper matching a Pascal Case name option and a kebab-casecomponent name ', () => {
+    const component = {
+      name: 'camel-case',
+      render: h => h('div')
+    }
+    const wrapper = mountingMethod(component)
+    expect(wrapper.find({ name: 'CamelCase' }).name()).to.equal('camel-case')
+  })
+
   it('returns Wrapper of Vue Component matching the ref in options object', () => {
     const wrapper = mountingMethod(ComponentWithChild)
     expect(wrapper.find({ ref: 'child' }).isVueInstance()).to.equal(true)
@@ -450,7 +468,7 @@ describeWithShallowAndMount('find', mountingMethod => {
     const wrapper = mountingMethod(compiled)
     const a = wrapper.find('a')
     const message =
-      '[vue-test-utils]: $ref selectors can only be used on Vue component wrappers'
+      '[vue-test-utils]: $ref selectors can used on Vue component wrappers'
     const fn = () => a.find({ ref: 'foo' })
     expect(fn)
       .to.throw()


### PR DESCRIPTION
resolves #1232

I think it's fine to support finding a component named `TestComponent` with `test-component` and vice versa, or event `testComponent` - especially for third party packages, it can be hard to know the `name` of a component. Just makes `find` a bit more forgiving and improves the DX with no real downside.

I forked from https://github.com/vuejs/vue-test-utils/pull/1396, will retarget once that is merged. I love the new workflow (run tests against `src`).