### PR TITLE
Update wrapper async mode docs

### DIFF
--- a/docs/api/wrapper/setChecked.md
+++ b/docs/api/wrapper/setChecked.md
@@ -12,9 +12,11 @@ Sets checked value for input element of type checkbox or radio and updates `v-mo
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-const radioInput = wrapper.find('input[type="radio"]')
-radioInput.setChecked()
+test('setChecked demo', async () => {
+  const wrapper = mount(Foo)
+  const radioInput = wrapper.find('input[type="radio"]')
+  await radioInput.setChecked()
+})
 ```
 
 - **Note:**

--- a/docs/api/wrapper/setChecked.md
+++ b/docs/api/wrapper/setChecked.md
@@ -15,7 +15,10 @@ import Foo from './Foo.vue'
 test('setChecked demo', async () => {
   const wrapper = mount(Foo)
   const radioInput = wrapper.find('input[type="radio"]')
+
   await radioInput.setChecked()
+
+  expect(radioInput.element.checked).toBeTruthy()
 })
 ```
 

--- a/docs/api/wrapper/setData.md
+++ b/docs/api/wrapper/setData.md
@@ -16,7 +16,9 @@ setData works by recursively calling Vue.set.
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-wrapper.setData({ foo: 'bar' })
-expect(wrapper.vm.foo).toBe('bar')
+test('setData demo', async () => {
+  const wrapper = mount(Foo)
+  await wrapper.setData({ foo: 'bar' })
+  expect(wrapper.vm.foo).toBe('bar')
+})
 ```

--- a/docs/api/wrapper/setData.md
+++ b/docs/api/wrapper/setData.md
@@ -18,7 +18,9 @@ import Foo from './Foo.vue'
 
 test('setData demo', async () => {
   const wrapper = mount(Foo)
+
   await wrapper.setData({ foo: 'bar' })
+
   expect(wrapper.vm.foo).toBe('bar')
 })
 ```

--- a/docs/api/wrapper/setProps.md
+++ b/docs/api/wrapper/setProps.md
@@ -14,9 +14,11 @@ Sets `Wrapper` `vm` props and forces update.
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-wrapper.setProps({ foo: 'bar' })
-expect(wrapper.vm.foo).toBe('bar')
+test('setProps demo', async () => {
+  const wrapper = mount(Foo)
+  await wrapper.setProps({ foo: 'bar' })
+  expect(wrapper.vm.foo).toBe('bar')
+})
 ```
 
 You can also pass a `propsData` object, which will initialize the Vue instance with passed values.

--- a/docs/api/wrapper/setProps.md
+++ b/docs/api/wrapper/setProps.md
@@ -16,7 +16,9 @@ import Foo from './Foo.vue'
 
 test('setProps demo', async () => {
   const wrapper = mount(Foo)
+
   await wrapper.setProps({ foo: 'bar' })
+
   expect(wrapper.vm.foo).toBe('bar')
 })
 ```

--- a/docs/api/wrapper/setSelected.md
+++ b/docs/api/wrapper/setSelected.md
@@ -8,10 +8,12 @@ Selects an option element and updates `v-model` bound data.
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-const options = wrapper.find('select').findAll('option')
+test('setSelected demo', async () => {
+  const wrapper = mount(Foo)
+  const options = wrapper.find('select').findAll('option')
 
-options.at(1).setSelected()
+  await options.at(1).setSelected()
+})
 ```
 
 - **Note:**

--- a/docs/api/wrapper/setSelected.md
+++ b/docs/api/wrapper/setSelected.md
@@ -13,6 +13,8 @@ test('setSelected demo', async () => {
   const options = wrapper.find('select').findAll('option')
 
   await options.at(1).setSelected()
+
+  expect(wrapper.find('option:checked').element.value).toBe('bar')
 })
 ```
 

--- a/docs/api/wrapper/setValue.md
+++ b/docs/api/wrapper/setValue.md
@@ -12,17 +12,19 @@ Sets value of a text-control input or select element and updates `v-model` bound
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
+test('setValue demo', async () => {
+  const wrapper = mount(Foo)
 
-const textInput = wrapper.find('input[type="text"]')
-textInput.setValue('some value')
+  const textInput = wrapper.find('input[type="text"]')
+  await textInput.setValue('some value')
 
-const select = wrapper.find('select')
-select.setValue('option value')
+  const select = wrapper.find('select')
+  await select.setValue('option value')
 
-// requires <select multiple>
-const multiselect = wrapper.find('select')
-multiselect.setValue(['value1', 'value3'])
+  // requires <select multiple>
+  const multiselect = wrapper.find('select')
+  await multiselect.setValue(['value1', 'value3'])
+})
 ```
 
 - **Note:**

