### PR TITLE
Add v-slot support in scopedSlots property, fix #1457

### DIFF
--- a/test/specs/mounting-options/scopedSlots.spec.js
+++ b/test/specs/mounting-options/scopedSlots.spec.js
@@ -281,6 +281,29 @@ describeWithShallowAndMount('scopedSlots', mountingMethod => {
     }
   )
 
+  itDoNotRunIf.only(
+    vueVersion < 2.5,
+    'renders scoped slot with v-slot syntax',
+    async () => {
+      const TestComponent = {
+        data() {
+          return {
+            val: 25
+          }
+        },
+        render() {
+          return this.$scopedSlots.default({ val: this.val })
+        }
+      }
+      const wrapper = mountingMethod(TestComponent, {
+        scopedSlots: {
+          default: '<template v-slot:default="{ val }">{{ val }}</template>'
+        }
+      })
+      expect(wrapper.html()).to.contain(25)
+    }
+  )
+
   itDoNotRunIf(
     vueVersion < 2.5 || mountingMethod.name !== 'mount',
     'renders using localVue constructor',

--- a/test/specs/mounting-options/scopedSlots.spec.js
+++ b/test/specs/mounting-options/scopedSlots.spec.js
@@ -281,26 +281,46 @@ describeWithShallowAndMount('scopedSlots', mountingMethod => {
     }
   )
 
-  itDoNotRunIf.only(
-    vueVersion < 2.5,
+  itDoNotRunIf(
+    vueVersion < 2.6,
     'renders scoped slot with v-slot syntax',
-    async () => {
+    () => {
       const TestComponent = {
         data() {
           return {
             val: 25
           }
         },
-        render() {
-          return this.$scopedSlots.default({ val: this.val })
-        }
+        template: '<div><slot :val="val"/></div>'
       }
       const wrapper = mountingMethod(TestComponent, {
         scopedSlots: {
-          default: '<template v-slot:default="{ val }">{{ val }}</template>'
+          default:
+            '<template v-slot:default="{ val }"><p>{{ val }}</p></template>'
         }
       })
-      expect(wrapper.html()).to.contain(25)
+      expect(wrapper.html()).to.equal('<div>\n  <p>25</p>\n</div>')
+    }
+  )
+
+  itDoNotRunIf(
+    vueVersion < 2.6,
+    'renders scoped slot with shorthand v-slot syntax',
+    () => {
+      const TestComponent = {
+        data() {
+          return {
+            val: 25
+          }
+        },
+        template: '<div><slot :val="val"/></div>'
+      }
+      const wrapper = mountingMethod(TestComponent, {
+        scopedSlots: {
+          default: '<template #default="{ val }"><p>{{ val }}</p></template>'
+        }
+      })
+      expect(wrapper.html()).to.equal('<div>\n  <p>25</p>\n</div>')
     }
   )
 

--- a/test/specs/mounting-options/scopedSlots.spec.js
+++ b/test/specs/mounting-options/scopedSlots.spec.js
@@ -288,18 +288,22 @@ describeWithShallowAndMount('scopedSlots', mountingMethod => {
       const TestComponent = {
         data() {
           return {
-            val: 25
+            val: 25,
+            val2: 50
           }
         },
-        template: '<div><slot :val="val"/></div>'
+        template:
+          '<div><slot :val="val"/><slot name="named" :val="val2"/></div>'
       }
       const wrapper = mountingMethod(TestComponent, {
         scopedSlots: {
           default:
-            '<template v-slot:default="{ val }"><p>{{ val }}</p></template>'
+            '<template v-slot:default="{ val }"><p>{{ val }}</p></template>',
+          named:
+            '<template v-slot:named="prop"><p>{{ prop.val }}</p></template>'
         }
       })
-      expect(wrapper.html()).to.equal('<div>\n  <p>25</p>\n</div>')
+      expect(wrapper.html()).to.equal('<div>\n  <p>25</p>\n  <p>50</p>\n</div>')
     }
   )
 
@@ -310,17 +314,20 @@ describeWithShallowAndMount('scopedSlots', mountingMethod => {
       const TestComponent = {
         data() {
           return {
-            val: 25
+            val: 25,
+            val2: 50
           }
         },
-        template: '<div><slot :val="val"/></div>'
+        template:
+          '<div><slot :val="val"/><slot name="named" :val="val2"/></div>'
       }
       const wrapper = mountingMethod(TestComponent, {
         scopedSlots: {
-          default: '<template #default="{ val }"><p>{{ val }}</p></template>'
+          default: '<template #default="{ val }"><p>{{ val }}</p></template>',
+          named: '<template #named="prop"><p>{{ prop.val }}</p></template>'
         }
       })
-      expect(wrapper.html()).to.equal('<div>\n  <p>25</p>\n</div>')
+      expect(wrapper.html()).to.equal('<div>\n  <p>25</p>\n  <p>50</p>\n</div>')
     }
   )
 


### PR DESCRIPTION
This PR adds support for providing templates with `v-slot` and the `v-slot` shorthand syntax (`#default`). It also supports distructuring. closes #1457 

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**
