### PR TITLE
fix #1655: extend Vue parent with options to support accessing root.$store in Composition API plugin

### DIFF
--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -123,7 +123,13 @@ export default function createInstance(
       createChildren(this, h, options)
     )
   }
-  const Parent = _Vue.extend(parentComponentOptions)
+
+  // options  "propsData" can only be used during instance creation with the `new` keyword
+  const { propsData, ...rest } = options // eslint-disable-line
+  const Parent = _Vue.extend({
+    ...rest,
+    ...parentComponentOptions
+  })
 
   return new Parent()
 }

--- a/test/specs/mount.spec.js
+++ b/test/specs/mount.spec.js
@@ -419,6 +419,24 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'mount', () => {
     expect(wrapper.html()).toEqual('<div>composition api</div>')
   })
 
+  it('allows accessing $root with composition api plugin', () => {
+    const localVue = createLocalVue()
+    localVue.use(Vuex)
+    localVue.use(CompositionAPI)
+    const store = new Vuex.Store({
+      state: {
+        msg: 'msg'
+      }
+    })
+    const Comp = {
+      setup(props, ctx) {
+        return () => createElement('div', ctx.root.$store.state.msg)
+      }
+    }
+    const wrapper = mount(Comp, { localVue, store })
+    expect(wrapper.html()).toEqual('<div>msg</div>')
+  })
+
   itDoNotRunIf.skip(
     vueVersion >= 2.5,
     'throws if component throws during update',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
