### PR TITLE
Added additional check before adding the ._error property

### DIFF
--- a/packages/test-utils/src/error.js
+++ b/packages/test-utils/src/error.js
@@ -8,7 +8,7 @@ function errorHandler(errorOrString, vm) {
   if (vm) {
     vm._error = error
   }
-  
+
   throw error
 }
 

--- a/packages/test-utils/src/error.js
+++ b/packages/test-utils/src/error.js
@@ -5,7 +5,10 @@ function errorHandler(errorOrString, vm) {
   const error =
     typeof errorOrString === 'object' ? errorOrString : new Error(errorOrString)
 
-  vm._error = error
+  if (vm) {
+    vm._error = error
+  }
+  
   throw error
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**

Sometimes an error may occur in nextTick. In this case an error message will be displayed in the console:
```
  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "[Vue warn]: Error in config.errorHandler: "TypeError: Cannot set property '_error' of undefined"".

      at BufferedConsole.error (node_modules/@jest/console/build/BufferedConsole.js:165:10)
      at warn (node_modules/vue/dist/vue.runtime.common.dev.js:621:15)
      at logError (node_modules/vue/dist/vue.runtime.common.dev.js:1880:5)
      at globalHandleError (node_modules/vue/dist/vue.runtime.common.dev.js:1871:9)
      at handleError (node_modules/vue/dist/vue.runtime.common.dev.js:1835:5)
      at Array.<anonymous> (node_modules/vue/dist/vue.runtime.common.dev.js:1978:9)
      at flushCallbacks (node_modules/vue/dist/vue.runtime.common.dev.js:1902:14)
```

In Vue in the nextTick handler, the context is an optional parameter (https://github.com/vuejs/vue/blob/dev/src/core/util/next-tick.js#L87-L95):
```
export function nextTick (cb?: Function, ctx?: Object) {
  let _resolve
  callbacks.push(() => {
    if (cb) {
      try {
        cb.call(ctx)
      } catch (e) {
        handleError(e, ctx, 'nextTick')
      }
// ...
```

In the `handleError` handler, the presence of `vm` is checked first, but later, if not, it is still called (https://github.com/vuejs/vue/blob/dev/src/core/util/error.js#L9-L30):
```
export function handleError (err: Error, vm: any, info: string) {
  // Deactivate deps tracking while processing error handler to avoid possible infinite rendering.
  // See: https://github.com/vuejs/vuex/issues/1505
  pushTarget()
  try {
    if (vm) {
      let cur = vm
      while ((cur = cur.$parent)) {
        const hooks = cur.$options.errorCaptured
        if (hooks) {
          for (let i = 0; i < hooks.length; i++) {
            try {
              const capture = hooks[i].call(cur, err, vm, info) === false
              if (capture) return
            } catch (e) {
              globalHandleError(e, cur, 'errorCaptured hook')
            }
          }
        }
      }
    }
    globalHandleError(err, vm, info)
//...
```

Finally, vue-test-utils register global error handler and try to add the new `._error` property to the `vm` parameter which can be undefined (https://github.com/vuejs/vue-test-utils/blob/dev/packages/test-utils/src/error.js#L4-L10):
```
function errorHandler(errorOrString, vm) {
  const error =
    typeof errorOrString === 'object' ? errorOrString : new Error(errorOrString)

  vm._error = error
  throw error
}
```

This PR adds extra checking in case.