### PR TITLE
fix #1550: add deprection warning

### DIFF
--- a/docs/api/wrapper/is.md
+++ b/docs/api/wrapper/is.md
@@ -1,5 +1,20 @@
 ## is
 
+::: warning Deprecation warning
+Using `is` to assert that DOM node or `vm` matches selector is deprecated and will be removed.
+
+Consider a custom matcher such as those provided in jest-dom: https://github.com/testing-library/jest-dom#custom-matchers
+or for DOM element type assertion use native [`Element.tagName`](https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName) instead.
+
+To keep these tests, a valid replacement for:
+
+- `is('DOM_SELECTOR')` is a assertion of `wrapper.element.tagName`.
+- `is('ATTR_NAME')` is a truthy assertion of `wrapper.attributes('ATTR_NAME')`.
+- `is('CLASS_NAME')` is a truthy assertion of `wrapper.classes('CLASS_NAME')`.
+
+When using with findComponent, access the DOM element with `findComponent(Comp).element`
+:::
+
 Assert `Wrapper` DOM node or `vm` matches [selector](../selectors.md).
 
 - **Arguments:**

--- a/docs/api/wrapper/is.md
+++ b/docs/api/wrapper/is.md
@@ -3,7 +3,7 @@
 ::: warning Deprecation warning
 Using `is` to assert that DOM node or `vm` matches selector is deprecated and will be removed.
 
-Consider a custom matcher such as those provided in jest-dom: https://github.com/testing-library/jest-dom#custom-matchers
+Consider a custom matcher such as those provided in [jest-dom](https://github.com/testing-library/jest-dom#custom-matchers).
 or for DOM element type assertion use native [`Element.tagName`](https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName) instead.
 
 To keep these tests, a valid replacement for:


### PR DESCRIPTION
Add deprecation notice for `wrapper.is()` method with couple examples how it could be replaced.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:
Improvie documentation

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