--- a/docs/api/wrapper/setValue.md
+++ b/docs/api/wrapper/setValue.md
@@ -18,12 +18,21 @@ test('setValue demo', async () => {
   const textInput = wrapper.find('input[type="text"]')
   await textInput.setValue('some value')
 
+  expect(wrapper.find('input[type="text"]').element.value).toBe('some value')
+
   const select = wrapper.find('select')
   await select.setValue('option value')
+
+  expect(wrapper.find('select').element.value).toBe('option value')
 
   // requires <select multiple>
   const multiselect = wrapper.find('select')
   await multiselect.setValue(['value1', 'value3'])
+
+  const selectedOptions = Array.from(multiselect.element.selectedOptions).map(
+    o => o.value
+  )
+  expect(selectedOptions).toEqual(['value1', 'value3'])
 })
 ```
 

--- a/docs/guides/common-tips.md
+++ b/docs/guides/common-tips.md
@@ -153,9 +153,11 @@ describe('ParentComponent', () => {
 You can directly manipulate the state of the component using the `setData` or `setProps` method on the wrapper:
 
 ```js
-wrapper.setData({ count: 10 })
+it('manipulates state', async () => {
+  await wrapper.setData({ count: 10 })
 
-wrapper.setProps({ foo: 'bar' })
+  await wrapper.setProps({ foo: 'bar' })
+})
 ```
 
 ### Mocking Props

--- a/docs/ja/api/wrapper/setChecked.md
+++ b/docs/ja/api/wrapper/setChecked.md
@@ -14,7 +14,10 @@ import Foo from './Foo.vue'
 test('setChecked demo', async () => {
   const wrapper = mount(Foo)
   const radioInput = wrapper.find('input[type="radio"]')
+
   await radioInput.setChecked()
+
+  expect(radioInput.element.checked).toBeTruthy()
 })
 ```
 

--- a/docs/ja/api/wrapper/setChecked.md
+++ b/docs/ja/api/wrapper/setChecked.md
@@ -11,9 +11,11 @@ checkbox 型もしくは radio 型の input 要素の checked の値をセット
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-const radioInput = wrapper.find('input[type="radio"]')
-radioInput.setChecked()
+test('setChecked demo', async () => {
+  const wrapper = mount(Foo)
+  const radioInput = wrapper.find('input[type="radio"]')
+  await radioInput.setChecked()
+})
 ```
 
 - **注:**

--- a/docs/ja/api/wrapper/setData.md
+++ b/docs/ja/api/wrapper/setData.md
@@ -16,7 +16,9 @@ setData は再帰的に Vue.set を実行することで動作します。
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-wrapper.setData({ foo: 'bar' })
-expect(wrapper.vm.foo).toBe('bar')
+test('setData demo', async () => {
+  const wrapper = mount(Foo)
+  await wrapper.setData({ foo: 'bar' })
+  expect(wrapper.vm.foo).toBe('bar')
+})
 ```

--- a/docs/ja/api/wrapper/setData.md
+++ b/docs/ja/api/wrapper/setData.md
@@ -18,7 +18,9 @@ import Foo from './Foo.vue'
 
 test('setData demo', async () => {
   const wrapper = mount(Foo)
+
   await wrapper.setData({ foo: 'bar' })
+
   expect(wrapper.vm.foo).toBe('bar')
 })
 ```

--- a/docs/ja/api/wrapper/setProps.md
+++ b/docs/ja/api/wrapper/setProps.md
@@ -14,9 +14,11 @@
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-wrapper.setProps({ foo: 'bar' })
-expect(wrapper.vm.foo).toBe('bar')
+test('setProps demo', async () => {
+  const wrapper = mount(Foo)
+  await wrapper.setProps({ foo: 'bar' })
+  expect(wrapper.vm.foo).toBe('bar')
+})
 ```
 
 渡された値で Vue インスタンス を初期化する `propsData` オブジェクトを渡すことができます。

