### PR TITLE
Fix small typo in api docs.

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -148,7 +148,7 @@ shallowMount(Component, {
 ```
 
 ::: warning Root Element required
-Due to the internal implementatioj of this feature, the slot content has to return a root element, even though a scoped slot is allowed to return an array of elements.
+Due to the internal implementation of this feature, the slot content has to return a root element, even though a scoped slot is allowed to return an array of elements.
 
 If you ever need this in a test, the recommended workaround is to wrap the component under test in another component and mount that one:
 :::


### PR DESCRIPTION
Just fixing small typo at [api docs](https://vue-test-utils.vuejs.org/api/options.html#scopedslots)