### PR TITLE
fix(test-utils): allow findComponent to be chained off find, fix #1644

### DIFF
--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -237,11 +237,6 @@ export default class Wrapper implements BaseWrapper {
    */
   findComponent(rawSelector: Selector): Wrapper | ErrorWrapper {
     const selector = getSelector(rawSelector, 'findComponent')
-    if (!this.vm && !this.isFunctionalComponent) {
-      throwError(
-        'You cannot chain findComponent off a DOM element. It can only be used on Vue Components.'
-      )
-    }
 
     if (selector.type === DOM_SELECTOR) {
       throwError(
@@ -285,11 +280,6 @@ export default class Wrapper implements BaseWrapper {
    */
   findAllComponents(rawSelector: Selector): WrapperArray {
     const selector = getSelector(rawSelector, 'findAll')
-    if (!this.vm) {
-      throwError(
-        'You cannot chain findAllComponents off a DOM element. It can only be used on Vue Components.'
-      )
-    }
     if (selector.type === DOM_SELECTOR) {
       throwError(
         'findAllComponents requires a Vue constructor or valid find object. If you are searching for DOM nodes, use `find` instead'

--- a/test/specs/wrapper/find.spec.js
+++ b/test/specs/wrapper/find.spec.js
@@ -148,12 +148,16 @@ describeWithShallowAndMount('find', mountingMethod => {
     expect(fn).toThrow(message)
   })
 
-  it('throws an error if findComponent is chained off a DOM element', () => {
+  it('returns Wrapper of Vue Components matching component using findComponent chained off find', () => {
     const wrapper = mountingMethod(ComponentWithChild)
-    const message =
-      '[vue-test-utils]: You cannot chain findComponent off a DOM element. It can only be used on Vue Components.'
-    const fn = () => wrapper.find('span').findComponent('#foo')
-    expect(fn).toThrow(message)
+    expect(wrapper.find('span').findComponent(Component).vnode).toBeTruthy()
+  })
+
+  it('returns Wrapper of Vue Components matching component name using findComponent chained off find', () => {
+    const wrapper = mountingMethod(ComponentWithChild)
+    expect(
+      wrapper.find('span').findComponent({ name: 'test-component' }).vnode
+    ).toBeTruthy()
   })
 
   it('allows using findComponent on functional component', () => {

--- a/test/specs/wrapper/findAll.spec.js
+++ b/test/specs/wrapper/findAll.spec.js
@@ -157,12 +157,31 @@ describeWithShallowAndMount('findAll', mountingMethod => {
     expect(fn).toThrow(message)
   })
 
-  it('throws an error if chaining findAllComponents off a DOM element', () => {
+  it('returns an array of VueWrappers of Vue Components matching component using findAllComponents chained off find', () => {
     const wrapper = mountingMethod(ComponentWithChild)
-    const message =
-      '[vue-test-utils]: You cannot chain findAllComponents off a DOM element. It can only be used on Vue Components.'
-    const fn = () => wrapper.find('span').findAllComponents('#foo')
-    expect(fn).toThrow(message)
+    const componentArr = wrapper.find('span').findAllComponents(Component)
+    expect(componentArr.length).toEqual(1)
+  })
+
+  it('returns an array of VueWrappers of Vue Components matching component name using findAllComponents chained off find', () => {
+    const wrapper = mountingMethod(ComponentWithChild)
+    const componentArr = wrapper
+      .find('span')
+      .findAllComponents({ name: 'test-component' })
+    expect(componentArr.length).toEqual(1)
+  })
+
+  it('allows using findAllComponents on a functional component', () => {
+    const FuncComponentWithChildren = {
+      functional: true,
+      components: {
+        ChildComponent: Component
+      },
+      render: h => h('div', {}, [h(Component)])
+    }
+    const wrapper = mountingMethod(FuncComponentWithChildren)
+    const componentArr = wrapper.findAllComponents(Component)
+    expect(componentArr.length).toEqual(1)
   })
 
   it('returns correct number of Vue Wrapper when component has a v-for', () => {


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**

Fixes #1644