### PR TITLE
Updated the Using `nextTick` section

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -122,7 +122,7 @@ In order to test that the counter text has updated, we need to learn about `next
 
 ### Using `nextTick`
 
-Anytime you make a change (in computed, data, vuex state, etc) which updates the DOM (ex. show a component from v-if), you should await the `nextTick` function before running the test. This is because Vue batches pending DOM updates and *applies them asynchronously* to prevent unnecessary re-renders caused by multiple data mutations.
+Anytime you make a change (in computed, data, vuex state, etc) which updates the DOM (ex. show a component from v-if), you should await the `nextTick` function before running the test. This is because Vue batches pending DOM updates and _applies them asynchronously_ to prevent unnecessary re-renders caused by multiple data mutations.
 
 _You can read more about asynchronous updates in the [Vue docs](https://vuejs.org/v2/guide/reactivity.html#Async-Update-Queue)_
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -136,7 +136,7 @@ it('button click should increment the count text', async () => {
   const button = wrapper.find('button')
   button.trigger('click')
   await wrapper.vm.$nextTick()
-	expect(wrapper.text()).toContain('1')
+  expect(wrapper.text()).toContain('1')
 })
 ```
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -122,21 +122,21 @@ In order to test that the counter text has updated, we need to learn about `next
 
 ### Using `nextTick`
 
-Vue batches pending DOM updates and applies them asynchronously to prevent unnecessary re-renders caused by multiple data mutations.
+Anytime you make a change (in computed, data, vuex state, etc) which updates the DOM (ex. show a component from v-if), you should await the `nextTick` function before running the test. This is because Vue batches pending DOM updates and *applies them asynchronously* to prevent unnecessary re-renders caused by multiple data mutations.
 
 _You can read more about asynchronous updates in the [Vue docs](https://vuejs.org/v2/guide/reactivity.html#Async-Update-Queue)_
 
-We need to use `Vue.nextTick()` to wait until Vue has performed the DOM update after we set a reactive property. In the counter example, setting the `count` property schedules a DOM update to run on the next tick.
+We need to use `wrapper.vm.$nextTick` to wait until Vue has performed the DOM update after we set a reactive property. In the counter example, setting the `count` property schedules a DOM update to run on the next tick.
 
-We can `await` `Vue.nextTick()` by writing the tests in an async function:
+We can `await` `wrapper.vm.$nextTick()` by writing the tests in an async function:
 
 ```js
 it('button click should increment the count text', async () => {
   expect(wrapper.text()).toContain('0')
   const button = wrapper.find('button')
   button.trigger('click')
-  await Vue.nextTick()
-  expect(wrapper.text()).toContain('1')
+  await wrapper.vm.$nextTick()
+	expect(wrapper.text()).toContain('1')
 })
 ```
 


### PR DESCRIPTION
1. The currrent description for Using `nextTick` was very confusing for a beginner so updated that for easier understanding.
2. The example provided for `nextTick` would have not worked unless the user would `import Vue` (which had not been stated anywhere so far, nor was necessary) so made changes for the example to work with `wrapper.vm.$nextTick()`.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
