### PR TITLE
Adds Context to attachTo Option Example

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -301,6 +301,10 @@ When attaching to the DOM, you should call `wrapper.destroy()` at the end of you
 remove the rendered elements from the document and destroy the component instance.
 
 ```js
+const div = document.createElement('div')
+div.id = 'root'
+document.body.appendChild(div)
+
 const Component = {
   template: '<div>ABC</div>'
 }


### PR DESCRIPTION
Previously, the documentation for attachTo provided an example where a component was being attached to a div with an id of `root`, but without it being defined it's kind of distracting. This update explicitly defines the element and attaches it to the document for clarity.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ x] Other, please describe: Documentation Change

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ x] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
