### PR TITLE
Release: 1.0.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "1.0.0-beta.33"
+  "version": "1.0.0"
 }

--- a/packages/test-utils/dist/vue-test-utils.umd.js
+++ b/packages/test-utils/dist/vue-test-utils.umd.js
@@ -1,8 +1,8 @@
 (function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('vue'), require('vue-template-compiler')) :
-  typeof define === 'function' && define.amd ? define(['exports', 'vue', 'vue-template-compiler'], factory) :
-  (global = global || self, factory(global.VueTestUtils = {}, global.Vue, global.VueTemplateCompiler));
-}(this, (function (exports, Vue, vueTemplateCompiler) { 'use strict';
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('vue'), require('vue-template-compiler'), require('@vue/test-utils')) :
+  typeof define === 'function' && define.amd ? define(['exports', 'vue', 'vue-template-compiler', '@vue/test-utils'], factory) :
+  (global = global || self, factory(global.VueTestUtils = {}, global.Vue, global.VueTemplateCompiler, global.testUtils));
+}(this, (function (exports, Vue, vueTemplateCompiler, testUtils) { 'use strict';
 
   Vue = Vue && Vue.hasOwnProperty('default') ? Vue['default'] : Vue;
 
@@ -1702,6 +1702,27 @@
   var semver_41 = semver.intersects;
   var semver_42 = semver.coerce;
 
+  var NAME_SELECTOR = 'NAME_SELECTOR';
+  var COMPONENT_SELECTOR = 'COMPONENT_SELECTOR';
+  var REF_SELECTOR = 'REF_SELECTOR';
+  var DOM_SELECTOR = 'DOM_SELECTOR';
+  var INVALID_SELECTOR = 'INVALID_SELECTOR';
+
+  var VUE_VERSION = Number(
+    ((Vue.version.split('.')[0]) + "." + (Vue.version.split('.')[1]))
+  );
+
+  var FUNCTIONAL_OPTIONS =
+    VUE_VERSION >= 2.5 ? 'fnOptions' : 'functionalOptions';
+
+  var BEFORE_RENDER_LIFECYCLE_HOOK = semver.gt(Vue.version, '2.1.8')
+    ? 'beforeCreate'
+    : 'beforeMount';
+
+  var CREATE_ELEMENT_ALIAS = semver.gt(Vue.version, '2.1.5')
+    ? '_c'
+    : '_h';
+
   // 
 
   function throwError(msg) {
@@ -1785,6 +1806,27 @@
     return 'change'
   }
 
+  /**
+   * Normalize nextTick to return a promise for all Vue 2 versions.
+   * Vue < 2.1 does not return a Promise from nextTick
+   * @return {Promise<R>}
+   */
+  function nextTick() {
+    if (VUE_VERSION > 2) { return Vue.nextTick() }
+    return new Promise(function (resolve) {
+      Vue.nextTick(resolve);
+    })
+  }
+
+  function warnDeprecated(method, fallback) {
+    if ( fallback === void 0 ) fallback = '';
+
+    if (!testUtils.config.showDeprecationWarnings) { return }
+    var msg = method + " is deprecated and will removed in the next major version";
+    if (fallback) { msg += " " + fallback; }
+    warn(msg);
+  }
+
   // 
 
   function addMocks(
@@ -1838,27 +1880,6 @@
       }
     });
   }
-
-  var NAME_SELECTOR = 'NAME_SELECTOR';
-  var COMPONENT_SELECTOR = 'COMPONENT_SELECTOR';
-  var REF_SELECTOR = 'REF_SELECTOR';
-  var DOM_SELECTOR = 'DOM_SELECTOR';
-  var INVALID_SELECTOR = 'INVALID_SELECTOR';
-
-  var VUE_VERSION = Number(
-    ((Vue.version.split('.')[0]) + "." + (Vue.version.split('.')[1]))
-  );
-
-  var FUNCTIONAL_OPTIONS =
-    VUE_VERSION >= 2.5 ? 'fnOptions' : 'functionalOptions';
-
-  var BEFORE_RENDER_LIFECYCLE_HOOK = semver.gt(Vue.version, '2.1.8')
-    ? 'beforeCreate'
-    : 'beforeMount';
-
-  var CREATE_ELEMENT_ALIAS = semver.gt(Vue.version, '2.1.5')
-    ? '_c'
-    : '_h';
 
   function addStubs(_Vue, stubComponents) {
     var obj;
@@ -1981,6 +2002,14 @@
 
   function isPlainObject(c) {
     return Object.prototype.toString.call(c) === '[object Object]'
+  }
+
+  function isHTMLElement(c) {
+    if (typeof HTMLElement === 'undefined') {
+      return false
+    }
+    // eslint-disable-next-line no-undef
+    return c instanceof HTMLElement
   }
 
   function makeMap(str, expectsLowerCase) {
@@ -2369,7 +2398,7 @@
 
   // DEPRECATED: converts string stub to template stub.
   function createStubFromString(templateString, name) {
-    warn('String stubs are deprecated and will be removed in future versions');
+    warnDeprecated('Using a string for stubs');
 
     if (templateContainsComponent(templateString, name)) {
       throwError('options.stub cannot contain a circular reference');
@@ -2964,6 +2993,10 @@
   ) {
     var mocks = (getOption(options.mocks, config.mocks));
     var methods = (getOption(options.methods, config.methods));
+    if (methods && Object.keys(methods).length) {
+      warnDeprecated('overwriting methods via the `methods` property');
+    }
+
     var provide = (getOption(options.provide, config.provide));
     var stubs = (getStubs(options.stubs, config.stubs));
     // $FlowIgnore
@@ -2975,11 +3008,16 @@
   }
 
   var config = {
-    stubs: {},
+    stubs: {
+      transition: true,
+      'transition-group': true
+    },
     mocks: {},
     methods: {},
     provide: {},
-    silent: true
+    silent: true,
+    showDeprecationWarnings:
+       true
   };
 
   // 
@@ -8561,6 +8599,15 @@
     );
   };
 
+  WrapperArray.prototype.overview = function overview () {
+    this.throwErrorIfWrappersIsEmpty('overview()');
+
+    throwError(
+      "overview() must be called on a single wrapper, use at(i) " +
+        "to access a wrapper"
+    );
+  };
+
   WrapperArray.prototype.props = function props () {
     this.throwErrorIfWrappersIsEmpty('props');
 
@@ -8817,6 +8864,14 @@
       ("find did not return " + (buildSelectorString(
         this.selector
       )) + ", cannot call name() on empty Wrapper")
+    );
+  };
+
+  ErrorWrapper.prototype.overview = function overview () {
+    throwError(
+      ("find did not return " + (buildSelectorString(
+        this.selector
+      )) + ", cannot call overview() on empty Wrapper")
     );
   };
 
@@ -10327,6 +10382,10 @@
    * Checks if wrapper contains provided selector.
    */
   Wrapper.prototype.contains = function contains (rawSelector) {
+    warnDeprecated(
+      'contains',
+      'Use `wrapper.find`, `wrapper.findComponent` or `wrapper.get` instead'
+    );
     var selector = getSelector(rawSelector, 'contains');
     var nodes = find(this.rootNode, this.vm, selector);
     return nodes.length > 0
@@ -10373,6 +10432,7 @@
    * Returns an Array containing custom events emitted by the Wrapper vm
    */
   Wrapper.prototype.emittedByOrder = function emittedByOrder () {
+    warnDeprecated('emittedByOrder', 'Use `wrapper.emitted` instead');
     if (!this._emittedByOrder && !this.vm) {
       throwError(
         "wrapper.emittedByOrder() can only be called on a Vue instance"
@@ -10408,11 +10468,17 @@
   };
 
   /**
-   * Finds first node in tree of the current wrapper that
+   * Finds first DOM node in tree of the current wrapper that
    * matches the provided selector.
    */
   Wrapper.prototype.find = function find$1 (rawSelector) {
     var selector = getSelector(rawSelector, 'find');
+    if (selector.type !== DOM_SELECTOR) {
+      warnDeprecated(
+        'finding components with `find`',
+        'Use `findComponent` instead'
+      );
+    }
     var node = find(this.rootNode, this.vm, selector)[0];
 
     if (!node) {
@@ -10425,13 +10491,68 @@
   };
 
   /**
-   * Finds node in tree of the current wrapper that matches
+   * Finds DOM elements in tree of the current wrapper that matches
    * the provided selector.
    */
   Wrapper.prototype.findAll = function findAll (rawSelector) {
       var this$1 = this;
 
     var selector = getSelector(rawSelector, 'findAll');
+    if (selector.type !== DOM_SELECTOR) {
+      warnDeprecated(
+        'finding components with `findAll`',
+        'Use `findAllComponents` instead'
+      );
+    }
+    var nodes = find(this.rootNode, this.vm, selector);
+    var wrappers = nodes.map(function (node) {
+      // Using CSS Selector, returns a VueWrapper instance if the root element
+      // binds a Vue instance.
+      var wrapper = createWrapper(node, this$1.options);
+      wrapper.selector = rawSelector;
+      return wrapper
+    });
+
+    var wrapperArray = new WrapperArray(wrappers);
+    wrapperArray.selector = rawSelector;
+    return wrapperArray
+  };
+
+  /**
+   * Finds first component in tree of the current wrapper that
+   * matches the provided selector.
+   */
+  Wrapper.prototype.findComponent = function findComponent (rawSelector) {
+    var selector = getSelector(rawSelector, 'findComponent');
+    if (selector.type === DOM_SELECTOR) {
+      throwError(
+        'findComponent requires a Vue constructor or valid find object. If you are searching for DOM nodes, use `find` instead'
+      );
+    }
+    var node = find(this.rootNode, this.vm, selector)[0];
+
+    if (!node) {
+      return new ErrorWrapper(rawSelector)
+    }
+
+    var wrapper = createWrapper(node, this.options);
+    wrapper.selector = rawSelector;
+    return wrapper
+  };
+
+  /**
+   * Finds components in tree of the current wrapper that matches
+   * the provided selector.
+   */
+  Wrapper.prototype.findAllComponents = function findAllComponents (rawSelector) {
+      var this$1 = this;
+
+    var selector = getSelector(rawSelector, 'findAll');
+    if (selector.type === DOM_SELECTOR) {
+      throwError(
+        'findAllComponent requires a Vue constructor or valid find object. If you are searching for DOM nodes, use `find` instead'
+      );
+    }
     var nodes = find(this.rootNode, this.vm, selector);
     var wrappers = nodes.map(function (node) {
       // Using CSS Selector, returns a VueWrapper instance if the root element
@@ -10457,6 +10578,7 @@
    * Checks if node matches selector
    */
   Wrapper.prototype.is = function is (rawSelector) {
+    warnDeprecated('is', 'Use element.tagName instead');
     var selector = getSelector(rawSelector, 'is');
 
     if (selector.type === REF_SELECTOR) {
@@ -10470,6 +10592,10 @@
    * Checks if node is empty
    */
   Wrapper.prototype.isEmpty = function isEmpty () {
+    warnDeprecated(
+      'isEmpty',
+      'Consider a custom matcher such as those provided in jest-dom: https://github.com/testing-library/jest-dom#tobeempty'
+    );
     if (!this.vnode) {
       return this.element.innerHTML === ''
     }
@@ -10494,6 +10620,10 @@
    * Checks if node is visible
    */
   Wrapper.prototype.isVisible = function isVisible () {
+    warnDeprecated(
+      'isEmpty',
+      "Consider a custom matcher such as those provided in jest-dom: https://github.com/testing-library/jest-dom#tobevisible"
+    );
     var element = this.element;
     while (element) {
       if (
@@ -10514,6 +10644,7 @@
    * Checks if wrapper is a vue instance
    */
   Wrapper.prototype.isVueInstance = function isVueInstance () {
+    warnDeprecated("isVueInstance");
     return !!this.vm
   };
 
@@ -10521,6 +10652,8 @@
    * Returns name of component, or tag name if node is not a Vue component
    */
   Wrapper.prototype.name = function name () {
+    warnDeprecated("name");
+
     if (this.vm) {
       return (
         this.vm.$options.name ||
@@ -10534,6 +10667,86 @@
     }
 
     return this.vnode.tag
+  };
+
+  /**
+   * Prints a simple overview of the wrapper current state
+   * with useful information for debugging
+   */
+  Wrapper.prototype.overview = function overview () {
+      var this$1 = this;
+
+    warnDeprecated("overview");
+
+    if (!this.isVueInstance()) {
+      throwError("wrapper.overview() can only be called on a Vue instance");
+    }
+
+    var identation = 4;
+    var formatJSON = function (json, replacer) {
+          if ( replacer === void 0 ) replacer = null;
+
+          return JSON.stringify(json, replacer, identation).replace(/"/g, '');
+      };
+
+    var visibility = this.isVisible() ? 'Visible' : 'Not visible';
+
+    var html = this.html()
+      ? this.html().replace(/^(?!\s*$)/gm, ' '.repeat(identation)) + '\n'
+      : '';
+
+    // $FlowIgnore
+    var data = formatJSON(this.vm.$data);
+
+    /* eslint-disable operator-linebreak */
+    // $FlowIgnore
+    var computed = this.vm._computedWatchers
+      ? formatJSON.apply(
+          // $FlowIgnore
+          void 0, Object.keys(this.vm._computedWatchers).map(function (computedKey) {
+              var obj;
+
+              return (( obj = {}, obj[computedKey] = this$1.vm[computedKey], obj ));
+      })
+        )
+      : // $FlowIgnore
+      this.vm.$options.computed
+      ? formatJSON.apply(
+          // $FlowIgnore
+          void 0, Object.entries(this.vm.$options.computed).map(function (ref) {
+              var obj;
+
+              var key = ref[0];
+              var value = ref[1];
+              return (( obj = {}, obj[key] = value(), obj ));
+      })
+        )
+      : '{}';
+    /* eslint-enable operator-linebreak */
+
+    var emittedJSONReplacer = function (key, value) { return value instanceof Array
+        ? value.map(function (calledWith, index) {
+            var callParams = calledWith.map(function (param) { return typeof param === 'object'
+                ? JSON.stringify(param)
+                    .replace(/"/g, '')
+                    .replace(/,/g, ', ')
+                : param; }
+            );
+
+            return (index + ": [ " + (callParams.join(', ')) + " ]")
+          })
+        : value; };
+
+    var emitted = formatJSON(this.emitted(), emittedJSONReplacer);
+
+    console.log(
+      '\n' +
+        "Wrapper (" + visibility + "):\n\n" +
+        "Html:\n" + html + "\n" +
+        "Data: " + data + "\n\n" +
+        "Computed: " + computed + "\n\n" +
+        "Emitted: " + emitted + "\n"
+    );
   };
 
   /**
@@ -10575,6 +10788,11 @@
   Wrapper.prototype.setChecked = function setChecked (checked) {
       if ( checked === void 0 ) checked = true;
 
+    warnDeprecated(
+      "setChecked",
+      'When you migrate to VTU 2, use setValue instead.'
+    );
+
     if (typeof checked !== 'boolean') {
       throwError('wrapper.setChecked() must be passed a boolean');
     }
@@ -10585,14 +10803,13 @@
 
     if (tagName === 'INPUT' && type === 'checkbox') {
       if (this.element.checked === checked) {
-        return
+        return nextTick()
       }
       if (event !== 'click' || isPhantomJS) {
         // $FlowIgnore
         this.element.checked = checked;
       }
-      this.trigger(event);
-      return
+      return this.trigger(event)
     }
 
     if (tagName === 'INPUT' && type === 'radio') {
@@ -10604,24 +10821,29 @@
       }
 
       if (this.element.checked === checked) {
-        return
+        return nextTick()
       }
 
       if (event !== 'click' || isPhantomJS) {
         // $FlowIgnore
         this.element.selected = true;
       }
-      this.trigger(event);
-      return
+      return this.trigger(event)
     }
 
     throwError("wrapper.setChecked() cannot be called on this element");
+    return nextTick()
   };
 
   /**
    * Selects <option></option> element
    */
   Wrapper.prototype.setSelected = function setSelected () {
+    warnDeprecated(
+      "setSelected",
+      'When you migrate to VTU 2, use setValue instead.'
+    );
+
     var tagName = this.element.tagName;
 
     if (tagName === 'SELECT') {
@@ -10631,28 +10853,27 @@
       );
     }
 
-    if (tagName === 'OPTION') {
-      if (this.element.selected) {
-        return
-      }
-
-      // $FlowIgnore
-      this.element.selected = true;
-      // $FlowIgnore
-      var parentElement = this.element.parentElement;
-
-      // $FlowIgnore
-      if (parentElement.tagName === 'OPTGROUP') {
-        // $FlowIgnore
-        parentElement = parentElement.parentElement;
-      }
-
-      // $FlowIgnore
-      createWrapper(parentElement, this.options).trigger('change');
-      return
+    if (tagName !== 'OPTION') {
+      throwError("wrapper.setSelected() cannot be called on this element");
     }
 
-    throwError("wrapper.setSelected() cannot be called on this element");
+    if (this.element.selected) {
+      return nextTick()
+    }
+
+    // $FlowIgnore
+    this.element.selected = true;
+    // $FlowIgnore
+    var parentElement = this.element.parentElement;
+
+    // $FlowIgnore
+    if (parentElement.tagName === 'OPTGROUP') {
+      // $FlowIgnore
+      parentElement = parentElement.parentElement;
+    }
+
+    // $FlowIgnore
+    return createWrapper(parentElement, this.options).trigger('change')
   };
 
   /**
@@ -10668,6 +10889,7 @@
     }
 
     recursivelySetData(this.vm, this.vm, data);
+    return nextTick()
   };
 
   /**
@@ -10675,6 +10897,8 @@
    */
   Wrapper.prototype.setMethods = function setMethods (methods) {
       var this$1 = this;
+
+    warnDeprecated("setMethods");
 
     if (!this.isVueInstance()) {
       throwError("wrapper.setMethods() can only be called on a Vue instance");
@@ -10737,7 +10961,7 @@
           if (VUE_VERSION > 2.3) {
             // $FlowIgnore : Problem with possibly null this.vm
             this$1.vm.$attrs[key] = data[key];
-            return
+            return nextTick()
           }
           throwError(
             "wrapper.setProps() called with " + key + " property which " +
@@ -10752,6 +10976,7 @@
 
       // $FlowIgnore : Problem with possibly null this.vm
       this.vm.$forceUpdate();
+      return nextTick()
     } catch (err) {
       throw err
     } finally {
@@ -10807,9 +11032,10 @@
       ) {
         this.trigger('change');
       }
-    } else {
-      throwError("wrapper.setValue() cannot be called on this element");
+      return nextTick()
     }
+    throwError("wrapper.setValue() cannot be called on this element");
+    return nextTick()
   };
 
   /**
@@ -10856,11 +11082,12 @@
     var tagName = this.element.tagName;
 
     if (this.attributes().disabled && supportedTags.indexOf(tagName) > -1) {
-      return
+      return nextTick()
     }
 
     var event = createDOMEvent(type, options);
     this.element.dispatchEvent(event);
+    return nextTick()
   };
 
   // 
@@ -12896,9 +13123,9 @@
   var _DataView = DataView;
 
   /* Built-in method references that are verified to be native. */
-  var Promise = _getNative(_root, 'Promise');
+  var Promise$1 = _getNative(_root, 'Promise');
 
-  var _Promise = Promise;
+  var _Promise = Promise$1;
 
   /* Built-in method references that are verified to be native. */
   var Set$1 = _getNative(_root, 'Set');
@@ -13544,6 +13771,20 @@
   var UNSUPPORTED_VERSION_OPTIONS = ['mocks', 'stubs', 'localVue'];
 
   function validateOptions(options, component) {
+    if (
+      options.attachTo &&
+      !isHTMLElement(options.attachTo) &&
+      !isDomSelector(options.attachTo)
+    ) {
+      throwError(
+        "options.attachTo should be a valid HTMLElement or CSS selector string"
+      );
+    }
+    if ('attachToDocument' in options) {
+      warn(
+        "options.attachToDocument is deprecated in favor of options.attachTo and will be removed in a future release"
+      );
+    }
     if (options.parentComponent && !isPlainObject(options.parentComponent)) {
       throwError(
         "options.parentComponent should be a valid Vue component options object"
@@ -13598,7 +13839,8 @@
 
     var parentVm = createInstance(component, mergedOptions, _Vue);
 
-    var el = options.attachToDocument ? createElement() : undefined;
+    var el =
+      options.attachTo || (options.attachToDocument ? createElement() : undefined);
     var vm = parentVm.$mount(el);
 
     component._Ctor = {};
@@ -13606,7 +13848,7 @@
     throwIfInstancesThrew(vm);
 
     var wrapperOptions = {
-      attachedToDocument: !!mergedOptions.attachToDocument
+      attachedToDocument: !!el
     };
 
     var root = parentVm.$options._isFunctionalContainer


### PR DESCRIPTION
A somewhat historic moment after years of waiting, endless bugfixes, debates about `shallowMount`, blood, sweat and tears is upon us - the greatly anticipated 1.0.0.

Some bugs will likely never be fixed due to flaws in the library design - we learned a lot and are using the lessons to improve with [VTU next](github.com/vuejs/vue-test-utils-next/), which targets Vue 3.

Thanks to the [217 contributors](https://github.com/vuejs/vue-test-utils/graphs/contributors) who helped build VTU, and the countless others who reported bugs, wrote articles, or contributed in some other form to the library! Special thanks must go to @eddyerburgh for writing the original library and acting as the lead maintainer for most of its existence.

The goal of this PR is to ensure we cover bases before doing a 1.0.0, sometime in the next week or two. This means API changes will be less likely to happen, and if they do, happen via the RFC process. It doesn't mean development will stop - as long as people are using the library, we (all the OSS contributors) will continue to improve the library, fix bugs, and update the documentation.

TODO before 1.0.0

- [ ] ensure all deprecation messages are up to date and accurate
- [ ] important features/changes are backported from VTU next
- [ ] write clear and concise release notes, detailing the "final" API and notable behaviors
- [ ] clean up docs a little - make sure any references to old APIs or behaviors are gone, remove some un-needed info.
- [ ] ??