### PR TITLE
docs(common-tips): fix syntax error

### DIFF
--- a/docs/guides/common-tips.md
+++ b/docs/guides/common-tips.md
@@ -56,9 +56,9 @@ it('updates text', async () => {
 it('render text', done => {
   const wrapper = mount(TestComponent)
   wrapper.trigger('click').then(() => {
-    wrapper.text().toContain('updated')
+    expect(wrapper.text()).toContain('updated')
     wrapper.trigger('click').then(() => {
-      wrapper.text().toContain('some different text')
+      expect(wrapper.text()).toContain('some different text')
       done()
     })
   })


### PR DESCRIPTION
Add missing `expect` in assertion


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Documentation fix

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
