### PR TITLE
docs: document resetAutoDestroyState method, fix #1638

### DIFF
--- a/docs/api/enableAutoDestroy.md
+++ b/docs/api/enableAutoDestroy.md
@@ -23,3 +23,33 @@ describe('Foo', () => {
   })
 })
 ```
+
+## resetAutoDestroyState
+
+- **Usage:**
+
+After calling `enableAutoDestroy` you might need to disable auto-destroy behavior (for example when some of your test suites rely on wrapper being persistent across separate tests)
+
+To achieve this you might call `resetAutoDestroyState` to disable previously registered hook
+
+```js
+import {
+  enableAutoDestroy,
+  resetAutoDestroyState,
+  mount
+} from '@vue/test-utils'
+import Foo from './Foo.vue'
+
+// calls wrapper.destroy() after each test
+enableAutoDestroy(afterEach)
+// resets auto-destroy after suite completes
+afterAll(resetAutoDestroyState)
+
+describe('Foo', () => {
+  it('renders a div', () => {
+    const wrapper = mount(Foo)
+    expect(wrapper.contains('div')).toBe(true)
+    // no need to call wrapper.destroy() here
+  })
+})
+```


### PR DESCRIPTION
`resetAutoDestroyState` hook was pretty poorly documented - it is mentioned only in `enableAutoDestroy` documentation. This PR adds it to docs as method to make it more visible and easily discoverable for users

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe: docs

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch.
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
