### PR TITLE
Remove type condition

### DIFF
--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -160,9 +160,9 @@ type ShallowMountOptions<V extends Vue> = MountOptions<V>
 type ThisTypedShallowMountOptions<V extends Vue> = ShallowMountOptions<V> & ThisType<V>
 
 interface VueTestUtilsConfigOptions {
-  stubs?: Record<string, Component | boolean | string>
-  mocks?: Record<string, any>
-  methods?: Record<string, Function>
+  stubs: Record<string, Component | boolean | string>
+  mocks: Record<string, any>
+  methods: Record<string, Function>
   provide?: Record<string, any>,
   silent?: Boolean,
   showDeprecationWarnings?: boolean


### PR DESCRIPTION
In cases where the empty object is already set as default in the config:

See: `stubs`, `mocks` and `methods`
https://github.com/vuejs/vue-test-utils/blob/dev/packages/test-utils/src/config.js

The ? is not necessary. In this case, we can import the config and we will not be forced to check the existence of attributes:

```
import { config } from '@vue/test-utils';

if (config.mocks) {
  config.mocks.i18n = { t: jest.fn() };
  config.mocks.$t = jest.fn();
}
```

and use directly

```
import { config } from '@vue/test-utils';

config.mocks.i18n = { t: jest.fn() };
config.mocks.$t = jest.fn();
```

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
