### PR TITLE
feat(config): introduce deprecation warning handler, fix #1672

### DIFF
--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -19,6 +19,29 @@ import { config } from '@vue/test-utils'
 config.showDeprecationWarnings = false
 ```
 
+### `deprecationWarningHandler`
+
+- type: `Function`
+
+Allows fine-grained control on deprecation warnings. When `showDeprecationWarnings` is set to `true`, all deprecation warnings will be passed to this handler with method name as first argument and original message as second.
+
+::: tip
+This could be useful to log deprecation messages to separate location or to help in gradual upgrade of codebase to latest version of test utils by ignoring certain deprecated functions warnings
+:::
+
+Example:
+
+```js
+import { config } from '@vue/test-utils'
+
+config.showDeprecationWarnings = true
+config.deprecationWarningHandler = (method, message) => {
+  if (method === 'emittedByOrder') return
+
+  console.error(msg)
+}
+```
+
 ### `stubs`
 
 - type: `{ [name: string]: Component | boolean | string }`

--- a/packages/shared/util.js
+++ b/packages/shared/util.js
@@ -105,5 +105,9 @@ export function warnDeprecated(method: string, fallback: string = '') {
   if (!config.showDeprecationWarnings) return
   let msg = `${method} is deprecated and will be removed in the next major version.`
   if (fallback) msg += ` ${fallback}.`
-  warn(msg)
+  if (config.deprecationWarningHandler) {
+    config.deprecationWarningHandler(method, msg)
+  } else {
+    warn(msg)
+  }
 }

--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -166,6 +166,7 @@ interface VueTestUtilsConfigOptions {
   provide?: Record<string, any>,
   silent?: Boolean,
   showDeprecationWarnings?: boolean
+  deprecationWarningHandler?: Function
 }
 
 export declare function createLocalVue (): typeof Vue

--- a/test/specs/config.spec.js
+++ b/test/specs/config.spec.js
@@ -19,6 +19,7 @@ describeWithShallowAndMount('config', mountingMethod => {
     config.stubs = configStubsSave
     config.silent = configSilentSave
     config.methods = {}
+    config.deprecationWarningHandler = null
     console.error = consoleErrorSave
   })
 
@@ -101,6 +102,17 @@ describeWithShallowAndMount('config', mountingMethod => {
     wrapper.setData({ expanded: true })
     await wrapper.vm.$nextTick()
     expect(wrapper.find('[data-testid="expanded"]').exists()).toEqual(false)
+  })
+
+  it('invokes custom deprecation warning handler if specified in config', () => {
+    config.showDeprecationWarnings = true
+    config.deprecationWarningHandler = jest.fn()
+
+    const TestComponent = { template: `<div>Test</div>` }
+    mountingMethod(TestComponent, { attachToDocument: true })
+
+    expect(config.deprecationWarningHandler).toHaveBeenCalledTimes(1)
+    expect(console.error).not.toHaveBeenCalled()
   })
 
   it('allows control deprecation warnings visibility for name method', () => {


### PR DESCRIPTION
Allow passing custom handler for deprecation warnings allowing fine-grained control how these are reported to a user.
This is super important for huge codebases, where simple `console.error` reporting is not enough. For example, for gradual migration I would like to turn deprecation reports one-by-one, while our codebase is cleaned, making sure they will never appear. Currently this is possible only by hooking into `console.error`, which is bad, "stringly-typed" and somewhat hard to implement

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch.
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

