### PR TITLE
fix: handle shallowMount on components with v-if and scoped slots

### DIFF
--- a/packages/create-instance/create-component-stubs.js
+++ b/packages/create-instance/create-component-stubs.js
@@ -95,7 +95,7 @@ function resolveOptions(component, _Vue) {
 function getScopedSlotRenderFunctions(ctx: any): Array<string> {
   // In Vue 2.6+ a new v-slot syntax was introduced
   // scopedSlots are now saved in parent._vnode.data.scopedSlots
-  // We filter out the _normalized and $stable key
+  // We filter out _normalized, $stable and $key keys
   if (
     ctx &&
     ctx.$options &&
@@ -105,7 +105,9 @@ function getScopedSlotRenderFunctions(ctx: any): Array<string> {
     ctx.$options.parent._vnode.data.scopedSlots
   ) {
     const slotKeys: Array<string> = ctx.$options.parent._vnode.data.scopedSlots
-    return keys(slotKeys).filter(x => x !== '_normalized' && x !== '$stable')
+    return keys(slotKeys).filter(
+      x => x !== '_normalized' && x !== '$stable' && x !== '$key'
+    )
   }
 
   return []

--- a/test/specs/shallow-mount.spec.js
+++ b/test/specs/shallow-mount.spec.js
@@ -150,6 +150,30 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'shallowMount', () => {
     )
   })
 
+  it('renders named slots when they are located inside component with v-if', () => {
+    const localVue = createLocalVue()
+    localVue.component('Foo', {
+      template: '<div><slot name="newSyntax" /></div>'
+    })
+    const TestComponent = {
+      template: `
+        <Foo v-if="true">
+          <template v-slot:newSyntax>
+            <p class="new-example">text</p>
+          </template>
+        </Foo>
+      `
+    }
+    const wrapper = shallowMount(TestComponent, {
+      localVue
+    })
+    expect(wrapper.find({ name: 'Foo' }).exists()).toEqual(true)
+    expect(wrapper.find('.new-example').exists()).toEqual(true)
+    expect(wrapper.html()).toEqual(
+      '<foo-stub>\n' + '  <p class="new-example">text</p>\n' + '</foo-stub>'
+    )
+  })
+
   it('renders no children if none supplied', () => {
     const TestComponent = {
       template: '<child />',


### PR DESCRIPTION
https://github.com/vuejs/vue/commit/d9b27a92bd5277ee23a4e68a8bd31ecc72f4c99b introduced a new `$key` property, stored inside `scopedSlots` to solve issues when component with scoped-slots is rendered inside `v-if`

As for now VTU crashes when trying to `shallowRender` such component, since $key is not filtered out when VTU tries to invoke each slot. This MR fixes this behavior 

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch.
- [-] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included
