### PR TITLE
stub globally registered components (fix #1272)

### DIFF
--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -52,8 +52,14 @@ export default function createInstance(
   // root instance when it's instantiated
   const instanceOptions = extractInstanceOptions(options)
 
+  const globalComponents = _Vue.options.components || {}
+  const componentsToStub = Object.assign(
+    Object.create(globalComponents),
+    componentOptions.components
+  )
+
   const stubComponentsObject = createStubsFromStubsObject(
-    componentOptions.components,
+    componentsToStub,
     // $FlowIgnore
     options.stubs,
     _Vue

--- a/test/specs/mounting-options/stubs.spec.js
+++ b/test/specs/mounting-options/stubs.spec.js
@@ -568,4 +568,26 @@ describeWithShallowAndMount('options.stub', mountingMethod => {
     expect(wrapper.find(ToStub).exists()).to.be.false
     expect(wrapper.find(Stub).exists()).to.be.true
   })
+
+  it('stubs globally registered components', () => {
+    const ChildComponent = {
+      template: '<div />',
+      props: ['propA'],
+      name: 'child-component'
+    }
+    const TestComponent = {
+      template: '<child-component prop-a="A" />'
+    }
+
+    Vue.component('child-component', ChildComponent)
+    const wrapper = mountingMethod(TestComponent, {
+      stubs: {
+        ChildComponent: true
+      }
+    })
+    const result = wrapper.find(ChildComponent)
+    expect(result.exists()).to.be.true
+    expect(result.props().propA).to.equal('A')
+    delete Vue.options.components['child-component']
+  })
 })


### PR DESCRIPTION
When specifying the components to stub, merge the globally registered components into the locally registered ones. (fix #1272)

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**
