### PR TITLE
Wrapper array consistency

### DIFF
--- a/docs/api/wrapper-array/setChecked.md
+++ b/docs/api/wrapper-array/setChecked.md
@@ -15,25 +15,27 @@ wrapperArray.wrappers.forEach(wrapper => wrapper.setChecked(checked))
 ```js
 import { mount } from '@vue/test-utils'
 
-const wrapper = mount({
-  data() {
-    return {
-      t1: false,
-      t2: ''
-    }
-  },
-  template: `
-    <div>
-      <input type="checkbox" name="t1" class="foo" v-model="t1" />
-      <input type="radio" name="t2" class="foo" value="foo" v-model="t2"/>
-      <input type="radio" name="t2" class="bar" value="bar" v-model="t2"/>
-    </div>`
-})
+test('setChecked demo', async () => {
+  const wrapper = mount({
+    data() {
+      return {
+        t1: false,
+        t2: ''
+      }
+    },
+    template: `
+      <div>
+        <input type="checkbox" name="t1" class="foo" v-model="t1" />
+        <input type="radio" name="t2" class="foo" value="foo" v-model="t2"/>
+        <input type="radio" name="t2" class="bar" value="bar" v-model="t2"/>
+      </div>`
+  })
 
-const wrapperArray = wrapper.findAll('.foo')
-expect(wrapper.vm.t1).toEqual(false)
-expect(wrapper.vm.t2).toEqual('')
-wrapperArray.setChecked()
-expect(wrapper.vm.t1).toEqual(true)
-expect(wrapper.vm.t2).toEqual('foo')
+  const wrapperArray = wrapper.findAll('.foo')
+  expect(wrapper.vm.t1).toEqual(false)
+  expect(wrapper.vm.t2).toEqual('')
+  await wrapperArray.setChecked()
+  expect(wrapper.vm.t1).toEqual(true)
+  expect(wrapper.vm.t2).toEqual('foo')
+})
 ```

--- a/docs/api/wrapper-array/setData.md
+++ b/docs/api/wrapper-array/setData.md
@@ -15,8 +15,10 @@ import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 
-const wrapper = mount(Foo)
-const barArray = wrapper.findAll(Bar)
-barArray.setData({ foo: 'bar' })
-expect(barArray.at(0).vm.foo).toBe('bar')
+test('setData demo', async () => {
+  const wrapper = mount(Foo)
+  const barArray = wrapper.findAll(Bar)
+  await barArray.setData({ foo: 'bar' })
+  expect(barArray.at(0).vm.foo).toBe('bar')
+})
 ```

--- a/docs/api/wrapper-array/setProps.md
+++ b/docs/api/wrapper-array/setProps.md
@@ -15,8 +15,10 @@ import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 
-const wrapper = mount(Foo)
-const barArray = wrapper.findAll(Bar)
-barArray.setProps({ foo: 'bar' })
-expect(barArray.at(0).vm.foo).toBe('bar')
+test('setProps demo', async () => {
+  const wrapper = mount(Foo)
+  const barArray = wrapper.findAll(Bar)
+  await barArray.setProps({ foo: 'bar' })
+  expect(barArray.at(0).vm.foo).toBe('bar')
+})
 ```

