### PR TITLE
Vue School links

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -22,7 +22,10 @@ module.exports = {
     }
   },
   serviceWorker: true,
-  head: [['link', { rel: 'icon', href: '/favicon.png' }]],
+  head: [
+    ['link', { rel: 'icon', href: '/favicon.png' }],
+    ['link', { rel: 'stylesheet', href: '/vueschool.css' }]
+  ],
   theme: 'vue',
   themeConfig: {
     algolia: {

--- a/docs/.vuepress/public/vueschool.css
+++ b/docs/.vuepress/public/vueschool.css
@@ -4,6 +4,7 @@
   border-radius: 2px;
   color: #486491;
   position: relative;
+  display: flex;
 }
 
 .vueschool a {
@@ -18,7 +19,7 @@
   display: block;
   width: 30px;
   height: 30px;
-  top: -5px;
+  top: calc(50% - 15px);
   left: -4px;
   border-radius: 50%;
   background-color: #73abfe;
@@ -30,7 +31,7 @@
   display: block;
   width: 0;
   height: 0;
-  top: 5px;
+  top: calc(50% - 5px);
   left: 8px;
   border-top: 5px solid transparent;
   border-bottom: 5px solid transparent;

--- a/docs/.vuepress/public/vueschool.css
+++ b/docs/.vuepress/public/vueschool.css
@@ -1,0 +1,38 @@
+.vueschool {
+  background-color: #e7ecf3;
+  padding: 1em 1.25em;
+  border-radius: 2px;
+  color: #486491;
+  position: relative;
+}
+
+.vueschool a {
+  color: #486491 !important;
+  position: relative;
+  padding-left: 36px;
+}
+
+.vueschool a:before {
+  content: '';
+  position: absolute;
+  display: block;
+  width: 30px;
+  height: 30px;
+  top: -5px;
+  left: -4px;
+  border-radius: 50%;
+  background-color: #73abfe;
+}
+
+.vueschool a:after {
+  content: '';
+  position: absolute;
+  display: block;
+  width: 0;
+  height: 0;
+  top: 5px;
+  left: 8px;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 8px solid #fff;
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 Vue Test Utils is the official unit testing utility library for Vue.js.
 
+<div class="vueschool"><a href="https://vueschool.io/courses/learn-how-to-test-vuejs-components?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how to use Vue Test Utils to test Vue.js Components with Vue School">Learn how to test Vue.js components with Vue School</a></div>
+
 - [Guides](./guides/)
   - [Getting Started](./guides/getting-started.md)
   - [Common Tips](guides/common-tips.md)

--- a/docs/api/wrapper/README.md
+++ b/docs/api/wrapper/README.md
@@ -4,6 +4,8 @@ Vue Test Utils is a wrapper based API.
 
 A `Wrapper` is an object that contains a mounted component or vnode and methods to test the component or vnode.
 
+<div class="vueschool"><a href="https://vueschool.io/lessons/the-wrapper-object?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn about the Wrapper object in a FREE video lesson from Vue School">Learn about the Wrapper object in a FREE video lesson from Vue School</a></div>
+
 ## Properties
 
 ### `vm`

--- a/docs/guides/common-tips.md
+++ b/docs/guides/common-tips.md
@@ -29,6 +29,8 @@ wrapper.vm // the mounted Vue instance
 
 ### Lifecycle Hooks
 
+<div class="vueschool" style="margin-top:1em;"><a href="https://vueschool.io/lessons/learn-how-to-test-vuejs-lifecycle-methods?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how to use Vue Test Utils to test Vue.js Lifecycle Hooks with Vue School">Learn how to test lifecycle methods and intervals with Vue School</a></div>
+
 When using either the `mount` or `shallowMount` methods, you can expect your component to respond to all lifecycle events. However, it is important to note that `beforeDestroy` and `destroyed` _will not be triggered_ unless the component is manually destroyed using `Wrapper.destroy()`.
 
 Additionally, the component will not be automatically destroyed at the end of each spec, and it is up to the user to stub or manually clean up tasks that will continue to run (`setInterval` or `setTimeout`, for example) before the end of each spec.

--- a/docs/guides/dom-events.md
+++ b/docs/guides/dom-events.md
@@ -1,5 +1,7 @@
 ## Testing Key, Mouse and other DOM events
 
+<div class="vueschool"><a href="https://vueschool.io/lessons/traversing-the-dom?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn to traverse and interact with the DOM with a free video lesson from Vue School">Learn to traverse and interact with the DOM with a free lesson on Vue School</a></div>
+
 ### Trigger events
 
 The `Wrapper` exposes a `trigger` method. It can be used to trigger DOM events.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,5 +1,7 @@
 ## Getting Started
 
+<div class="vueschool"><a href="https://vueschool.io/lessons/installing-vue-test-utils?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how to get started with Vue Test Utils, Jest, and testing Vue Components with Vue School">Learn how to get started with Vue Test Utils, Jest, and testing Vue Components</a></div>
+
 ### Setup
 
 To get a quick taste of using Vue Test Utils, clone our demo repository with basic setup and install the dependencies:

--- a/docs/guides/testing-single-file-components-with-jest.md
+++ b/docs/guides/testing-single-file-components-with-jest.md
@@ -4,6 +4,8 @@
 
 Jest is a test runner developed by Facebook, aiming to deliver a battery-included unit testing solution. You can learn more about Jest on its [official documentation](https://jestjs.io/).
 
+<div class="vueschool"><a href="https://vueschool.io/courses/learn-how-to-test-vuejs-components?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how to use Jest and Vue Test Utils to test Single File Components with Vue School">Learn how to use Jest to test Single File Components with Vue School</a></div>
+
 #### Setting up Jest
 
 We will assume you are starting with a setup that already has webpack, vue-loader and Babel properly configured - e.g. the `webpack-simple` template scaffolded by `vue-cli`.

--- a/docs/guides/using-with-vuex.md
+++ b/docs/guides/using-with-vuex.md
@@ -2,6 +2,8 @@
 
 In this guide, we'll see how to test Vuex in components with Vue Test Utils, and how to approach testing a Vuex store.
 
+<div class="vueschool"><a href="https://vueschool.io/lessons/how-to-test-vuejs-component-with-vuex-store?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how to test that a Vuex Store is injected into a component with a free video lesson on Vue School">Learn how to test that a Vuex Store is injected into a component with Vue School</a></div>
+
 ## Testing Vuex in components
 
 ### Mocking Actions


### PR DESCRIPTION
*What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

This PR adds links to free lessons from the Testing Vue.js Components course on Vue School.

We have made premium lessons free to accompany the official docs. Each lesson makes sense and is valuable on its own. It's not required to have watched the previous or following lessons.

The course teacher is Roman Kuba.

The PR also adds the blue box style from Vuejs.org. I have tweaked the CSS to have a better appearance on smaller screens.


**Lessons**
[Testing Vue.js Component course](https://vueschool.io/courses/learn-how-to-test-vuejs-components)
[Installing Vue Test Utils lesson](https://vueschool.io/lessons/installing-vue-test-utils)
[Wrapper Object lesson](https://vueschool.io/lessons/the-wrapper-object?)
[Testing Lifecycle Hooks lesson](https://vueschool.io/lessons/learn-how-to-test-vuejs-lifecycle-methods)
[Traversing The DOM lesson](https://vueschool.io/lessons/traversing-the-dom)
[Test Vuex Store Injection lesson](https://vueschool.io/lessons/how-to-test-vuejs-component-with-vuex-store)

**Visuals**
[Screenshots of the placements can be seen here](https://imgur.com/a/7PdjVZG)


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
