### PR TITLE
feat: treat document.body in attachTo in special way

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -302,6 +302,10 @@ HTMLElement, to which your component will be fully mounted in the document.
 When attaching to the DOM, you should call `wrapper.destroy()` at the end of your test to
 remove the rendered elements from the document and destroy the component instance.
 
+::: tip
+When using `attachTo: document.body` new `div` instead of replacing entire body new `<div>` will be appended. This is designed to mimic Vue3 behavior and simplify future migration. See [this comment](https://github.com/vuejs/vue-test-utils/issues/1578#issuecomment-674652747) for details
+:::
+
 ```js
 const div = document.createElement('div')
 div.id = 'root'

--- a/packages/test-utils/src/mount.js
+++ b/packages/test-utils/src/mount.js
@@ -32,7 +32,9 @@ export default function mount(component, options = {}) {
   const parentVm = createInstance(component, mergedOptions, _Vue)
 
   const el =
-    options.attachTo || (options.attachToDocument ? createElement() : undefined)
+    options.attachToDocument || options.attachTo instanceof HTMLBodyElement
+      ? createElement()
+      : options.attachTo
   const vm = parentVm.$mount(el)
 
   component._Ctor = {}

--- a/test/specs/mounting-options/attachTo.spec.js
+++ b/test/specs/mounting-options/attachTo.spec.js
@@ -32,6 +32,19 @@ describeWithShallowAndMount('options.attachTo', mountingMethod => {
     wrapper.destroy()
     expect(document.getElementById('attach-to')).toBeNull()
   })
+  it('appends new node when attached to document.body', () => {
+    const unrelatedDiv = document.createElement('div')
+    unrelatedDiv.id = 'unrelated'
+    document.body.appendChild(unrelatedDiv)
+    const wrapper = mountingMethod(TestComponent, {
+      attachTo: document.body
+    })
+    expect(document.body.contains(unrelatedDiv)).toBe(true)
+    expect(wrapper.vm.$el.parentNode).toBe(document.body)
+    expect(wrapper.options.attachedToDocument).toEqual(true)
+    wrapper.destroy()
+    unrelatedDiv.remove()
+  })
   it('attaches to a provided CSS selector string', () => {
     const div = document.createElement('div')
     div.id = 'root'


### PR DESCRIPTION
When using attachTo with document.body as a target do not replace original content of body but append a new div instead

See #1578 for details and discussion

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
