### PR TITLE
Missing Vue import

### DIFF
--- a/docs/guides/testing-async-components.md
+++ b/docs/guides/testing-async-components.md
@@ -16,6 +16,13 @@ In practice, this means you have to use `Vue.nextTick()` to wait until Vue has p
 The easiest way to use `Vue.nextTick()` is to write your tests in an async function:
 
 ```js
+// import Vue at the top of file
+import Vue from 'vue'
+
+...
+...
+
+// inside test-suite, add this test case
 it('button click should increment the count text', async () => {
   expect(wrapper.text()).toContain('0')
   const button = wrapper.find('button')

--- a/docs/guides/testing-async-components.md
+++ b/docs/guides/testing-async-components.md
@@ -19,8 +19,7 @@ The easiest way to use `Vue.nextTick()` is to write your tests in an async funct
 // import Vue at the top of file
 import Vue from 'vue'
 
-...
-...
+// other code snippet...
 
 // inside test-suite, add this test case
 it('button click should increment the count text', async () => {


### PR DESCRIPTION
`import Vue` was missing in the code block.
when someone, new to vue tries to follow the guide, it becomes a pain-point to figure why test case which included `Vue.nextTick()` failed.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
