### PR TITLE
fix(setprops): allowed for setProps to be synced with nextTick intervals

### DIFF
--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -711,7 +711,7 @@ export default class Wrapper implements BaseWrapper {
 
       // $FlowIgnore : Problem with possibly null this.vm
       this.vm.$forceUpdate()
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         nextTick().then(() => {
           const isUpdated = Object.keys(data).some(key => {
             return (

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -711,7 +711,17 @@ export default class Wrapper implements BaseWrapper {
 
       // $FlowIgnore : Problem with possibly null this.vm
       this.vm.$forceUpdate()
-      return nextTick()
+      return new Promise((resolve, reject) => {
+        nextTick().then(() => {
+          const isUpdated = Object.keys(data).some(key => {
+            return (
+              // $FlowIgnore : Problem with possibly null this.vm
+              this.vm[key] === data[key] || this.vm.$attrs[key] === data[key]
+            )
+          })
+          return !isUpdated ? this.setProps(data).then(resolve()) : resolve()
+        })
+      })
     } catch (err) {
       throw err
     } finally {

--- a/test/specs/wrapper/setProps.spec.js
+++ b/test/specs/wrapper/setProps.spec.js
@@ -187,6 +187,81 @@ describeWithShallowAndMount('setProps', mountingMethod => {
       await wrapper.setProps({ prop1 })
       expect(wrapper.vm.prop2).to.equal(prop1)
     })
+
+    it('invokes watchers with immediate set to "true"', async () => {
+      const callback = sinon.spy()
+      const TestComponent = {
+        template: '<div />',
+        props: ['propA'],
+        mounted() {
+          this.$watch(
+            'propA',
+            function() {
+              callback()
+            },
+            { immediate: true }
+          )
+        }
+      }
+      const wrapper = mountingMethod(TestComponent, {
+        propsData: { propA: 'none' }
+      })
+
+      expect(callback.calledOnce)
+      callback.resetHistory()
+
+      await wrapper.setProps({ propA: 'value' })
+      expect(wrapper.props().propA).to.equal('value')
+      expect(callback.calledOnce)
+    })
+
+    it('invokes watchers with immediate set to "true" with deep objects', async () => {
+      const callback = sinon.spy()
+      const TestComponent = {
+        template: '<div />',
+        props: ['propA'],
+        mounted() {
+          this.$watch(
+            'propA',
+            function() {
+              callback()
+            },
+            { immediate: true }
+          )
+        }
+      }
+      const wrapper = mountingMethod(TestComponent, {
+        propsData: {
+          propA: {
+            key: {
+              nestedKey: 'value'
+            },
+            key2: 'value2'
+          }
+        }
+      })
+
+      expect(callback.calledOnce)
+      callback.resetHistory()
+
+      await wrapper.setProps({
+        propA: {
+          key: {
+            nestedKey: 'newValue',
+            anotherNestedKey: 'value'
+          },
+          key2: 'value2'
+        }
+      })
+      expect(wrapper.props().propA).to.deep.equal({
+        key: {
+          nestedKey: 'newValue',
+          anotherNestedKey: 'value'
+        },
+        key2: 'value2'
+      })
+      expect(callback.calledOnce)
+    })
   })
 
   it('props and setProps should return the same reference when called with same object', () => {


### PR DESCRIPTION
setProps in certain cases was being blown away by nextTick intervals. If the property is not up to
date, setProps will be called again to sync the changes.

fix #1419

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
