### PR TITLE
docs(guides): remove links to deprecated examples

### DIFF
--- a/docs/guides/choosing-a-test-runner.md
+++ b/docs/guides/choosing-a-test-runner.md
@@ -41,8 +41,8 @@ Read the following guides for different setups:
 ### Resources
 
 - [Test runner performance comparison](https://github.com/eddyerburgh/vue-unit-test-perf-comparison)
-- [Example project with Jest](https://github.com/vuejs/vue-test-utils-jest-example)
-- [Example project with Mocha](https://github.com/vuejs/vue-test-utils-mocha-webpack-example)
+- [Example project with Jest](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest)
+- [Example project with Mocha](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-mocha)
 - [Example project with tape](https://github.com/eddyerburgh/vue-test-utils-tape-example)
 - [Example project with AVA](https://github.com/eddyerburgh/vue-test-utils-ava-example)
 - [tyu - Delightful web testing by egoist](https://github.com/egoist/tyu)

--- a/docs/guides/testing-single-file-components-with-jest.md
+++ b/docs/guides/testing-single-file-components-with-jest.md
@@ -1,6 +1,6 @@
 ## Testing Single-File Components with Jest
 
-> An example project for this setup is available on [GitHub](https://github.com/vuejs/vue-test-utils-jest-example).
+> An example project for this setup is available on [GitHub](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest).
 
 Jest is a test runner developed by Facebook, aiming to deliver a battery-included unit testing solution. You can learn more about Jest on its [official documentation](https://jestjs.io/).
 
@@ -205,7 +205,7 @@ Then configure it in `package.json`:
 
 ### Resources
 
-- [Example project for this setup](https://github.com/vuejs/vue-test-utils-jest-example)
+- [Example project for this setup](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest)
 - [Examples and slides from Vue Conf 2017](https://github.com/codebryo/vue-testing-with-jest-conf17)
 - [Jest](https://jestjs.io/)
 - [Babel preset env](https://github.com/babel/babel-preset-env)

--- a/docs/ja/guides/choosing-a-test-runner.md
+++ b/docs/ja/guides/choosing-a-test-runner.md
@@ -41,7 +41,7 @@ require('jsdom-global')()
 ### リソース
 
 - [テストランナの性能比較](https://github.com/eddyerburgh/vue-unit-test-perf-comparison)
-- [Jest のプロジェクト例](https://github.com/vuejs/vue-test-utils-jest-example)
-- [Mocha のプロジェクト例](https://github.com/vuejs/vue-test-utils-mocha-webpack-example)
+- [Jest のプロジェクト例](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest)
+- [Mocha のプロジェクト例](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-mocha)
 - [tape のプロジェクト例](https://github.com/eddyerburgh/vue-test-utils-tape-example)
 - [AVA のプロジェクト例](https://github.com/eddyerburgh/vue-test-utils-ava-example)

--- a/docs/ja/guides/testing-single-file-components-with-jest.md
+++ b/docs/ja/guides/testing-single-file-components-with-jest.md
@@ -1,6 +1,6 @@
 ## Jest を使用した単一ファイルコンポーネントのテスト
 
-> このセットアップのサンプルプロジェクトは、 [GitHub](https://github.com/vuejs/vue-test-utils-jest-example) にあります。
+> このセットアップのサンプルプロジェクトは、 [GitHub](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest) にあります。
 
 Jest は Facebook が開発したテストランナであり、ユニットテストソリューションの提供を目指しています。 Jest の詳細については、[公式ドキュメント](https://jestjs.io/)を参照してください。
 
@@ -201,7 +201,7 @@ npm install --save-dev jest-serializer-vue
 
 ### リソース
 
-- [このセットアップのプロジェクト例](https://github.com/vuejs/vue-test-utils-jest-example)
+- [このセットアップのプロジェクト例](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest)
 - [Vue Conf 2017 のスライド](https://github.com/codebryo/vue-testing-with-jest-conf17)
 - [Jest](https://jestjs.io/)
 - [Babel preset env](https://github.com/babel/babel-preset-env)

--- a/docs/ja/guides/testing-single-file-components-with-mocha-webpack.md
+++ b/docs/ja/guides/testing-single-file-components-with-mocha-webpack.md
@@ -1,6 +1,6 @@
 ### Mocha + webpack による単一ファイルコンポーネントのテスト
 
-> このセットアップのサンプルプロジェクトは、 [GitHub](https://github.com/vuejs/vue-test-utils-mocha-webpack-example) にあります。
+> このセットアップのサンプルプロジェクトは、 [GitHub](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-mocha) にあります。
 
 単一ファイルコンポーネントをテストするためのもう一つの戦略は、webpack を使用してすべてのテストをコンパイルし、それをテストランナで実行することです。このアプローチの利点は、すべての webpack と `vue-loader` 機能を完全にサポートしていることです。ソースコードに妥協する必要はありません。
 
@@ -176,7 +176,7 @@ mocha-webpack にコードカバレッジをセットしたい場合は、 [the 
 
 ### リソース
 
-- [この設定のプロジェクトの例](https://github.com/vuejs/vue-test-utils-mocha-webpack-example)
+- [この設定のプロジェクトの例](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-mocha)
 - [Mocha](https://mochajs.org/)
 - [mocha-webpack](http://zinserjan.github.io/mocha-webpack/)
 - [Chai](http://chaijs.com/)

--- a/docs/ru/guides/choosing-a-test-runner.md
+++ b/docs/ru/guides/choosing-a-test-runner.md
@@ -41,8 +41,8 @@ require('jsdom-global')()
 ### Дополнительные ресурсы
 
 - [Сравнение производительности программ для запуска тестов](https://github.com/eddyerburgh/vue-unit-test-perf-comparison)
-- [Пример проекта с Jest](https://github.com/vuejs/vue-test-utils-jest-example)
-- [Пример проекта с Mocha](https://github.com/vuejs/vue-test-utils-mocha-webpack-example)
+- [Пример проекта с Jest](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest)
+- [Пример проекта с Mocha](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-mocha)
 - [Пример проекта с tape](https://github.com/eddyerburgh/vue-test-utils-tape-example)
 - [Пример проекта с AVA](https://github.com/eddyerburgh/vue-test-utils-ava-example)
 - [tyu — Восхитительное веб-тестирование от egoist](https://github.com/egoist/tyu)

--- a/docs/ru/guides/testing-single-file-components-with-jest.md
+++ b/docs/ru/guides/testing-single-file-components-with-jest.md
@@ -1,6 +1,6 @@
 ## Тестирование однофайловых компонентов с Jest
 
-> Пример проекта для этой конфигурации доступен на [GitHub](https://github.com/vuejs/vue-test-utils-jest-example).
+> Пример проекта для этой конфигурации доступен на [GitHub](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest).
 
 Jest — это программа для запуска тестов, разработанная Facebook, направленная на предоставление функционального решения для модульного тестирования. Вы можете узнать больше о Jest в [официальной документации](https://jestjs.io/).
 
@@ -203,7 +203,7 @@ npm install --save-dev jest-serializer-vue
 
 ### Ресурсы
 
-- [Пример проекта для этой конфигурации](https://github.com/vuejs/vue-test-utils-jest-example)
+- [Пример проекта для этой конфигурации](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest)
 - [Примеры и слайды с Vue Conf 2017](https://github.com/codebryo/vue-testing-with-jest-conf17)
 - [Jest](https://jestjs.io/)
 - [Babel preset env](https://github.com/babel/babel-preset-env)

--- a/docs/ru/guides/testing-single-file-components-with-mocha-webpack.md
+++ b/docs/ru/guides/testing-single-file-components-with-mocha-webpack.md
@@ -1,6 +1,6 @@
 ## Тестирование однофайловых компонентов с Mocha и webpack
 
-> Пример проекта для этой конфигурации доступен на [GitHub](https://github.com/vuejs/vue-test-utils-mocha-webpack-example).
+> Пример проекта для этой конфигурации доступен на [GitHub](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-mocha).
 
 Другая стратегия тестирования однофайловых компонентов заключается в компиляции всех наших тестов с помощью webpack, а затем программой для запуска тестов. Преимущество такого подхода заключается в том, что он даёт нам полную поддержку всех функций webpack и `vue-loader`, поэтому нам не нужно идти на компромиссы в нашем исходном коде.
 
@@ -176,7 +176,7 @@ npm run test
 
 ### Ресурсы
 
-- [Пример проекта для этой настройки](https://github.com/vuejs/vue-test-utils-mocha-webpack-example)
+- [Пример проекта для этой настройки](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-mocha)
 - [Mocha](https://mochajs.org/)
 - [mocha-webpack](http://zinserjan.github.io/mocha-webpack/)
 - [Chai](http://chaijs.com/)

--- a/docs/zh/guides/choosing-a-test-runner.md
+++ b/docs/zh/guides/choosing-a-test-runner.md
@@ -41,8 +41,8 @@ Vue 的单文件组件在它们运行于 Node 或浏览器之前是需要预编�
 ### 相关资料
 
 - [测试运行器性能比拼](https://github.com/eddyerburgh/vue-unit-test-perf-comparison)
-- [使用 Jest 的示例工程](https://github.com/vuejs/vue-test-utils-jest-example)
-- [使用 Mocha 的示例工程](https://github.com/vuejs/vue-test-utils-mocha-webpack-example)
+- [使用 Jest 的示例工程](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest)
+- [使用 Mocha 的示例工程](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-mocha)
 - [使用 tape 的示例工程](https://github.com/eddyerburgh/vue-test-utils-tape-example)
 - [使用 AVA 的示例工程](https://github.com/eddyerburgh/vue-test-utils-ava-example)
 - [tyu - Delightful web testing by egoist](https://github.com/egoist/tyu)

--- a/docs/zh/guides/testing-single-file-components-with-jest.md
+++ b/docs/zh/guides/testing-single-file-components-with-jest.md
@@ -1,6 +1,6 @@
 ## 用 Jest 测试单文件组件
 
-> 我们在 [GitHub](https://github.com/vuejs/vue-test-utils-jest-example) 上放有一个关于这些设置的示例工程。
+> 我们在 [GitHub](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest) 上放有一个关于这些设置的示例工程。
 
 Jest 是一个由 Facebook 开发的测试运行器，致力于提供一个“bettery-included”单元测试解决方案。你可以在其[官方文档](https://jestjs.io/)学习到更多 Jest 的知识。
 
@@ -201,7 +201,7 @@ npm install --save-dev jest-serializer-vue
 
 ### 相关资料
 
-- [该设置的示例工程](https://github.com/vuejs/vue-test-utils-jest-example)
+- [该设置的示例工程](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest)
 - [Vue Conf 2017 中的示例和幻灯片](https://github.com/codebryo/vue-testing-with-jest-conf17)
 - [Jest](https://jestjs.io/)
 - [Babel preset env](https://github.com/babel/babel-preset-env)

--- a/docs/zh/guides/testing-single-file-components-with-mocha-webpack.md
+++ b/docs/zh/guides/testing-single-file-components-with-mocha-webpack.md
@@ -1,6 +1,6 @@
 ## 用 Mocha 和 webpack 测试单文件组件
 
-> 我们在 [GitHub](https://github.com/vuejs/vue-test-utils-mocha-webpack-example) 上放有一个关于这些设置的示例工程。
+> 我们在 [GitHub](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-mocha) 上放有一个关于这些设置的示例工程。
 
 另一个测试单文件组件的策略是通过 webpack 编译所有的测试文件然后在测试运行器中运行。这样做的好处是可以完全支持所有 webpack 和 `vue-loader` 的功能，所以我们不必对我们的源代码做任何妥协。
 
@@ -177,7 +177,7 @@ npm run test
 
 ### 相关资料
 
-- [该设置的示例工程](https://github.com/vuejs/vue-test-utils-mocha-webpack-example)
+- [该设置的示例工程](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-mocha)
 - [Mocha](https://mochajs.org/)
 - [mocha-webpack](http://zinserjan.github.io/mocha-webpack/)
 - [Chai](http://chaijs.com/)

--- a/packages/server-test-utils/README.md
+++ b/packages/server-test-utils/README.md
@@ -22,8 +22,8 @@ Refer to [documentation](https://vue-test-utils.vuejs.org/)
 
 ## Examples
 
-- [example with Jest](https://github.com/vuejs/vue-test-utils-jest-example)
-- [example with Mocha](https://github.com/vuejs/vue-test-utils-mocha-webpack-example)
+- [example with Jest](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest)
+- [example with Mocha](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-mocha)
 - [example with tape](https://github.com/eddyerburgh/vue-test-utils-tape-example)
 - [example with AVA](https://github.com/eddyerburgh/vue-test-utils-ava-example)
 

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -22,8 +22,8 @@ Refer to the [documentation](https://vue-test-utils.vuejs.org/)
 
 ## Examples
 
-- [example with Jest](https://github.com/vuejs/vue-test-utils-jest-example)
-- [example with Mocha](https://github.com/vuejs/vue-test-utils-mocha-webpack-example)
+- [example with Jest](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest)
+- [example with Mocha](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-mocha)
 - [example with tape](https://github.com/eddyerburgh/vue-test-utils-tape-example)
 - [example with AVA](https://github.com/eddyerburgh/vue-test-utils-ava-example)
 


### PR DESCRIPTION
## Description

The [Jest](https://github.com/vuejs/vue-test-utils-jest-example) and [Mocha](https://github.com/vuejs/vue-test-utils-mocha-webpack-example) examples in the docs have been deprecated by the vue-test-utils maintainers. The READMEs in those deprecated examples just point to the [Vue CLI website](https://cli.vuejs.org/). 

This commit will update the URLs in the docs to point to the Vue CLI plugins [cli-plugin-unit-jest](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-jest) and [cli-plugin-unit-mocha](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/cli-plugin-unit-mocha).

## Checklist

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: update to docs

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
