### PR TITLE
fix(test-utils): fix cancelable attribute in dom events

### DIFF
--- a/packages/test-utils/src/create-dom-event.js
+++ b/packages/test-utils/src/create-dom-event.js
@@ -32,7 +32,7 @@ function getOptions(eventParams) {
     ...options, // What the user passed in as the second argument to #trigger
 
     bubbles: meta.bubbles,
-    meta: meta.cancelable,
+    cancelable: meta.cancelable,
 
     // Any derived options should go here
     keyCode,

--- a/test/specs/create-dom-event.spec.js
+++ b/test/specs/create-dom-event.spec.js
@@ -1,0 +1,11 @@
+import createDOMEvent from '../../packages/test-utils/src/create-dom-event'
+import { isRunningPhantomJS } from '~resources/utils'
+import { itDoNotRunIf } from 'conditional-specs'
+
+describe('createDOMEvent', () => {
+  itDoNotRunIf(isRunningPhantomJS, 'returns cancelable event', () => {
+    const event = createDOMEvent('click', {})
+    expect(event.bubbles).to.equal(true)
+    expect(event.cancelable).to.equal(true)
+  })
+})


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

It's my first PR (big hello to everyone!) with a small fix to correctly assign `cancelable` attribute for events created via `trigger(event_name)` API in modern browsers.

I've tried to come with some tests for this bug:

```javascript
// test/specs/create-dom-event.spec.js
import createDOMEvent from '../../packages/test-utils/src/create-dom-event'

describe('createDOMEvent', () => {
  it('returns event', () => {
    const event = createDOMEvent('click', {})
    expect(event.bubbles).to.equal(true)
    expect(event.cancelable).to.equal(true)
  })
})
```

But it turns out that tests are run in PhantomJS and I believe it uses `createOldEvent` instead of `createEvent` which is not affected by this bug.

PS. How could I import `create-dom-event` file in such test to avoid all those `../../` in the beginning of the file's path?