### PR TITLE
fix: link to attachToDocument definition

### DIFF
--- a/docs/api/wrapper/README.md
+++ b/docs/api/wrapper/README.md
@@ -18,7 +18,7 @@ A `Wrapper` is an object that contains a mounted component or vnode and methods 
 
 #### `options.attachedToDocument`
 
-`Boolean` (read-only): True if component is attached to document when rendered.
+`Boolean` (read-only): `true` if component is [attached to document](../options.md) when rendered.
 
 ### `selector`
 


### PR DESCRIPTION
This PR links to the definition of `attachToDocument`, bringing clarification to users who might be confused by it when reading up the [wrapper properties](https://vue-test-utils.vuejs.org/api/wrapper/#properties).

**Note**: I couldn't edit the Japanese, Chinese and Russian docs as I'm not able to identify where to put the link.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

Documentation update.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included