--- a/docs/api/wrapper-array/setValue.md
+++ b/docs/api/wrapper-array/setValue.md
@@ -29,10 +29,12 @@ const wrapper = mount({
     </div>`
 })
 
-const wrapperArray = wrapper.findAll('.foo')
-expect(wrapper.vm.t1).toEqual('')
-expect(wrapper.vm.t2).toEqual('')
-wrapperArray.setValue('foo')
-expect(wrapper.vm.t1).toEqual('foo')
-expect(wrapper.vm.t2).toEqual('foo')
+test('setValue demo', async () => {
+  const wrapperArray = wrapper.findAll('.foo')
+  expect(wrapper.vm.t1).toEqual('')
+  expect(wrapper.vm.t2).toEqual('')
+  await wrapperArray.setValue('foo')
+  expect(wrapper.vm.t1).toEqual('foo')
+  expect(wrapper.vm.t2).toEqual('foo')
+})
 ```

--- a/docs/api/wrapper-array/trigger.md
+++ b/docs/api/wrapper-array/trigger.md
@@ -16,12 +16,14 @@ import { mount } from '@vue/test-utils'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 
-const clickHandler = sinon.stub()
-const wrapper = mount(Foo, {
-  propsData: { clickHandler }
-})
+test('trigger demo', async () => {
+  const clickHandler = sinon.stub()
+  const wrapper = mount(Foo, {
+    propsData: { clickHandler }
+  })
 
-const divArray = wrapper.findAll('div')
-divArray.trigger('click')
-expect(clickHandler.called).toBe(true)
+  const divArray = wrapper.findAll('div')
+  await divArray.trigger('click')
+  expect(clickHandler.called).toBe(true)
+})
 ```

--- a/docs/ja/api/wrapper-array/setChecked.md
+++ b/docs/ja/api/wrapper-array/setChecked.md
@@ -15,25 +15,27 @@ wrapperArray.wrappers.forEach(wrapper => wrapper.setChecked(checked))
 ```js
 import { mount } from '@vue/test-utils'
 
-const wrapper = mount({
-  data() {
-    return {
-      t1: false,
-      t2: ''
-    }
-  },
-  template: `
-    <div>
-      <input type="checkbox" name="t1" class="foo" v-model="t1" />
-      <input type="radio" name="t2" class="foo" value="foo" v-model="t2"/>
-      <input type="radio" name="t2" class="bar" value="bar" v-model="t2"/>
-    </div>`
-})
+test('setChecked demo', async () => {
+  const wrapper = mount({
+    data() {
+      return {
+        t1: false,
+        t2: ''
+      }
+    },
+    template: `
+      <div>
+        <input type="checkbox" name="t1" class="foo" v-model="t1" />
+        <input type="radio" name="t2" class="foo" value="foo" v-model="t2"/>
+        <input type="radio" name="t2" class="bar" value="bar" v-model="t2"/>
+      </div>`
+  })
 
-const wrapperArray = wrapper.findAll('.foo')
-expect(wrapper.vm.t1).toEqual(false)
-expect(wrapper.vm.t2).toEqual('')
-wrapperArray.setChecked()
-expect(wrapper.vm.t1).toEqual(true)
-expect(wrapper.vm.t2).toEqual('foo')
+  const wrapperArray = wrapper.findAll('.foo')
+  expect(wrapper.vm.t1).toEqual(false)
+  expect(wrapper.vm.t2).toEqual('')
+  await wrapperArray.setChecked()
+  expect(wrapper.vm.t1).toEqual(true)
+  expect(wrapper.vm.t2).toEqual('foo')
+})
 ```

--- a/docs/ja/api/wrapper-array/setData.md
+++ b/docs/ja/api/wrapper-array/setData.md
@@ -15,8 +15,10 @@ import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 
-const wrapper = mount(Foo)
-const barArray = wrapper.findAll(Bar)
-barArray.setData({ foo: 'bar' })
-expect(barArray.at(0).vm.foo).toBe('bar')
+test('setData demo', async () => {
+  const wrapper = mount(Foo)
+  const barArray = wrapper.findAll(Bar)
+  await barArray.setData({ foo: 'bar' })
+  expect(barArray.at(0).vm.foo).toBe('bar')
+})
 ```

--- a/docs/ja/api/wrapper-array/setProps.md
+++ b/docs/ja/api/wrapper-array/setProps.md
@@ -15,8 +15,10 @@ import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 
-const wrapper = mount(Foo)
-const barArray = wrapper.findAll(Bar)
-barArray.setProps({ foo: 'bar' })
-expect(barArray.at(0).vm.foo).toBe('bar')
+test('setProps demo', async () => {
+  const wrapper = mount(Foo)
+  const barArray = wrapper.findAll(Bar)
+  await barArray.setProps({ foo: 'bar' })
+  expect(barArray.at(0).vm.foo).toBe('bar')
+})
 ```

--- a/docs/ja/api/wrapper-array/setValue.md
+++ b/docs/ja/api/wrapper-array/setValue.md
@@ -29,10 +29,12 @@ const wrapper = mount({
     </div>`
 })
 
