### PR TITLE
docs: Document data mounting option

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -10,6 +10,7 @@ These options will be merged with the component's existing options when mounted 
 :::
 
 - [`context`](#context)
+- [`data`](#data)
 - [`slots`](#slots)
 - [`scopedSlots`](#scopedslots)
 - [`stubs`](#stubs)
@@ -42,6 +43,43 @@ const wrapper = mount(Component, {
 })
 
 expect(wrapper.is(Component)).toBe(true)
+```
+
+## data
+
+- type: `Function`
+
+Passes data to a component. It will merge with the existing `data` function.
+
+Example:
+
+```js
+const Component = {
+  template: `
+    <div>
+      <span id="foo">{{ foo }}</span>
+      <span id="bar">{{ bar }}</span>
+    </div>
+  `,
+
+  data() {
+    return {
+      foo: 'foo',
+      bar: 'bar'
+    }
+  }
+}
+
+const wrapper = mount(Component, {
+  data() {
+    return {
+      bar: 'my-override'
+    }
+  }
+})
+
+wrapper.find('#foo').text() // 'foo'
+wrapper.find('#bar').text() // 'my-override'
 ```
 
 ## slots


### PR DESCRIPTION
Not sure how we did not have this very important feature documented. A lot of people are using `setData` since they did not know about this method! Tertia from GL pointed this out.