--- a/docs/ja/api/wrapper/setProps.md
+++ b/docs/ja/api/wrapper/setProps.md
@@ -16,7 +16,9 @@ import Foo from './Foo.vue'
 
 test('setProps demo', async () => {
   const wrapper = mount(Foo)
+
   await wrapper.setProps({ foo: 'bar' })
+
   expect(wrapper.vm.foo).toBe('bar')
 })
 ```

--- a/docs/ja/api/wrapper/setSelected.md
+++ b/docs/ja/api/wrapper/setSelected.md
@@ -8,10 +8,12 @@ option 要素を選択します。そして、 `v-model` に束縛されてい�
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-const options = wrapper.find('select').findAll('option')
+test('setSelected demo', async () => {
+  const wrapper = mount(Foo)
+  const options = wrapper.find('select').findAll('option')
 
-options.at(1).setSelected()
+  await options.at(1).setSelected()
+})
 ```
 
 - **注:**

--- a/docs/ja/api/wrapper/setSelected.md
+++ b/docs/ja/api/wrapper/setSelected.md
@@ -13,6 +13,8 @@ test('setSelected demo', async () => {
   const options = wrapper.find('select').findAll('option')
 
   await options.at(1).setSelected()
+
+  expect(wrapper.find('option:checked').element.value).toBe('bar')
 })
 ```
 

--- a/docs/ja/api/wrapper/setValue.md
+++ b/docs/ja/api/wrapper/setValue.md
@@ -12,17 +12,19 @@ text コントロールの input 要素の 値をセットします。そして�
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
+test('setValue demo', async () => {
+  const wrapper = mount(Foo)
 
-const textInput = wrapper.find('input[type="text"]')
-textInput.setValue('some value')
+  const textInput = wrapper.find('input[type="text"]')
+  await textInput.setValue('some value')
 
-const select = wrapper.find('select')
-select.setValue('option value')
+  const select = wrapper.find('select')
+  await select.setValue('option value')
 
-// requires <select multiple>
-const multiselect = wrapper.find('select')
-multiselect.setValue(['value1', 'value3'])
+  // requires <select multiple>
+  const multiselect = wrapper.find('select')
+  await multiselect.setValue(['value1', 'value3'])
+})
 ```
 
 - **注:**

--- a/docs/ja/api/wrapper/setValue.md
+++ b/docs/ja/api/wrapper/setValue.md
@@ -18,12 +18,21 @@ test('setValue demo', async () => {
   const textInput = wrapper.find('input[type="text"]')
   await textInput.setValue('some value')
 
+  expect(wrapper.find('input[type="text"]').element.value).toBe('some value')
+
   const select = wrapper.find('select')
   await select.setValue('option value')
+
+  expect(wrapper.find('select').element.value).toBe('option value')
 
   // requires <select multiple>
   const multiselect = wrapper.find('select')
   await multiselect.setValue(['value1', 'value3'])
+
+  const selectedOptions = Array.from(multiselect.element.selectedOptions).map(
+    o => o.value
+  )
+  expect(selectedOptions).toEqual(['value1', 'value3'])
 })
 ```
 

--- a/docs/ja/guides/common-tips.md
+++ b/docs/ja/guides/common-tips.md
@@ -63,9 +63,11 @@ expect(wrapper.emitted().foo[1]).toEqual([123])
 ラッパの `setData` メソッドまたは `setProps` メソッドを使って、コンポーネントの状態を直接操作することができます。:
 
 ```js
-wrapper.setData({ count: 10 })
+it('manipulates state', async () => {
+  await wrapper.setData({ count: 10 })
 
-wrapper.setProps({ foo: 'bar' })
+  await wrapper.setProps({ foo: 'bar' })
+})
 ```
 
 ### プロパティをモックする

--- a/docs/ru/api/wrapper/setChecked.md
+++ b/docs/ru/api/wrapper/setChecked.md
@@ -15,7 +15,10 @@ import Foo from './Foo.vue'
 test('setChecked demo', async () => {
   const wrapper = mount(Foo)
   const radioInput = wrapper.find('input[type="radio"]')
+
   await radioInput.setChecked()
+
+  expect(radioInput.element.checked).toBeTruthy()
 })
 ```
 

