### PR TITLE
fix(types): emitted can return undefined

### DIFF
--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -102,8 +102,8 @@ export interface Wrapper<V extends Vue | null> extends BaseWrapper {
   text (): string
   name (): string
 
-  emitted (): { [name: string]: Array<Array<any>> }
-  emitted (event: string): Array<any>
+  emitted (): { [name: string]: Array<Array<any>>|undefined }
+  emitted (event: string): Array<any>|undefined
   emittedByOrder (): Array<{ name: string, args: Array<any> }>
 }
 

--- a/packages/test-utils/types/test/wrapper.ts
+++ b/packages/test-utils/types/test/wrapper.ts
@@ -23,8 +23,8 @@ bool = wrapper.isVueInstance()
 
 wrapper.vm.$emit('hello')
 
-let n: number = wrapper.emitted().hello[0][0]
-let o: string = wrapper.emitted('hello')[0]
+let n: number = wrapper.emitted().hello![0][0]
+let o: string = wrapper.emitted('hello')![0]
 
 const emittedByOrder = wrapper.emittedByOrder()
 const name: string = emittedByOrder[0].name


### PR DESCRIPTION
I’m not sure how strict this project is about `undefined` types in general, but I found it confusing that the documentation advised to use `expect(…).toBeTruthy()` on a function (`emitted( 'foo' )`) that was typed to always return an array (i. e., always truthy).

It might be better to only add the `|undefined` to the overload with an event name, not to the overload that returns all events at once… not sure.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

~~I suppose in theory it’s a breaking change? People who previously assigned the result of `.emitted()` to a variable with an explicit type might now get a type error. The expected use, inline within `expect()`, should be fine, though.~~

Calls like `.emitted().foo[0]` or `.emitted('foo')[0]` may also need to be updated, depending on TypeScript config – in the tests, I’ve used the non-null assertion operator.

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**