### PR TITLE
docs: updating ja documents about deprecation warning

### DIFF
--- a/docs/ja/api/options.md
+++ b/docs/ja/api/options.md
@@ -192,6 +192,23 @@ expect(wrapper.vm.$route).toBeInstanceOf(Object)
 - 型: `boolean`
 - デフォルト: `false`
 
+::: warning Deprecation warning
+`attachToDocument` は非推奨となり、将来のリリースで削除される予定です。
+
+代わりに [attachTo](#attachto) を使用してください。たとえば、コンポーネントを document.body にアタッチする必要がある場合は：
+
+```js
+const elem = document.createElement('div')
+if (document.body) {
+  document.body.appendChild(elem)
+}
+wrapper = mount(Component, {
+  attachTo: elem
+})
+```
+
+:::
+
 `true` に設定されている場合、描画時にコンポーネントは DOM にアタッチされます。
 
 DOM にアタッチされた際に、テストの最後で `wrapper.destroy()` を呼び出さなければなりません。レンダリングされた要素をドキュメントから取り除いて、コンポーネントインスタンスを壊さなければならないからです。

--- a/docs/ja/api/wrapper-array/isEmpty.md
+++ b/docs/ja/api/wrapper-array/isEmpty.md
@@ -1,5 +1,13 @@
 ## isEmpty()
 
+::: warning Deprecation warning
+`isEmpty` は非推奨となり、将来のリリースで削除される予定です。
+
+[jest-dom](https://github.com/testing-library/jest-dom#custom-matchers) で提供されているようなカスタムマッチャの使用を検討してください。
+
+findComponent で使用する場合は、 `findComponent(Comp).element` で DOM 要素にアクセスします。
+:::
+
 `WrapperArray` のすべての `Wrapper` に子ノードを含んでいないか検証します。
 
 - **戻り値:** `{boolean}`

--- a/docs/ja/api/wrapper-array/isVueInstance.md
+++ b/docs/ja/api/wrapper-array/isVueInstance.md
@@ -1,5 +1,13 @@
 ## isVueInstance()
 
+::: warning Deprecation warning
+`isVueInstance` は非推奨となり、将来のリリースで削除される予定です。
+
+`isVueInstance` アサーションに依存するテストは、ほとんどまたは全く価値を提供しません。それらを意図のあるアサーションに置き換えることをお勧めします。
+
+テストを維持するために、`isVueInstance()` を置き換える場合は、 `wrapper.find(...).vm` のアサーションが有効です。
+:::
+
 `WrapperArray` の全ての `Wrapper` が Vue インスタンスであるか検証します。
 
 - **戻り値:** `{boolean}`

--- a/docs/ja/api/wrapper-array/setMethods.md
+++ b/docs/ja/api/wrapper-array/setMethods.md
@@ -1,5 +1,15 @@
 ## setMethods(methods)
 
+::: warning Deprecation warning
+`setMethods` は非推奨となり、将来のリリースで削除される予定です。
+
+`setMethods` を置き換える明確な方法はありません。それは、置き換え前の使われ方に非常に依存しているためです。 `setMethods` は実装の詳細に依存する不安定なテストに簡単につながるため、[お勧めしません](https://github.com/vuejs/rfcs/blob/668866fa71d70322f6a7689e88554ab27d349f9c/active-rfcs/0000-vtu-api.md#setmethods)。
+
+それらテストを見直すことをお勧めします。
+
+複雑なメソッドをスタブするには、コンポーネントからメソッドを抽出し、単独でテストします。 メソッドが呼び出されたことをアサートするには、テストランナーを使用してそれを探ります。
+:::
+
 `WrapperArray` の `Wrapper` ごとに `Wrapper` に `vm` メソッドをセットし、強制的に更新します。
 
 **すべての `Wrapper` は Vue インスタンスを含んでいなければならないことに注意してください。**

--- a/docs/ja/api/wrapper/emittedByOrder.md
+++ b/docs/ja/api/wrapper/emittedByOrder.md
@@ -1,5 +1,11 @@
 ## emittedByOrder()
 
+::: warning Deprecation warning
+`emittedByOrder` は非推奨となり、将来のリリースで削除される予定です。
+
+代わりに `wrapper.emitted` を使用してください。
+:::
+
 `Wrapper` `vm` によって生成されたカスタムイベントを含む配列を返します。
 
 - **戻り値:** `Array<{ name: string, args: Array<any> }>`

--- a/docs/ja/api/wrapper/find.md
+++ b/docs/ja/api/wrapper/find.md
@@ -1,5 +1,9 @@
 ## find(selector)
 
+::: warning Deprecation warning
+コンポーネントの検索に `find` を使用することは非推奨となり、削除される予定です。代わりに `findComponent` を使用してください。
+:::
+
 最初の DOM ノードの Wrapper、またはセレクタで一致した Vue コンポーネントを返します。
 
 有効な[セレクタ](../selectors.md)を使用してください。

--- a/docs/ja/api/wrapper/findAll.md
+++ b/docs/ja/api/wrapper/findAll.md
@@ -1,5 +1,9 @@
 ## findAll(selector)
 
+::: warning Deprecation warning
+`findAll` を使用してコンポーネントを検索することは非推奨となり、削除される予定です。代わりに `findAllComponents` を使用してください。
+:::
+
 [`WrapperArray`](../wrapper-array/)を返します。
 
 有効な[セレクタ](../selectors.md)を使用してください。

--- a/docs/ja/api/wrapper/is.md
+++ b/docs/ja/api/wrapper/is.md
@@ -1,5 +1,19 @@
 ## is(selector)
 
+::: warning Deprecation warning
+`is` を使用して、 DOM ノードまたは `vm` がセレクタに一致することをアサートするのは非推奨となり、削除される予定です。
+
+[jest-dom](https://github.com/testing-library/jest-dom#custom-matchers) で提供されているようなカスタムマッチャの使用を検討してください。または、 DOM 要素などに対するアサーションには、代わりにネイティブの [Element.tagName](https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName) を使用してください。
+
+テストを維持するためには、以下の置き換えが有効です。
+
+- `is('DOM_SELECTOR')` は `wrapper.element.tagName` のアサーションです。
+- `is('ATTR_NAME')` は真に `wrapper.attributes('ATTR_NAME')` のアサーションです。
+- `is('CLASS_NAME')` は真に `wrapper.classes('CLASS_NAME')` のアサーションです。
+
+findComponent で使用する場合は、 `findComponent(Comp).element` で DOM 要素にアクセスします。
+:::
+
 `Wrapper` DOM ノード、または `vm` が[セレクタ](../selectors.md)と一致しているか検証します。
 
 - **引数:**

--- a/docs/ja/api/wrapper/isVisible.md
+++ b/docs/ja/api/wrapper/isVisible.md
@@ -1,5 +1,13 @@
 ## isVisible()
 
+::: warning Deprecation warning
+`isVisible` は非推奨となり、将来のリリースで削除される予定です。
+
+[jest-dom](https://github.com/testing-library/jest-dom#custom-matchers) で提供されているようなカスタムマッチャの使用を検討してください。
+
+findComponent で使用する場合は、 `findComponent(Comp).element` で DOM 要素にアクセスします。
+:::
+
 `Wrapper` が表示されているかアサートします。
 
 style が `display: none` か  `visibility: hidden` の親要素がある場合、 false を返します。

--- a/docs/ja/api/wrapper/isVueInstance.md
+++ b/docs/ja/api/wrapper/isVueInstance.md
@@ -1,5 +1,13 @@
 ## isVueInstance()
 
+::: warning Deprecation warning
+`isVueInstance` は非推奨となり、将来のリリースで削除される予定です。
+
+`isVueInstance` アサーションに依存するテストは、ほとんどまたは全く価値を提供しません。それらを意図のあるアサーションに置き換えることをお勧めします。
+
+テストを維持するために、`isVueInstance()` を置き換える場合は、 `wrapper.find(...).vm` のアサーションが有効です。
+:::
+
 `Wrapper` が Vue インスタンスか検証します。
 
 - **戻り値:** `{boolean}`

--- a/docs/ja/api/wrapper/name.md
+++ b/docs/ja/api/wrapper/name.md
@@ -1,5 +1,9 @@
 ## name()
 
+::: warning Deprecation warning
+`name` は非推奨となり、将来のリリースで削除される予定です。
+:::
+
 `Wrapper` に Vue インスタンスが含まれている場合はコンポーネント名を返し、そうでない場合は `Wrapper` DOM ノードのタグ名を返します。
 
 - **戻り値:** `{string}`

--- a/docs/ja/api/wrapper/setMethods.md
+++ b/docs/ja/api/wrapper/setMethods.md
@@ -1,5 +1,15 @@
 ## setMethods(methods)
 
+::: warning Deprecation warning
+`setMethods` は非推奨となり、将来のリリースで削除される予定です。
+
+`setMethods` を置き換える明確な方法はありません。それは、置き換え前の使われ方に非常に依存しているためです。 `setMethods` は実装の詳細に依存する不安定なテストに簡単につながるため、[お勧めしません](https://github.com/vuejs/rfcs/blob/668866fa71d70322f6a7689e88554ab27d349f9c/active-rfcs/0000-vtu-api.md#setmethods)。
+
+それらテストを見直すことをお勧めします。
+
+複雑なメソッドをスタブするには、コンポーネントからメソッドを抽出し、単独でテストします。 メソッドが呼び出されたことをアサートするには、テストランナーを使用してそれを探ります。
+:::
+
 `Wrapper` `vm` メソッドを設定し、更新を強制します。
 
 **Wrapper には Vue インスタンスを含む必要があることに注意してください**


### PR DESCRIPTION
Added deprecation warning texts to Japanese version because There are no writtern deprecation
warning texts yet

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Documentation

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
