### PR TITLE
Docs: deprecations

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -49,6 +49,10 @@ module.exports = {
           {
             text: 'Guides',
             link: '/guides/'
+          },
+          {
+            text: 'Upgrading to V1',
+            link: '/upgrading-to-v1/'
           }
         ],
         sidebar: [

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -4,6 +4,18 @@ Vue Test Utils includes a config object to defined options used by Vue Test Util
 
 ### Vue Test Utils Config Options
 
+### `showDeprecationWarnings`
+
+Turn off deprecation warnings.
+
+Example:
+
+```js
+import { config } from `@vue/test-utils`
+
+config.showDeprecationWarnings = false
+```
+
 ### `stubs`
 
 - type: `{ [name: string]: Component | boolean | string }`

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -11,7 +11,7 @@ Turn off deprecation warnings.
 Example:
 
 ```js
-import { config } from `@vue/test-utils`
+import { config } from '@vue/test-utils'
 
 config.showDeprecationWarnings = false
 ```

--- a/docs/upgrading-to-v1/README.md
+++ b/docs/upgrading-to-v1/README.md
@@ -40,7 +40,7 @@ See `isEmpty` above. Consider using [toBeVisible](https://github.com/testing-lib
 
 ### `name`
 
-Asserting against `name` encourages testing implementation details, which is a bad practice. Avoid this is possible. If you need this feature, though, you can use `vm.$options.name` for Vue components or `element.tagName` for DOM nodes. Again, consider if you really need this test - it's likely you don't.
+Asserting against `name` encourages testing implementation details, which is a bad practice. If you need this feature, though, you can use `vm.$options.name` for Vue components or `element.tagName` for DOM nodes. Again, consider if you really need this test - it's likely you don't.
 
 ### `setMethods` and `mountingOptions.methods`
 

--- a/docs/upgrading-to-v1/README.md
+++ b/docs/upgrading-to-v1/README.md
@@ -6,7 +6,7 @@ You can read the release notes for V1 [here](https://github.com/vuejs/vue-test-u
 
 ### `find`
 
-In the beta,`find` could be used to find both DOm nodes using the `querySelector` syntax, or a component via a component reference, a `ref` or a `name` option. This behavior is now split into two methods: `find` and `findComponent`.
+In beta,`find` could be used to find both DOM nodes (using the `querySelector` syntax) or a component (via a component reference, a `ref` or a `name` option). This behavior is now split into two methods: `find` and `findComponent`.
 
 If you were using this syntax:
 

--- a/docs/upgrading-to-v1/README.md
+++ b/docs/upgrading-to-v1/README.md
@@ -24,7 +24,7 @@ This method was deprecated because it tends to encourage testing implementation 
 
 ### `contains`
 
-Tests using `contains` can be replaced with `find` or `findComponent` or `get`. For example, `expect(wrapper.contains('#el')).toBe(true)` may be written as `expect(wrapper.find('#el')).toBe(true)`.
+Tests using `contains` can be replaced with `find` or `findComponent` or `get`. For example, `expect(wrapper.contains('#el')).toBe(true)` may be written as `wrapper.get('#el')`, which will throw an error if the selector is not matched. Another way to write this using `find` is `expect(wrapper.find('#el').element).toBeTruthy()`.
 
 ### `is`
 
@@ -36,7 +36,18 @@ Finding out whether a DOM node is empty is not a Vue specific feature, and it is
 
 ### `isVisible`
 
-See `isEmpty` above. Consider using [toBeVisible](https://github.com/testing-library/jest-dom#tobevisible) from `jest-dom` if you are using Jest.
+See `isEmpty` above. Consider using [toBeVisible](https://github.com/testing-library/jest-dom#tobevisible) from `jest-dom` if you are using Jest. For example:
+
+```js
+// old assertion
+expect(wrapper.find('.selector').isVisible()).toBeTruthy()
+
+// new assertion
+// consider making this matcher globally availalbe in your tests!
+import '@testing-library/jest-dom'
+
+expect(wrapper.find('.selector').element).toBeVisible()
+```
 
 ### `name`
 

--- a/docs/upgrading-to-v1/README.md
+++ b/docs/upgrading-to-v1/README.md
@@ -14,7 +14,9 @@ If you were using this syntax:
 - `find({ name: 'foo' })`
 - `find({ ref: 'my-ref' })`
 
-You should change those instances to be `findComponent`. You may continue using `find` on DOM nodes using the `querySelector` syntax.
+Change them to be `findComponent`.
+
+You may continue using `find` on DOM nodes using the `querySelector` syntax.
 
 ### `isVueInstance`
 

--- a/docs/upgrading-to-v1/README.md
+++ b/docs/upgrading-to-v1/README.md
@@ -1,6 +1,6 @@
 ### Upgrading to V1.0
 
-After a long time in beta, Vue Test Utils finally released v1.0! Some APIs that made sense during beta but turned out to be not such a good idea were deprecated. This guide will help you migrate away from the deprecation warnings you may be seeing if you were using the beta heavily.
+After a long time in Beta, Vue Test Utils finally released v1.0! We deprecated some methods that were not helpful, so you might see several deprecation warnings after upgrading. This guide will help you migrate away from them.
 
 You can read the release notes for V1 [here](https://github.com/vuejs/vue-test-utils/releases) or the discussion around the deprecations [here](https://github.com/vuejs/rfcs/pull/161).
 

--- a/docs/upgrading-to-v1/README.md
+++ b/docs/upgrading-to-v1/README.md
@@ -70,7 +70,7 @@ mount(Foo, {
   methods: {
     getData: () => {}
   }
-}
+})
 ```
 
 Mock out the `axios` dependency. In Jest, for example, you can do `jest.mock('axios')`. This will prevent the API call, without mutating your Vue component.

--- a/docs/upgrading-to-v1/README.md
+++ b/docs/upgrading-to-v1/README.md
@@ -76,3 +76,13 @@ mount(Foo, {
 Mock out the `axios` dependency. In Jest, for example, you can do `jest.mock('axios')`. This will prevent the API call, without mutating your Vue component.
 
 If you need more help migrating, you can join the [VueLand server](https://chat.vuejs.org/) on Discord.
+
+### Deprecation Warnings
+
+Deprecation warnings can be silenced.
+
+```js
+import { config } from '@vue/test-utils'
+
+config.showDeprecationWarnings = false
+```

--- a/docs/upgrading-to-v1/README.md
+++ b/docs/upgrading-to-v1/README.md
@@ -1,0 +1,72 @@
+### Upgrading to V1.0
+
+After a long time in beta, Vue Test Utils finally released v1.0! Some APIs that made sense during beta but turned out to be not such a good idea were deprecated. This guide will help you migrate away from the deprecation warnings you may be seeing if you were using the beta heavily.
+
+You can read the release notes for V1 [here](https://github.com/vuejs/vue-test-utils/releases) or the discussion around the deprecations [here](https://github.com/vuejs/rfcs/pull/161).
+
+### `find`
+
+In the beta,`find` could be used to find both DOm nodes using the `querySelector` syntax, or a component via a component reference, a `ref` or a `name` option. This behavior is now split into two methods: `find` and `findComponent`.
+
+If you were using this syntax:
+
+- `find(Foo)`
+- `find({ name: 'foo' })`
+- `find({ ref: 'my-ref' })`
+
+You should change those instances to be `findComponent`. You may continue using `find` on DOM nodes using the `querySelector` syntax.
+
+### `isVueInstance`
+
+This method was deprecated because it tends to encourage testing implementation details, which is a bad practice. Assertions using this can simply be removed; if you really need a substitute, you can do `expect((...).vm).toBeTruthy()`, which is basically what `isVueInstance` was doing.
+
+### `contains`
+
+Tests using `contains` can be replaced with `find` or `findComponent` or `get`. For example, `expect(wrapper.contains('#el')).toBe(true)` may be written as `expect(wrapper.find('#el')).toBe(true)`.
+
+### `is`
+
+You may rewrite tests using `is` to use `element.tagName` instead. For example, `wrapper.find('div').is('div')` may be written as `wrapper.find('div').element.tagName`.
+
+### `isEmpty`
+
+Finding out whether a DOM node is empty is not a Vue specific feature, and it is something that is difficult to get right. Rather than re-invent the wheel, we have decided it's better to delegate to an existing, well tested solution by default. Consider the excellent `toBeEmpty` matchers from [jest-dom](https://github.com/testing-library/jest-dom#tobeempty), for example, if you are using Jest.
+
+### `isVisible`
+
+See `isEmpty` above. Consider using [toBeVisible](https://github.com/testing-library/jest-dom#tobevisible) from `jest-dom` if you are using Jest.
+
+### `name`
+
+Asserting against `name` encourages testing implementation details, which is a bad practice. Avoid this is possible. If you need this feature, though, you can use `vm.$options.name` for Vue components or `element.tagName` for DOM nodes. Again, consider if you really need this test - it's likely you don't.
+
+### `setMethods` and `mountingOptions.methods`
+
+By using `setMethods`, you are mutating the Vue instance - this is nothing some Vue supports, and can often hide tests that would otherwise fail. There is no straight forward replacement for this, it depends on you use case. If you have a comlex method you would like to stub out, consider moving it another file and using your test runnner's stub or mock functionality. For example, you may want to avoid an API call:
+
+```js
+const Foo = {
+  created() {
+    this.getData()
+  },
+  methods: {
+    getData() {
+      axios.get('...')
+    }
+  }
+}
+```
+
+Instead of doing:
+
+```js
+mount(Foo, {
+  methods: {
+    getData: () => {}
+  }
+}
+```
+
+Mock out the `axios` dependency. In Jest, for example, you can do `jest.mock('axios')`. This will prevent the API call, without mutating your Vue component.
+
+If you need more help migrating, you can join the Discord server VueLand. Alternatively, open an issue on this project's GitHub repository and someone will do their best to help you.

--- a/docs/upgrading-to-v1/README.md
+++ b/docs/upgrading-to-v1/README.md
@@ -75,4 +75,4 @@ mount(Foo, {
 
 Mock out the `axios` dependency. In Jest, for example, you can do `jest.mock('axios')`. This will prevent the API call, without mutating your Vue component.
 
-If you need more help migrating, you can join the Discord server VueLand. Alternatively, open an issue on this project's GitHub repository and someone will do their best to help you.
+If you need more help migrating, you can join the [VueLand server](https://chat.vuejs.org/) on Discord.

--- a/docs/upgrading-to-v1/README.md
+++ b/docs/upgrading-to-v1/README.md
@@ -42,7 +42,11 @@ Asserting against `name` encourages testing implementation details, which is a b
 
 ### `setMethods` and `mountingOptions.methods`
 
-By using `setMethods`, you are mutating the Vue instance - this is nothing some Vue supports, and can often hide tests that would otherwise fail. There is no straight forward replacement for this, it depends on you use case. If you have a comlex method you would like to stub out, consider moving it another file and using your test runnner's stub or mock functionality. For example, you may want to avoid an API call:
+By using `setMethods`, you are mutating the Vue instance - this is not something Vue supports, and may lead to coupled, flaky tests.
+
+There is no straight forward replacement for this. If you have a complex method you would like to stub out, consider moving it another file and using your test runner's stub or mock functionality.
+
+For example, you may want to avoid an API call:
 
 ```js
 const Foo = {

--- a/packages/shared/util.js
+++ b/packages/shared/util.js
@@ -2,7 +2,7 @@
 import Vue from 'vue'
 import semver from 'semver'
 import { VUE_VERSION } from './consts'
-import { config } from '@vue/test-utils'
+import { config } from '../test-utils/src'
 
 export function throwError(msg: string): void {
   throw new Error(`[vue-test-utils]: ${msg}`)


### PR DESCRIPTION
We should have done this for V1. Anyway, better late than ever. Let's provide a solid "this is how you migrate" docs - some of the deprecation messages are unclear or difficult to understand.