### PR TITLE
docs: uses 'findComponent' to find components instead of 'find'

### DIFF
--- a/docs/guides/common-tips.md
+++ b/docs/guides/common-tips.md
@@ -142,7 +142,7 @@ import ChildComponent from '@/components/ChildComponent'
 describe('ParentComponent', () => {
   it("displays 'Emitted!' when custom event is emitted", () => {
     const wrapper = mount(ParentComponent)
-    wrapper.find(ChildComponent).vm.$emit('custom')
+    wrapper.findComponent(ChildComponent).vm.$emit('custom')
     expect(wrapper.html()).toContain('Emitted!')
   })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ X] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X ] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The Wrapper function [find](https://vue-test-utils.vuejs.org/api/wrapper/#find) is deprecated for searching components. We should use [findComponent](https://vue-test-utils.vuejs.org/api/wrapper/findComponent.html) instead.