-const wrapperArray = wrapper.findAll('.foo')
-expect(wrapper.vm.t1).toEqual('')
-expect(wrapper.vm.t2).toEqual('')
-wrapperArray.setValue('foo')
-expect(wrapper.vm.t1).toEqual('foo')
-expect(wrapper.vm.t2).toEqual('foo')
+test('setValue demo', async () => {
+  const wrapperArray = wrapper.findAll('.foo')
+  expect(wrapper.vm.t1).toEqual('')
+  expect(wrapper.vm.t2).toEqual('')
+  await wrapperArray.setValue('foo')
+  expect(wrapper.vm.t1).toEqual('foo')
+  expect(wrapper.vm.t2).toEqual('foo')
+})
 ```

--- a/docs/ja/api/wrapper-array/trigger.md
+++ b/docs/ja/api/wrapper-array/trigger.md
@@ -15,12 +15,14 @@ import { mount } from '@vue/test-utils'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 
-const clickHandler = sinon.stub()
-const wrapper = mount(Foo, {
-  propsData: { clickHandler }
-})
+test('trigger demo', async () => {
+  const clickHandler = sinon.stub()
+  const wrapper = mount(Foo, {
+    propsData: { clickHandler }
+  })
 
-const divArray = wrapper.findAll('div')
-divArray.trigger('click')
-expect(clickHandler.called).toBe(true)
+  const divArray = wrapper.findAll('div')
+  await divArray.trigger('click')
+  expect(clickHandler.called).toBe(true)
+})
 ```

--- a/docs/ja/api/wrapper/trigger.md
+++ b/docs/ja/api/wrapper/trigger.md
@@ -16,18 +16,24 @@ import { mount } from '@vue/test-utils'
 import sinon from 'sinon'
 import Foo from './Foo'
 
-const clickHandler = sinon.stub()
-const wrapper = mount(Foo, {
-  propsData: { clickHandler }
+test('trigger demo', async () => {
+  const clickHandler = sinon.stub()
+  const wrapper = mount(Foo, {
+    propsData: { clickHandler }
+  })
+
+  await wrapper.trigger('click')
+
+  await wrapper.trigger('click', {
+    button: 0
+  })
+
+  await wrapper.trigger('click', {
+    ctrlKey: true
+  })
+
+  expect(clickHandler.called).toBe(true)
 })
-
-wrapper.trigger('click')
-
-wrapper.trigger('click', {
-  button: 0
-})
-
-expect(clickHandler.called).toBe(true)
 ```
 
 - **イベントターゲットの設定:**

--- a/docs/ru/api/wrapper-array/setChecked.md
+++ b/docs/ru/api/wrapper-array/setChecked.md
@@ -15,25 +15,27 @@ wrapperArray.wrappers.forEach(wrapper => wrapper.setChecked(checked))
 ```js
 import { mount } from '@vue/test-utils'
 
-const wrapper = mount({
-  data() {
-    return {
-      t1: false,
-      t2: ''
-    }
-  },
-  template: `
-    <div>
-      <input type="checkbox" name="t1" class="foo" v-model="t1" />
-      <input type="radio" name="t2" class="foo" value="foo" v-model="t2"/>
-      <input type="radio" name="t2" class="bar" value="bar" v-model="t2"/>
-    </div>`
-})
+test('setChecked demo', async () => {
+  const wrapper = mount({
+    data() {
+      return {
+        t1: false,
+        t2: ''
+      }
+    },
+    template: `
+      <div>
+        <input type="checkbox" name="t1" class="foo" v-model="t1" />
+        <input type="radio" name="t2" class="foo" value="foo" v-model="t2"/>
+        <input type="radio" name="t2" class="bar" value="bar" v-model="t2"/>
+      </div>`
+  })
 
-const wrapperArray = wrapper.findAll('.foo')
-expect(wrapper.vm.t1).toEqual(false)
-expect(wrapper.vm.t2).toEqual('')
-wrapperArray.setChecked()
-expect(wrapper.vm.t1).toEqual(true)
-expect(wrapper.vm.t2).toEqual('foo')
+  const wrapperArray = wrapper.findAll('.foo')
+  expect(wrapper.vm.t1).toEqual(false)
+  expect(wrapper.vm.t2).toEqual('')
+  await wrapperArray.setChecked()
+  expect(wrapper.vm.t1).toEqual(true)
+  expect(wrapper.vm.t2).toEqual('foo')
+})
 ```

--- a/docs/ru/api/wrapper-array/setData.md
+++ b/docs/ru/api/wrapper-array/setData.md
@@ -15,8 +15,10 @@ import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 
-const wrapper = mount(Foo)
-const barArray = wrapper.findAll(Bar)
-barArray.setData({ foo: 'bar' })
-expect(barArray.at(0).vm.foo).toBe('bar')
+test('setData demo', async () => {
+  const wrapper = mount(Foo)
+  const barArray = wrapper.findAll(Bar)
+  await barArray.setData({ foo: 'bar' })
+  expect(barArray.at(0).vm.foo).toBe('bar')
+})
 ```

--- a/docs/ru/api/wrapper-array/setProps.md
+++ b/docs/ru/api/wrapper-array/setProps.md
@@ -15,8 +15,10 @@ import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 
-const wrapper = mount(Foo)
-const barArray = wrapper.findAll(Bar)
-barArray.setProps({ foo: 'bar' })
-expect(barArray.at(0).vm.foo).toBe('bar')
+test('setProps demo', async () => {
+  const wrapper = mount(Foo)
+  const barArray = wrapper.findAll(Bar)
+  await barArray.setProps({ foo: 'bar' })
+  expect(barArray.at(0).vm.foo).toBe('bar')
+})
 ```

--- a/docs/ru/api/wrapper-array/setValue.md
+++ b/docs/ru/api/wrapper-array/setValue.md
@@ -29,10 +29,12 @@ const wrapper = mount({
     </div>`
 })
 
