### PR TITLE
fix: allow using findComponent on a functional component, fix #1577

### DIFF
--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -237,7 +237,7 @@ export default class Wrapper implements BaseWrapper {
    */
   findComponent(rawSelector: Selector): Wrapper | ErrorWrapper {
     const selector = getSelector(rawSelector, 'findComponent')
-    if (!this.vm) {
+    if (!this.vm && !this.isFunctionalComponent) {
       throwError(
         'You cannot chain findComponent off a DOM element. It can only be used on Vue Components.'
       )

--- a/test/specs/wrapper/find.spec.js
+++ b/test/specs/wrapper/find.spec.js
@@ -162,6 +162,18 @@ describeWithShallowAndMount('find', mountingMethod => {
       .with.property('message', message)
   })
 
+  it('allows using findComponent on functional component', () => {
+    const FuncComponentWithChildren = {
+      functional: true,
+      components: {
+        ChildComponent: Component
+      },
+      render: h => h('div', {}, [h(Component)])
+    }
+    const wrapper = mountingMethod(FuncComponentWithChildren)
+    expect(wrapper.findComponent(Component).exists()).to.be.true
+  })
+
   itSkipIf(isRunningPhantomJS, 'returns Wrapper of class component', () => {
     const TestComponent = {
       template: `


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Removes the warning when using `findComponent` on functional comps. Fixes #1577 
