### PR TITLE
docs: replace BABEL_ENV with NODE_ENV

### DIFF
--- a/docs/guides/testing-single-file-components-with-karma.md
+++ b/docs/guides/testing-single-file-components-with-karma.md
@@ -136,13 +136,13 @@ Install `karma-coverage`, `babel-plugin-istanbul`, and `cross-env`:
 npm install --save-dev karma-coverage cross-env
 ```
 
-We're going to use `cross-env` to set a `BABEL_ENV` environment variable. This way we can use `babel-plugin-istanbul` when we're compiling for our tests—we don't want to include `babel-plugin-istanbul` when we compile our production code:
+We're going to use `cross-env` to set a `NODE_ENV` environment variable. This way we can use `babel-plugin-istanbul` when we're compiling for our tests—we don't want to include `babel-plugin-istanbul` when we compile our production code:
 
 ```
 npm install --save-dev babel-plugin-istanbul
 ```
 
-Update your `.babelrc` file to use `babel-plugin-istanbul` when `BABEL_ENV` is set to test:
+Update your `.babelrc` file to use `babel-plugin-istanbul` when `NODE_ENV` is set to test:
 
 ```json
 {
@@ -174,13 +174,13 @@ module.exports = function(config) {
 }
 ```
 
-And update the `test` script to set the `BABEL_ENV`:
+And update the `test` script to set the `NODE_ENV`:
 
 ```json
 // package.json
 {
   "scripts": {
-    "test": "cross-env BABEL_ENV=test karma start --single-run"
+    "test": "cross-env NODE_ENV=test karma start --single-run"
   }
 }
 ```


### PR DESCRIPTION
According to the [babel documentation](https://babeljs.io/docs/en/options#envname),
`NODE_ENV` can also be recognized when loading configurations, and
`NODE_ENV` has better interoperability in the ecosystem.

Here's a use case that `NODE_ENV` works well while `BABEL_ENV` might
cause confusion: https://github.com/vuejs/vue-cli/issues/5525#issuecomment-634523493

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Documentation

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