-const wrapperArray = wrapper.findAll('.foo')
-expect(wrapper.vm.t1).toEqual('')
-expect(wrapper.vm.t2).toEqual('')
-wrapperArray.setValue('foo')
-expect(wrapper.vm.t1).toEqual('foo')
-expect(wrapper.vm.t2).toEqual('foo')
+test('setValue demo', async () => {
+  const wrapperArray = wrapper.findAll('.foo')
+  expect(wrapper.vm.t1).toEqual('')
+  expect(wrapper.vm.t2).toEqual('')
+  await wrapperArray.setValue('foo')
+  expect(wrapper.vm.t1).toEqual('foo')
+  expect(wrapper.vm.t2).toEqual('foo')
+})
 ```

--- a/docs/ru/api/wrapper-array/trigger.md
+++ b/docs/ru/api/wrapper-array/trigger.md
@@ -16,12 +16,14 @@ import { mount } from '@vue/test-utils'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 
-const clickHandler = sinon.stub()
-const wrapper = mount(Foo, {
-  propsData: { clickHandler }
-})
+test('trigger demo', async () => {
+  const clickHandler = sinon.stub()
+  const wrapper = mount(Foo, {
+    propsData: { clickHandler }
+  })
 
-const divArray = wrapper.findAll('div')
-divArray.trigger('click')
-expect(clickHandler.called).toBe(true)
+  const divArray = wrapper.findAll('div')
+  await divArray.trigger('click')
+  expect(clickHandler.called).toBe(true)
+})
 ```

--- a/docs/ru/api/wrapper/trigger.md
+++ b/docs/ru/api/wrapper/trigger.md
@@ -16,18 +16,24 @@ import { mount } from '@vue/test-utils'
 import sinon from 'sinon'
 import Foo from './Foo'
 