--- a/docs/ru/api/wrapper/setChecked.md
+++ b/docs/ru/api/wrapper/setChecked.md
@@ -12,9 +12,11 @@
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-const radioInput = wrapper.find('input[type="radio"]')
-radioInput.setChecked()
+test('setChecked demo', async () => {
+  const wrapper = mount(Foo)
+  const radioInput = wrapper.find('input[type="radio"]')
+  await radioInput.setChecked()
+})
 ```
 
 - **Примечание:**

--- a/docs/ru/api/wrapper/setData.md
+++ b/docs/ru/api/wrapper/setData.md
@@ -20,7 +20,9 @@ import Foo from './Foo.vue'
 
 test('setData demo', async () => {
   const wrapper = mount(Foo)
+
   await wrapper.setData({ foo: 'bar' })
+
   expect(wrapper.vm.foo).toBe('bar')
 })
 ```

--- a/docs/ru/api/wrapper/setData.md
+++ b/docs/ru/api/wrapper/setData.md
@@ -18,7 +18,9 @@ setData работает путём слияния существующих св
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-wrapper.setData({ foo: 'bar' })
-expect(wrapper.vm.foo).toBe('bar')
+test('setData demo', async () => {
+  const wrapper = mount(Foo)
+  await wrapper.setData({ foo: 'bar' })
+  expect(wrapper.vm.foo).toBe('bar')
+})
 ```

--- a/docs/ru/api/wrapper/setProps.md
+++ b/docs/ru/api/wrapper/setProps.md
@@ -16,7 +16,9 @@ import Foo from './Foo.vue'
 
 test('setProps demo', async () => {
   const wrapper = mount(Foo)
+
   await wrapper.setProps({ foo: 'bar' })
+
   expect(wrapper.vm.foo).toBe('bar')
 })
 ```

--- a/docs/ru/api/wrapper/setProps.md
+++ b/docs/ru/api/wrapper/setProps.md
@@ -14,9 +14,11 @@
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-wrapper.setProps({ foo: 'bar' })
-expect(wrapper.vm.foo).toBe('bar')
+test('setProps demo', async () => {
+  const wrapper = mount(Foo)
+  await wrapper.setProps({ foo: 'bar' })
+  expect(wrapper.vm.foo).toBe('bar')
+})
 ```
 
 Вы также можете передать объект `propsData`, который инициализирует экземпляр Vue с переданными значениями.

--- a/docs/ru/api/wrapper/setSelected.md
+++ b/docs/ru/api/wrapper/setSelected.md
@@ -8,10 +8,12 @@
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-const options = wrapper.find('select').findAll('option')
+test('setSelected demo', async () => {
+  const wrapper = mount(Foo)
+  const options = wrapper.find('select').findAll('option')
 
-options.at(1).setSelected()
+  await options.at(1).setSelected()
+})
 ```
 
 - **Примечание:**

--- a/docs/ru/api/wrapper/setSelected.md
+++ b/docs/ru/api/wrapper/setSelected.md
@@ -13,6 +13,8 @@ test('setSelected demo', async () => {
   const options = wrapper.find('select').findAll('option')
 
   await options.at(1).setSelected()
+
+  expect(wrapper.find('option:checked').element.value).toBe('bar')
 })
 ```
 

--- a/docs/ru/api/wrapper/setValue.md
+++ b/docs/ru/api/wrapper/setValue.md
@@ -12,17 +12,19 @@
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
+test('setValue demo', async () => {
+  const wrapper = mount(Foo)
 
-const textInput = wrapper.find('input[type="text"]')
-textInput.setValue('some value')
+  const textInput = wrapper.find('input[type="text"]')
+  await textInput.setValue('some value')
 
-const select = wrapper.find('select')
-select.setValue('option value')
+  const select = wrapper.find('select')
+  await select.setValue('option value')
 
-// требует <select multiple>
-const multiselect = wrapper.find('select')
-multiselect.setValue(['value1', 'value3'])
+  // requires <select multiple>
+  const multiselect = wrapper.find('select')
+  await multiselect.setValue(['value1', 'value3'])
+})
 ```
 
 - **Примечание:**

