### PR TITLE
fix #1377 string stubs dropping props

### DIFF
--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -116,7 +116,7 @@ describe('Foo', () => {
   it('renders a div', () => {
     const wrapper = mount(Foo, {
       stubs: {
-        Bar: '<div class="stubbed" />',
+        Bar: '<div class="stubbed" />', // DEPRECATED
         BarFoo: true,
         FooBar: Faz
       }

--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -116,9 +116,9 @@ describe('Foo', () => {
   it('renders a div', () => {
     const wrapper = mount(Foo, {
       stubs: {
-        Bar: '<div class="stubbed" />', // DEPRECATED
         BarFoo: true,
-        FooBar: Faz
+        FooBar: Faz,
+        Bar: { template: '<div class="stubbed" />' }
       }
     })
     expect(wrapper.contains('.stubbed')).toBe(true)
@@ -126,5 +126,9 @@ describe('Foo', () => {
   })
 })
 ```
+
+**Deprecation Notice:**
+
+When stubbing components, supplying a string (`ComponentToStub: '<div class="stubbed" />`) is no longer supported.
 
 - **See also:** [Wrapper](wrapper/)

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -210,10 +210,11 @@ const wrapper = mount(WrapperComp).find(ComponentUnderTest)
 
 - type: `{ [name: string]: Component | string | boolean } | Array<string>`
 
-Stubs child components. Can be an Array of component names to stub, or an object. If `stubs` is an Array, every stub is `<${component name}-stub>`.
+Stubs child components can be an Array of component names to stub, or an object. If `stubs` is an Array, every stub is `<${component name}-stub>`.
 
-Depercation note:
-If declaring an object, string stubs are now deprecated and will be removed in a future version.
+**Deprecation Notice:**
+
+When stubbing components, supplying a string (`ComponentToStub: '<div class="stubbed" />`) is no longer supported.
 
 Example:
 

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -208,9 +208,12 @@ const wrapper = mount(WrapperComp).find(ComponentUnderTest)
 
 ## stubs
 
-- type: `{ [name: string]: Component | boolean } | Array<string>`
+- type: `{ [name: string]: Component | string | boolean } | Array<string>`
 
 Stubs child components. Can be an Array of component names to stub, or an object. If `stubs` is an Array, every stub is `<${component name}-stub>`.
+
+Depercation note:
+If declaring an object, string stubs are now deprecated and will be removed in a future version.
 
 Example:
 

--- a/packages/shared/compile-template.js
+++ b/packages/shared/compile-template.js
@@ -4,19 +4,16 @@ import { compileToFunctions } from 'vue-template-compiler'
 import { componentNeedsCompiling } from './validators'
 import { throwError } from './util'
 
-export function compileFromString(str: string) {
-  if (!compileToFunctions) {
-    throwError(
-      `vueTemplateCompiler is undefined, you must pass ` +
-        `precompiled components if vue-template-compiler is ` +
-        `undefined`
-    )
-  }
-  return compileToFunctions(str)
-}
-
 export function compileTemplate(component: Component): void {
   if (component.template) {
+    if (!compileToFunctions) {
+      throwError(
+        `vueTemplateCompiler is undefined, you must pass ` +
+          `precompiled components if vue-template-compiler is ` +
+          `undefined`
+      )
+    }
+
     if (component.template.charAt('#') === '#') {
       var el = document.querySelector(component.template)
       if (!el) {
@@ -27,7 +24,10 @@ export function compileTemplate(component: Component): void {
       component.template = el.innerHTML
     }
 
-    Object.assign(component, compileToFunctions(component.template))
+    Object.assign(component, {
+      ...compileToFunctions(component.template),
+      name: component.name
+    })
   }
 
   if (component.components) {

--- a/test/resources/components/component-with-nested-childern-and-attributes.vue
+++ b/test/resources/components/component-with-nested-childern-and-attributes.vue
@@ -1,0 +1,24 @@
+<template>
+  <div>
+    <span>
+      <slot-component>
+        <template v-slot:newSyntax>
+          <child-component prop1="foobar" prop2="fizzbuzz" />
+        </template>
+      </slot-component>
+    </span>
+  </div>
+</template>
+
+<script>
+import ComponentWithProps from './component-with-props.vue'
+import ComponentWithSlots from './component-with-v-slot.vue'
+
+export default {
+  name: 'component-with-nested-children',
+  components: {
+    ChildComponent: ComponentWithProps,
+    SlotComponent: ComponentWithSlots
+  }
+}
+</script>

--- a/test/resources/components/component-with-nested-childern-and-attributes.vue
+++ b/test/resources/components/component-with-nested-childern-and-attributes.vue
@@ -1,24 +1,22 @@
 <template>
   <div>
     <span>
-      <slot-component>
-        <template v-slot:newSyntax>
-          <child-component prop1="foobar" prop2="fizzbuzz" />
-        </template>
-      </slot-component>
+      <slot-component prop1="foobar" prop2="fizzbuzz" />
+      <child-component prop1="foobar" prop2="fizzbuzz" />
+      <original-component prop1="foobar" prop2="fizzbuzz" />
     </span>
   </div>
 </template>
 
 <script>
 import ComponentWithProps from './component-with-props.vue'
-import ComponentWithSlots from './component-with-v-slot.vue'
 
 export default {
   name: 'component-with-nested-children',
   components: {
     ChildComponent: ComponentWithProps,
-    SlotComponent: ComponentWithSlots
+    SlotComponent: ComponentWithProps,
+    OriginalComponent: ComponentWithProps
   }
 }
 </script>

--- a/test/specs/mounting-options/stubs.spec.js
+++ b/test/specs/mounting-options/stubs.spec.js
@@ -596,34 +596,38 @@ describeWithShallowAndMount('options.stub', mountingMethod => {
     delete Vue.options.components['child-component']
   })
 
-  it('renders props in the element as attributes', () => {
-    const ComponentStub = { template: '<div id="component-stub" />' }
-    const StringStub = '<div id="string-stub" />'
-    const BooleanStub = true
+  itRunIf(
+    vueVersion >= 2.2,
+    'renders props in the element as attributes',
+    () => {
+      const ComponentStub = { template: '<div id="component-stub" />' }
+      const StringStub = '<div id="string-stub" />'
+      const BooleanStub = true
 
-    const wrapper = mountingMethod(ComponentWithNestedChildrenAndAttributes, {
-      stubs: {
-        SlotComponent: ComponentStub,
-        ChildComponent: StringStub,
-        OriginalComponent: BooleanStub
-      }
-    })
+      const wrapper = mountingMethod(ComponentWithNestedChildrenAndAttributes, {
+        stubs: {
+          SlotComponent: ComponentStub,
+          ChildComponent: StringStub,
+          OriginalComponent: BooleanStub
+        }
+      })
 
-    expect(wrapper.find('#component-stub').attributes()).to.eql({
-      id: 'component-stub',
-      prop1: 'foobar',
-      prop2: 'fizzbuzz'
-    })
-    expect(wrapper.find('#string-stub').attributes()).to.eql({
-      id: 'string-stub',
-      prop1: 'foobar',
-      prop2: 'fizzbuzz'
-    })
-    expect(wrapper.find('originalcomponent-stub').attributes()).to.eql({
-      prop1: 'foobar',
-      prop2: 'fizzbuzz'
-    })
-  })
+      expect(wrapper.find('#component-stub').attributes()).to.eql({
+        id: 'component-stub',
+        prop1: 'foobar',
+        prop2: 'fizzbuzz'
+      })
+      expect(wrapper.find('#string-stub').attributes()).to.eql({
+        id: 'string-stub',
+        prop1: 'foobar',
+        prop2: 'fizzbuzz'
+      })
+      expect(wrapper.find('originalcomponent-stub').attributes()).to.eql({
+        prop1: 'foobar',
+        prop2: 'fizzbuzz'
+      })
+    }
+  )
 
   it('warns when passing a string', () => {
     const StringComponent = '<div></div>'

--- a/test/specs/mounting-options/stubs.spec.js
+++ b/test/specs/mounting-options/stubs.spec.js
@@ -2,6 +2,7 @@ import ComponentWithChild from '~resources/components/component-with-child.vue'
 import ComponentWithNestedChildren from '~resources/components/component-with-nested-children.vue'
 import Component from '~resources/components/component.vue'
 import ComponentAsAClass from '~resources/components/component-as-a-class.vue'
+import ComponentWithNestedChildrenAndAttributes from '~resources/components/component-with-nested-childern-and-attributes.vue'
 import { createLocalVue, config } from '@vue/test-utils'
 import { config as serverConfig } from '@vue/server-test-utils'
 import Vue from 'vue'
@@ -589,5 +590,27 @@ describeWithShallowAndMount('options.stub', mountingMethod => {
     expect(result.exists()).to.be.true
     expect(result.props().propA).to.equal('A')
     delete Vue.options.components['child-component']
+  })
+
+  it.only('replaces component with a component and inherits attributes', () => {
+    const mounted = sandbox.stub()
+    const Stub = {
+      template: '<div id="SlotComponent"><slot name="newSyntax"/></div>',
+      mounted
+    }
+    const wrapper = mountingMethod(ComponentWithNestedChildrenAndAttributes, {
+      stubs: {
+        SlotComponent: Stub,
+        ChildComponent: '<div id="child-component"/>'
+      }
+    })
+
+    const childStub = wrapper.find('#child-component')
+    expect(wrapper.vm.$el.innerHTML).to.include('prop1="foobar"')
+    expect(wrapper.vm.$el.innerHTML).to.include('prop2="fizzbuzz"')
+    expect(childStub.attributes()).to.eql({
+      prop1: 'foobar',
+      prop2: 'fizzbuzz'
+    })
   })
 })


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch.
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

**Other information:**
This deprecates using a string stub.  It fixes a missing check on the compile function along with the dropping of the component name on `template` stubs.