-const clickHandler = sinon.stub()
-const wrapper = mount(Foo, {
-  propsData: { clickHandler }
+test('trigger demo', async () => {
+  const clickHandler = sinon.stub()
+  const wrapper = mount(Foo, {
+    propsData: { clickHandler }
+  })
+
+  await wrapper.trigger('click')
+
+  await wrapper.trigger('click', {
+    button: 0
+  })
+
+  await wrapper.trigger('click', {
+    ctrlKey: true
+  })
+
+  expect(clickHandler.called).toBe(true)
 })
-
-wrapper.trigger('click')
-
-wrapper.trigger('click', {
-  button: 0
-})
-
-expect(clickHandler.called).toBe(true)
 ```
 
 - **Установка target для event:**

--- a/docs/zh/api/wrapper-array/setChecked.md
+++ b/docs/zh/api/wrapper-array/setChecked.md
@@ -15,25 +15,27 @@ wrapperArray.wrappers.forEach(wrapper => wrapper.setChecked(checked))
 ```js
 import { mount } from '@vue/test-utils'
 
-const wrapper = mount({
-  data() {
-    return {
-      t1: false,
-      t2: ''
-    }
-  },
-  template: `
-    <div>
-      <input type="checkbox" name="t1" class="foo" v-model="t1" />
-      <input type="radio" name="t2" class="foo" value="foo" v-model="t2"/>
-      <input type="radio" name="t2" class="bar" value="bar" v-model="t2"/>
-    </div>`
-})
+test('setChecked demo', async () => {
+  const wrapper = mount({
+    data() {
+      return {
+        t1: false,
+        t2: ''
+      }
+    },
+    template: `
+      <div>
+        <input type="checkbox" name="t1" class="foo" v-model="t1" />
+        <input type="radio" name="t2" class="foo" value="foo" v-model="t2"/>
+        <input type="radio" name="t2" class="bar" value="bar" v-model="t2"/>
+      </div>`
+  })
 
-const wrapperArray = wrapper.findAll('.foo')
-expect(wrapper.vm.t1).toEqual(false)
-expect(wrapper.vm.t2).toEqual('')
-wrapperArray.setChecked()
-expect(wrapper.vm.t1).toEqual(true)
-expect(wrapper.vm.t2).toEqual('foo')
+  const wrapperArray = wrapper.findAll('.foo')
+  expect(wrapper.vm.t1).toEqual(false)
+  expect(wrapper.vm.t2).toEqual('')
+  await wrapperArray.setChecked()
+  expect(wrapper.vm.t1).toEqual(true)
+  expect(wrapper.vm.t2).toEqual('foo')
+})
 ```

--- a/docs/zh/api/wrapper-array/setData.md
+++ b/docs/zh/api/wrapper-array/setData.md
@@ -15,8 +15,10 @@ import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 
-const wrapper = mount(Foo)
-const barArray = wrapper.findAll(Bar)
-barArray.setData({ foo: 'bar' })
-expect(barArray.at(0).vm.foo).toBe('bar')
+test('setData demo', async () => {
+  const wrapper = mount(Foo)
+  const barArray = wrapper.findAll(Bar)
+  await barArray.setData({ foo: 'bar' })
+  expect(barArray.at(0).vm.foo).toBe('bar')
+})
 ```

--- a/docs/zh/api/wrapper-array/setProps.md
+++ b/docs/zh/api/wrapper-array/setProps.md
@@ -15,8 +15,10 @@ import { mount } from '@vue/test-utils'
 import Foo from './Foo.vue'
 import Bar from './Bar.vue'
 
-const wrapper = mount(Foo)
-const barArray = wrapper.findAll(Bar)
-barArray.setProps({ foo: 'bar' })
-expect(barArray.at(0).vm.foo).toBe('bar')
+test('setProps demo', async () => {
+  const wrapper = mount(Foo)
+  const barArray = wrapper.findAll(Bar)
+  await barArray.setProps({ foo: 'bar' })
+  expect(barArray.at(0).vm.foo).toBe('bar')
+})
 ```

--- a/docs/zh/api/wrapper-array/setValue.md
+++ b/docs/zh/api/wrapper-array/setValue.md
@@ -29,10 +29,12 @@ const wrapper = mount({
     </div>`
 })
 
-const wrapperArray = wrapper.findAll('.foo')
-expect(wrapper.vm.t1).toEqual('')
-expect(wrapper.vm.t2).toEqual('')
-wrapperArray.setValue('foo')
-expect(wrapper.vm.t1).toEqual('foo')
-expect(wrapper.vm.t2).toEqual('foo')
+test('setValue demo', async () => {
+  const wrapperArray = wrapper.findAll('.foo')
+  expect(wrapper.vm.t1).toEqual('')
+  expect(wrapper.vm.t2).toEqual('')
+  await wrapperArray.setValue('foo')
+  expect(wrapper.vm.t1).toEqual('foo')
+  expect(wrapper.vm.t2).toEqual('foo')
+})
 ```

--- a/docs/zh/api/wrapper-array/trigger.md
+++ b/docs/zh/api/wrapper-array/trigger.md
@@ -16,12 +16,14 @@ import { mount } from '@vue/test-utils'
 import sinon from 'sinon'
 import Foo from './Foo.vue'
 
-const clickHandler = sinon.stub()
-const wrapper = mount(Foo, {
-  propsData: { clickHandler }
-})
+test('trigger demo', async () => {
+  const clickHandler = sinon.stub()
+  const wrapper = mount(Foo, {
+    propsData: { clickHandler }
+  })
 
-const divArray = wrapper.findAll('div')
-divArray.trigger('click')
-expect(clickHandler.called).toBe(true)
+  const divArray = wrapper.findAll('div')
+  await divArray.trigger('click')
+  expect(clickHandler.called).toBe(true)
+})
 ```