--- a/docs/ru/api/wrapper/setValue.md
+++ b/docs/ru/api/wrapper/setValue.md
@@ -18,12 +18,21 @@ test('setValue demo', async () => {
   const textInput = wrapper.find('input[type="text"]')
   await textInput.setValue('some value')
 
+  expect(wrapper.find('input[type="text"]').element.value).toBe('some value')
+
   const select = wrapper.find('select')
   await select.setValue('option value')
+
+  expect(wrapper.find('select').element.value).toBe('option value')
 
   // requires <select multiple>
   const multiselect = wrapper.find('select')
   await multiselect.setValue(['value1', 'value3'])
+
+  const selectedOptions = Array.from(multiselect.element.selectedOptions).map(
+    o => o.value
+  )
+  expect(selectedOptions).toEqual(['value1', 'value3'])
 })
 ```
 

--- a/docs/ru/guides/common-tips.md
+++ b/docs/ru/guides/common-tips.md
@@ -113,9 +113,11 @@ describe('ParentComponent', () => {
 Вы можете напрямую манипулировать состоянием компонента с помощью методов `setData` или `setProps` на обёртке:
 
 ```js
-wrapper.setData({ count: 10 })
+it('manipulates state', async () => {
+  await wrapper.setData({ count: 10 })
 
-wrapper.setProps({ foo: 'bar' })
+  await wrapper.setProps({ foo: 'bar' })
+})
 ```
 
 ### Моки входных параметров

--- a/docs/zh/api/wrapper/setChecked.md
+++ b/docs/zh/api/wrapper/setChecked.md
@@ -12,9 +12,11 @@
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-const radioInput = wrapper.find('input[type="radio"]')
-radioInput.setChecked()
+test('setChecked demo', async () => {
+  const wrapper = mount(Foo)
+  const radioInput = wrapper.find('input[type="radio"]')
+  await radioInput.setChecked()
+})
 ```
 
 - **注意：**

--- a/docs/zh/api/wrapper/setChecked.md
+++ b/docs/zh/api/wrapper/setChecked.md
@@ -15,7 +15,10 @@ import Foo from './Foo.vue'
 test('setChecked demo', async () => {
   const wrapper = mount(Foo)
   const radioInput = wrapper.find('input[type="radio"]')
+
   await radioInput.setChecked()
+
+  expect(radioInput.element.checked).toBeTruthy()
 })
 ```
 

--- a/docs/zh/api/wrapper/setData.md
+++ b/docs/zh/api/wrapper/setData.md
@@ -16,7 +16,9 @@
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-wrapper.setData({ foo: 'bar' })
-expect(wrapper.vm.foo).toBe('bar')
+test('setData demo', async () => {
+  const wrapper = mount(Foo)
+  await wrapper.setData({ foo: 'bar' })
+  expect(wrapper.vm.foo).toBe('bar')
+})
 ```

--- a/docs/zh/api/wrapper/setData.md
+++ b/docs/zh/api/wrapper/setData.md
@@ -18,7 +18,9 @@ import Foo from './Foo.vue'
 
 test('setData demo', async () => {
   const wrapper = mount(Foo)
+
   await wrapper.setData({ foo: 'bar' })
+
   expect(wrapper.vm.foo).toBe('bar')
 })
 ```

--- a/docs/zh/api/wrapper/setProps.md
+++ b/docs/zh/api/wrapper/setProps.md
@@ -14,9 +14,11 @@
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-wrapper.setProps({ foo: 'bar' })
-expect(wrapper.vm.foo).toBe('bar')
+test('setProps demo', async () => {
+  const wrapper = mount(Foo)
+  await wrapper.setProps({ foo: 'bar' })
+  expect(wrapper.vm.foo).toBe('bar')
+})
 ```
 
 你也可以传递一个 `propsData` 对象，这会用该对象来初始化 Vue 示例。

--- a/docs/zh/api/wrapper/setProps.md
+++ b/docs/zh/api/wrapper/setProps.md
@@ -16,7 +16,9 @@ import Foo from './Foo.vue'
 
 test('setProps demo', async () => {
   const wrapper = mount(Foo)
+
   await wrapper.setProps({ foo: 'bar' })
+
   expect(wrapper.vm.foo).toBe('bar')
 })
 ```

--- a/docs/zh/api/wrapper/setSelected.md
+++ b/docs/zh/api/wrapper/setSelected.md
@@ -8,10 +8,12 @@
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
-const options = wrapper.find('select').findAll('option')
+test('setSelected demo', async () => {
+  const wrapper = mount(Foo)
+  const options = wrapper.find('select').findAll('option')
 
-options.at(1).setSelected()
+  await options.at(1).setSelected()
+})
 ```
 
 - **注意：**

