### PR TITLE
allow array for multiselect .setValue() method

### DIFF
--- a/docs/api/wrapper/setValue.md
+++ b/docs/api/wrapper/setValue.md
@@ -19,6 +19,10 @@ textInput.setValue('some value')
 
 const select = wrapper.find('select')
 select.setValue('option value')
+
+// requires <select multiple>
+const multiselect = wrapper.find('select')
+multiselect.setValue(['value1', 'value3'])
 ```
 
 - **Note:**

--- a/docs/ja/api/wrapper/setValue.md
+++ b/docs/ja/api/wrapper/setValue.md
@@ -19,6 +19,10 @@ textInput.setValue('some value')
 
 const select = wrapper.find('select')
 select.setValue('option value')
+
+// requires <select multiple>
+const multiselect = wrapper.find('select')
+multiselect.setValue(['value1', 'value3'])
 ```
 
 - **注:**

--- a/docs/ru/api/wrapper/setValue.md
+++ b/docs/ru/api/wrapper/setValue.md
@@ -19,6 +19,10 @@ textInput.setValue('some value')
 
 const select = wrapper.find('select')
 select.setValue('option value')
+
+// требует <select multiple>
+const multiselect = wrapper.find('select')
+multiselect.setValue(['value1', 'value3'])
 ```
 
 - **Примечание:**

--- a/docs/zh/api/wrapper/setValue.md
+++ b/docs/zh/api/wrapper/setValue.md
@@ -19,6 +19,10 @@ textInput.setValue('some value')
 
 const select = wrapper.find('select')
 select.setValue('option value')
+
+// requires <select multiple>
+const multiselect = wrapper.find('select')
+multiselect.setValue(['value1', 'value3'])
 ```
 
 - **注意：**

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -747,8 +747,9 @@ export default class Wrapper implements BaseWrapper {
     } else if (tagName === 'SELECT') {
       if (Array.isArray(value)) {
         // $FlowIgnore
-        for (let i = 0; i < this.element.options.length; i++) {
-          const option = this.element.options[i]
+        const options = this.element.options
+        for (let i = 0; i < options.length; i++) {
+          const option = options[i]
           option.selected = value.indexOf(option.value) >= 0
         }
       } else {

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -744,27 +744,29 @@ export default class Wrapper implements BaseWrapper {
         `wrapper.setValue() cannot be called on a <input type="radio" /> ` +
           `element. Use wrapper.setChecked() instead`
       )
-    } else if (
-      tagName === 'INPUT' ||
-      tagName === 'TEXTAREA' ||
-      tagName === 'SELECT'
-    ) {
+    } else if (tagName === 'SELECT') {
+      if (Array.isArray(value)) {
+        // $FlowIgnore
+        for (let i = 0; i < this.element.options.length; i++) {
+          const option = this.element.options[i]
+          option.selected = value.indexOf(option.value) >= 0
+        }
+      } else {
+        // $FlowIgnore
+        this.element.value = value
+      }
+
+      this.trigger('change')
+      return nextTick()
+    } else if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
       // $FlowIgnore
       this.element.value = value
 
-      if (tagName === 'SELECT') {
-        this.trigger('change')
-      } else {
-        this.trigger('input')
-      }
+      this.trigger('input')
 
       // for v-model.lazy, we need to trigger a change event, too.
       // $FlowIgnore
-      if (
-        (tagName === 'INPUT' || tagName === 'TEXTAREA') &&
-        this.element._vModifiers &&
-        this.element._vModifiers.lazy
-      ) {
+      if (this.element._vModifiers && this.element._vModifiers.lazy) {
         this.trigger('change')
       }
       return nextTick()

--- a/test/resources/components/component-with-input.vue
+++ b/test/resources/components/component-with-input.vue
@@ -20,6 +20,11 @@
       <option value="selectB"></option>
       <option value="selectC"></option>
     </select>
+    <select v-model="multiselectVal" class="multiselect" multiple>
+      <option value="selectA"></option>
+      <option value="selectB"></option>
+      <option value="selectC"></option>
+    </select>
     <select v-model="selectVal" class="with-optgroups">
       <optgroup label="Group1">
         <option value="selectA"></option>
@@ -35,6 +40,7 @@
     <span class="counter">{{ counter }}</span>
     {{ textVal }}
     {{ selectVal }}
+    {{ JSON.stringify(multiselectVal) }}
     {{ radioVal }}
     <input id="lazy" type="text" v-model.lazy="lazy" />
     {{ lazy }}
@@ -52,6 +58,7 @@ export default {
       textareaVal: undefined,
       radioVal: undefined,
       selectVal: undefined,
+      multiselectVal: [],
       counter: 0
     }
   },

--- a/test/specs/wrapper/setValue.spec.js
+++ b/test/specs/wrapper/setValue.spec.js
@@ -65,7 +65,7 @@ describeWithShallowAndMount('setValue', mountingMethod => {
     expect(wrapper.text()).to.contain('selectB')
   })
 
-  it('sets element of multiselect value when array', () => {
+  it('sets element of multiselect value', () => {
     const wrapper = mountingMethod(ComponentWithInput)
     const select = wrapper.find('select.multiselect')
     select.setValue(['selectA', 'selectC'])

--- a/test/specs/wrapper/setValue.spec.js
+++ b/test/specs/wrapper/setValue.spec.js
@@ -65,6 +65,37 @@ describeWithShallowAndMount('setValue', mountingMethod => {
     expect(wrapper.text()).to.contain('selectB')
   })
 
+  it('sets element of multiselect value when array', () => {
+    const wrapper = mountingMethod(ComponentWithInput)
+    const select = wrapper.find('select.multiselect')
+    select.setValue(['selectA', 'selectC'])
+
+    const selectedOptions = Array.from(select.element.selectedOptions).map(
+      o => o.value
+    )
+    expect(selectedOptions).to.deep.equal(['selectA', 'selectC'])
+  })
+
+  it('sets element of multiselect value when array overrides', () => {
+    const wrapper = mountingMethod(ComponentWithInput)
+    const select = wrapper.find('select.multiselect')
+    select.setValue(['selectA', 'selectC'])
+    select.setValue(['selectB'])
+
+    const selectedOptions = Array.from(select.element.selectedOptions).map(
+      o => o.value
+    )
+    expect(selectedOptions).to.deep.equal(['selectB'])
+  })
+
+  it('updates dom with multiselect v-model when array', async () => {
+    const wrapper = mountingMethod(ComponentWithInput)
+    const select = wrapper.find('select.multiselect')
+    await select.setValue(['selectA', 'selectC'])
+
+    expect(wrapper.text()).to.contain('["selectA","selectC"]')
+  })
+
   it('throws error if element is option', () => {
     const message =
       'wrapper.setValue() cannot be called on an <option> element. Use wrapper.setSelected() instead'

--- a/test/specs/wrapper/setValue.spec.js
+++ b/test/specs/wrapper/setValue.spec.js
@@ -76,7 +76,7 @@ describeWithShallowAndMount('setValue', mountingMethod => {
     expect(selectedOptions).to.deep.equal(['selectA', 'selectC'])
   })
 
-  it('sets element of multiselect value when array overrides', () => {
+  it('overrides elements of multiselect', () => {
     const wrapper = mountingMethod(ComponentWithInput)
     const select = wrapper.find('select.multiselect')
     select.setValue(['selectA', 'selectC'])


### PR DESCRIPTION
enables Wrapper.setValue() method to accept array value for select elements (requires select to have an attribute 'multiple' or 'multiple="true"')

fix #1505

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch.
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature: see https://github.com/vuejs/vue-test-utils/issues/1505
