### PR TITLE
fix(create-instance): revert stubbing of component _Ctor

### DIFF
--- a/packages/create-instance/create-component-stubs.js
+++ b/packages/create-instance/create-component-stubs.js
@@ -86,13 +86,9 @@ function resolveOptions(component, _Vue) {
     return {}
   }
 
-  if (isConstructor(component)) {
-    return component.options
-  }
-  const options = _Vue.extend(component).options
-  component._Ctor = {}
-
-  return options
+  return isConstructor(component)
+    ? component.options
+    : _Vue.extend(component).options
 }
 
 function getScopedSlotRenderFunctions(ctx: any): Array<string> {

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -93,7 +93,6 @@ export default function createInstance(
 
   // make sure all extends are based on this instance
   const Constructor = _Vue.extend(componentOptions).extend(instanceOptions)
-  componentOptions._Ctor = {}
   Constructor.options._base = _Vue
 
   const scopedSlots = createScopedSlots(options.scopedSlots, _Vue)

--- a/packages/create-instance/patch-create-element.js
+++ b/packages/create-instance/patch-create-element.js
@@ -21,7 +21,6 @@ function shouldExtend(component, _Vue) {
 function extend(component, _Vue) {
   const componentOptions = component.options ? component.options : component
   const stub = _Vue.extend(componentOptions)
-  componentOptions._Ctor = {}
   stub.options.$_vueTestUtils_original = component
   stub.options._base = _Vue
   return stub


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number) N/A
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included (please see Other Information below)

**Other information:**

Hello and thank you for these awesome utils, they make testing components a breeze!

This PR is a fix to address what is likely to be a very extreme edge-case. It reverts three small changes made between v1.0.0-beta.29 and v1.0.0-beta.30 that are preventing us from being able to upgrade. The offending changes were included in this commit https://github.com/vuejs/vue-test-utils/commit/0c07653ddff92fbbc8852256ee99e1c41476e6ab, but appear to not specifically be a requirement for that change.

When upgrading v1.0.0-beta.30, a few tests for our custom scrollable table started to fail. After some careful investigation, it appears the cause of the failure was the inability to support the DOM restructuring done in the directive. We do some shallow cloning of Nodes and move some parts around using standard DOM APIs including `insertBefore` and `append`.

I've tried to come up with the exact scenario to reproduce the issue, but I've come up short! Here's what we're doing in a nutshell:
* Wrapping the bootstrap-vue table component (https://bootstrap-vue.js.org/docs/components/table) with our own render function in order to customize the component more easily
* Including a directive that restructures the resulting DOM template to support a "sticky" header -- we're basically ripping the `<thead>` out and putting it in a new `<table>` alongside the component's rendered table. This approach works perfectly in browsers and with test-utils v1.0.0-beta.29 in jest.

I've attempted to recreate the scenario in a unit test, but I can't get the test to fail, so I'm confident I'm missing a key piece of knowledge around the inner workings of Vue. 

We tried a handful of approaches to satisfy the test utils, but kept getting stuck in the same spot: appending the `<thead>` into the new `<table>` simultaneously caused the `<thead>` and `<tbody>` to disappear from the original `<table>` and nothing to render in the new header `<table>`. Given that it worked in beta.29 and not in beta.30, I combed through the changelog and commits. Nothing jumped out, so I bisected commits between the two releases and finally identified the commit above.

I'm not entirely up to speed with how the `_Ctor` reference works in Vue, but the issue was resolved as soon as I removed the `_Ctor` stubs from the `component` reference. This revert did not cause any tests to fail, but I wish I could better reproduce the issue in testing to avoid having it re-introduced, as it's not an obvious issue.