--- a/docs/zh/api/wrapper/setSelected.md
+++ b/docs/zh/api/wrapper/setSelected.md
@@ -13,6 +13,8 @@ test('setSelected demo', async () => {
   const options = wrapper.find('select').findAll('option')
 
   await options.at(1).setSelected()
+
+  expect(wrapper.find('option:checked').element.value).toBe('bar')
 })
 ```
 

--- a/docs/zh/api/wrapper/setValue.md
+++ b/docs/zh/api/wrapper/setValue.md
@@ -12,17 +12,19 @@
 import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 
-const wrapper = mount(Foo)
+test('setValue demo', async () => {
+  const wrapper = mount(Foo)
 
-const textInput = wrapper.find('input[type="text"]')
-textInput.setValue('some value')
+  const textInput = wrapper.find('input[type="text"]')
+  await textInput.setValue('some value')
 
-const select = wrapper.find('select')
-select.setValue('option value')
+  const select = wrapper.find('select')
+  await select.setValue('option value')
 
-// requires <select multiple>
-const multiselect = wrapper.find('select')
-multiselect.setValue(['value1', 'value3'])
+  // requires <select multiple>
+  const multiselect = wrapper.find('select')
+  await multiselect.setValue(['value1', 'value3'])
+})
 ```
 
 - **注意：**

--- a/docs/zh/api/wrapper/setValue.md
+++ b/docs/zh/api/wrapper/setValue.md
@@ -18,12 +18,21 @@ test('setValue demo', async () => {
   const textInput = wrapper.find('input[type="text"]')
   await textInput.setValue('some value')
 
+  expect(wrapper.find('input[type="text"]').element.value).toBe('some value')
+
   const select = wrapper.find('select')
   await select.setValue('option value')
+
+  expect(wrapper.find('select').element.value).toBe('option value')
 
   // requires <select multiple>
   const multiselect = wrapper.find('select')
   await multiselect.setValue(['value1', 'value3'])
+
+  const selectedOptions = Array.from(multiselect.element.selectedOptions).map(
+    o => o.value
+  )
+  expect(selectedOptions).toEqual(['value1', 'value3'])
 })
 ```
 

--- a/docs/zh/guides/common-tips.md
+++ b/docs/zh/guides/common-tips.md
@@ -151,9 +151,11 @@ describe('ParentComponent', () => {
 你可以在包裹器上用 `setData` 或 `setProps` 方法直接操作组件状态：
 
 ```js
-wrapper.setData({ count: 10 })
+it('manipulates state', async () => {
+  await wrapper.setData({ count: 10 })
 
-wrapper.setProps({ foo: 'bar' })
+  await wrapper.setProps({ foo: 'bar' })
+})
 ```
 
 ### 仿造 Prop


### PR DESCRIPTION
Since `sync` mode has been [removed](https://github.com/vuejs/vue-test-utils/issues/1137), many of the wrapper methods now return `nextTick`, which is `async` and is `await`able. These methods include [setValue](https://github.com/vuejs/vue-test-utils/blob/dev/packages/test-utils/src/wrapper.js#L739), [setSelected](https://github.com/vuejs/vue-test-utils/blob/dev/packages/test-utils/src/wrapper.js#L581), [setChecked](https://github.com/vuejs/vue-test-utils/blob/dev/packages/test-utils/src/wrapper.js#L534), [setData](https://github.com/vuejs/vue-test-utils/blob/dev/packages/test-utils/src/wrapper.js#L617), and [setProps](https://github.com/vuejs/vue-test-utils/blob/dev/packages/test-utils/src/wrapper.js#L659). Though these methods are `async`, the documentation has them referenced/used in a `sync` fashion. I am not sure if this is intentional or just missed with the `sync` removal, but the use of these methods seems a bit unclear. Hopefully updating the documentation will allow for clearer use. If there are issues with the examples I have updated (esp. likely on the offshoot examples), please let me know!

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Documentation Update

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
