### PR TITLE
feat: remove deprecation when `is` is called with component definition

### DIFF
--- a/docs/api/wrapper/is.md
+++ b/docs/api/wrapper/is.md
@@ -1,16 +1,18 @@
 ## is
 
 ::: warning Deprecation warning
-Using `is` to assert that DOM node or `vm` matches selector is deprecated and will be removed.
+Using `is` to assert that wrapper matches DOM selector is deprecated and will be removed.
 
-Consider a custom matcher such as those provided in [jest-dom](https://github.com/testing-library/jest-dom#custom-matchers).
+For such use cases consider a custom matcher such as those provided in [jest-dom](https://github.com/testing-library/jest-dom#custom-matchers).
 or for DOM element type assertion use native [`Element.tagName`](https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName) instead.
 
 To keep these tests, a valid replacement for:
 
-- `is('DOM_SELECTOR')` is a assertion of `wrapper.element.tagName`.
+- `is('DOM_SELECTOR')` is an assertion of `wrapper.element.tagName`.
 - `is('ATTR_NAME')` is a truthy assertion of `wrapper.attributes('ATTR_NAME')`.
 - `is('CLASS_NAME')` is a truthy assertion of `wrapper.classes('CLASS_NAME')`.
+
+Assertion against component definition is not deprecated
 
 When using with findComponent, access the DOM element with `findComponent(Comp).element`
 :::

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -321,12 +321,17 @@ export default class Wrapper implements BaseWrapper {
   }
 
   /**
-   * Checks if node matches selector
-   * @deprecated
+   * Checks if node matches selector or component definition
    */
   is(rawSelector: Selector): boolean {
-    warnDeprecated('is', 'Use element.tagName instead')
     const selector = getSelector(rawSelector, 'is')
+
+    if (selector.type === DOM_SELECTOR) {
+      warnDeprecated(
+        'checking tag name with `is`',
+        'Use `element.tagName` instead'
+      )
+    }
 
     if (selector.type === REF_SELECTOR) {
       throwError('$ref selectors can not be used with wrapper.is()')


### PR DESCRIPTION
See #1532 for discussion

This PR removes deprecation warnings when `is` is called against component definition:

```js
// generates warning
expect(wrapper.is('div')).toBe(true);
// does not generate warning
expect(wrapper.is(SomeComponent)).toBe(true)
```

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included
