### PR TITLE
fix a typo in common-tips.md

### DIFF
--- a/docs/guides/common-tips.md
+++ b/docs/guides/common-tips.md
@@ -14,7 +14,7 @@ This topic is discussed with more details in a [great presentation by Matt O'Con
 
 ### Shallow mounting
 
-Sometimes, mounting a whole component with all its all dependencies might become slow or cumbersome. For example, components that contain many child components.
+Sometimes, mounting a whole component with all its dependencies might become slow or cumbersome. For example, components that contain many child components.
 
 Vue Test Utils allows you to mount a component without rendering its child components (by stubbing them) with the [`shallowMount`](../api/#shallowmount) method.
 


### PR DESCRIPTION
Fixed a typo in the first sentence of shallow mounting.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe: Typo Inside Docs

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