--- a/packages/test-utils/src/wrapper-array.js
+++ b/packages/test-utils/src/wrapper-array.js
@@ -217,10 +217,12 @@ export default class WrapperArray implements BaseWrapper {
     )
   }
 
-  trigger(event: string, options: Object): void {
+  trigger(event: string, options: Object): Promise<any> {
     this.throwErrorIfWrappersIsEmpty('trigger')
 
-    this.wrappers.forEach(wrapper => wrapper.trigger(event, options))
+    return Promise.all(
+      this.wrappers.map(wrapper => wrapper.trigger(event, options))
+    )
   }
 
   destroy(): void {

--- a/packages/test-utils/src/wrapper-array.js
+++ b/packages/test-utils/src/wrapper-array.js
@@ -200,10 +200,12 @@ export default class WrapperArray implements BaseWrapper {
     return Promise.all(this.wrappers.map(wrapper => wrapper.setValue(value)))
   }
 
-  setChecked(checked: boolean = true): void {
+  setChecked(checked: boolean = true): Promise<any> {
     this.throwErrorIfWrappersIsEmpty('setChecked')
 
-    this.wrappers.forEach(wrapper => wrapper.setChecked(checked))
+    return Promise.all(
+      this.wrappers.map(wrapper => wrapper.setChecked(checked))
+    )
   }
 
   setSelected(): void {

--- a/packages/test-utils/src/wrapper-array.js
+++ b/packages/test-utils/src/wrapper-array.js
@@ -188,10 +188,10 @@ export default class WrapperArray implements BaseWrapper {
     this.wrappers.forEach(wrapper => wrapper.setMethods(props))
   }
 
-  setProps(props: Object): void {
+  setProps(props: Object): Promise<any> {
     this.throwErrorIfWrappersIsEmpty('setProps')
 
-    this.wrappers.forEach(wrapper => wrapper.setProps(props))
+    return Promise.all(this.wrappers.map(wrapper => wrapper.setProps(props)))
   }
 
   setValue(value: any): void {

--- a/packages/test-utils/src/wrapper-array.js
+++ b/packages/test-utils/src/wrapper-array.js
@@ -176,10 +176,10 @@ export default class WrapperArray implements BaseWrapper {
     }
   }
 
-  setData(data: Object): void {
+  setData(data: Object): Promise<any> {
     this.throwErrorIfWrappersIsEmpty('setData')
 
-    this.wrappers.forEach(wrapper => wrapper.setData(data))
+    return Promise.all(this.wrappers.map(wrapper => wrapper.setData(data)))
   }
 
   setMethods(props: Object): void {

--- a/packages/test-utils/src/wrapper-array.js
+++ b/packages/test-utils/src/wrapper-array.js
@@ -194,10 +194,10 @@ export default class WrapperArray implements BaseWrapper {
     return Promise.all(this.wrappers.map(wrapper => wrapper.setProps(props)))
   }
 
-  setValue(value: any): void {
+  setValue(value: any): Promise<any> {
     this.throwErrorIfWrappersIsEmpty('setValue')
 
-    this.wrappers.forEach(wrapper => wrapper.setValue(value))
+    return Promise.all(this.wrappers.map(wrapper => wrapper.setValue(value)))
   }
 
   setChecked(checked: boolean = true): void {

--- a/test/specs/wrapper-array.spec.js
+++ b/test/specs/wrapper-array.spec.js
@@ -219,11 +219,11 @@ describeWithShallowAndMount('WrapperArray', mountingMethod => {
     expect(setMethods).toHaveBeenCalledWith(methods)
   })
 
-  it('setData calls setData on each wrapper', () => {
-    const setData = jest.fn()
+  it('setData calls setData on each wrapper', async () => {
+    const setData = jest.fn().mockResolvedValue()
     const data = {}
     const wrapperArray = getWrapperArray([{ setData }, { setData }])
-    wrapperArray.setData(data)
+    await wrapperArray.setData(data)
     expect(setData).toHaveBeenCalledTimes(2)
     expect(setData).toHaveBeenCalledWith(data)
   })

--- a/test/specs/wrapper-array.spec.js
+++ b/test/specs/wrapper-array.spec.js
@@ -254,12 +254,12 @@ describeWithShallowAndMount('WrapperArray', mountingMethod => {
     expect(setChecked).toHaveBeenCalledWith(true)
   })
 
-  it('trigger calls trigger on each wrapper', () => {
-    const trigger = jest.fn()
+  it('trigger calls trigger on each wrapper', async () => {
+    const trigger = jest.fn().mockResolvedValue()
     const event = 'click'
     const options = {}
     const wrapperArray = getWrapperArray([{ trigger }, { trigger }])
-    wrapperArray.trigger(event, options)
+    await wrapperArray.trigger(event, options)
     expect(trigger).toHaveBeenCalledTimes(2)
     expect(trigger).toHaveBeenCalledWith(event, options)
   })

--- a/test/specs/wrapper-array.spec.js
+++ b/test/specs/wrapper-array.spec.js
@@ -237,6 +237,15 @@ describeWithShallowAndMount('WrapperArray', mountingMethod => {
     expect(setProps).toHaveBeenCalledWith(props)
   })
 
+  it('setValue calls setValue on each wrapper', async () => {
+    const setValue = jest.fn().mockResolvedValue()
+    const value = {}
+    const wrapperArray = getWrapperArray([{ setValue }, { setValue }])
+    await wrapperArray.setValue(value)
+    expect(setValue).toHaveBeenCalledTimes(2)
+    expect(setValue).toHaveBeenCalledWith(value)
+  })
+
   it('trigger calls trigger on each wrapper', () => {
     const trigger = jest.fn()
     const event = 'click'

--- a/test/specs/wrapper-array.spec.js
+++ b/test/specs/wrapper-array.spec.js
@@ -246,6 +246,14 @@ describeWithShallowAndMount('WrapperArray', mountingMethod => {
     expect(setValue).toHaveBeenCalledWith(value)
   })
 
+  it('setChecked calls setChecked on each wrapper', async () => {
+    const setChecked = jest.fn().mockResolvedValue()
+    const wrapperArray = getWrapperArray([{ setChecked }, { setChecked }])
+    await wrapperArray.setChecked()
+    expect(setChecked).toHaveBeenCalledTimes(2)
+    expect(setChecked).toHaveBeenCalledWith(true)
+  })
+
   it('trigger calls trigger on each wrapper', () => {
     const trigger = jest.fn()
     const event = 'click'

--- a/test/specs/wrapper-array.spec.js
+++ b/test/specs/wrapper-array.spec.js
@@ -228,11 +228,11 @@ describeWithShallowAndMount('WrapperArray', mountingMethod => {
     expect(setData).toHaveBeenCalledWith(data)
   })
 
-  it('setProps calls setProps on each wrapper', () => {
-    const setProps = jest.fn()
+  it('setProps calls setProps on each wrapper', async () => {
+    const setProps = jest.fn().mockResolvedValue()
     const props = {}
     const wrapperArray = getWrapperArray([{ setProps }, { setProps }])
-    wrapperArray.setProps(props)
+    await wrapperArray.setProps(props)
     expect(setProps).toHaveBeenCalledTimes(2)
     expect(setProps).toHaveBeenCalledWith(props)
   })


### PR DESCRIPTION
Currently, the `wrapper-array` and `wrapper` API's are a bit diverged. The standalone `wrapper` is `await`able, but the `wrapper-array` is not currently, which means other means of promise settling are needed to make sure the components are updated in `wrapper-array`. This PR allows for those `wrapper-array` items to be `await`ed and consistent with the `wrapper` API. 

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Documentation Update

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
