### PR TITLE
fix: support v-text on child functional components with shallowMount (fix #1693)

### DIFF
--- a/packages/create-instance/create-component-stubs.js
+++ b/packages/create-instance/create-component-stubs.js
@@ -135,6 +135,9 @@ export function createStubFromComponent(
         tagName,
         {
           ref: componentOptions.functional ? context.data.ref : undefined,
+          domProps: componentOptions.functional
+            ? context.data.domProps
+            : undefined,
           attrs: componentOptions.functional
             ? {
                 ...context.props,

--- a/test/resources/components/component-with-functional-child.vue
+++ b/test/resources/components/component-with-functional-child.vue
@@ -1,6 +1,7 @@
 <template>
   <functional-component
     :class="{ bar: a + b === 2, foo: a === 1, qux: a === 2 }"
+    v-text="something"
   />
 </template>
 
@@ -15,7 +16,8 @@ export default {
   data() {
     return {
       a: 1,
-      b: 1
+      b: 1,
+      something: 'value'
     }
   }
 }

--- a/test/resources/components/functional-component.vue
+++ b/test/resources/components/functional-component.vue
@@ -1,3 +1,5 @@
 <template functional>
-  <div />
+  <div>
+    <slot />
+  </div>
 </template>

--- a/test/specs/shallow-mount.spec.js
+++ b/test/specs/shallow-mount.spec.js
@@ -41,6 +41,11 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'shallowMount', () => {
     )
   })
 
+  it('renders v-text content of functional child', () => {
+    const wrapper = shallowMount(ComponentWithFunctionalChild)
+    expect(wrapper.find('functional-component-stub').text()).toBe('value')
+  })
+
   it('returns new VueWrapper of Vue localVue if no options are passed', () => {
     const compiled = compileToFunctions('<div><input /></div>')
     const wrapper = shallowMount(compiled)


### PR DESCRIPTION
a child functional component must display content of v-text directive when it is mounted with
shallowMount

fix #1693

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**