### PR TITLE
fix(setData): allow empty objects to be set fix #1704

### DIFF
--- a/packages/test-utils/src/recursively-set-data.js
+++ b/packages/test-utils/src/recursively-set-data.js
@@ -5,7 +5,7 @@ export function recursivelySetData(vm, target, data) {
     const val = data[key]
     const targetVal = target[key]
 
-    if (isPlainObject(val) && isPlainObject(targetVal)) {
+    if (isPlainObject(val) && isPlainObject(targetVal) && Object.keys(val).length > 0) {
       recursivelySetData(vm, targetVal, val)
     } else {
       vm.$set(target, key, val)

--- a/packages/test-utils/src/recursively-set-data.js
+++ b/packages/test-utils/src/recursively-set-data.js
@@ -5,7 +5,11 @@ export function recursivelySetData(vm, target, data) {
     const val = data[key]
     const targetVal = target[key]
 
-    if (isPlainObject(val) && isPlainObject(targetVal) && Object.keys(val).length > 0) {
+    if (
+      isPlainObject(val) &&
+      isPlainObject(targetVal) &&
+      Object.keys(val).length > 0
+    ) {
       recursivelySetData(vm, targetVal, val)
     } else {
       vm.$set(target, key, val)

--- a/test/specs/wrapper/setData.spec.js
+++ b/test/specs/wrapper/setData.spec.js
@@ -320,4 +320,29 @@ describeWithShallowAndMount('setData', mountingMethod => {
     await wrapper.setData({ selectedDate: testDate })
     expect(wrapper.vm.selectedDate).toEqual(testDate)
   })
+
+  it('allows empty objects to be set', () => {
+    const TestComponent = {
+      data() {
+        return {
+          someKey: { someValue: true }
+        }
+      },
+      render(h) {
+        return h('span')
+      }
+    }
+
+    const wrapper = mountingMethod(TestComponent)
+
+    expect(wrapper.vm.$data).toEqual({ someKey: { someValue: true } })
+
+    wrapper.setData({ someKey: {} })
+
+    expect(wrapper.vm.$data).toEqual({ someKey: {} })
+
+    wrapper.setData({ someKey: { someValue: false } })
+
+    expect(wrapper.vm.$data).toEqual({ someKey: { someValue: false } })
+  })
 })


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No


If yes, please describe the impact and migration path for existing applications:

if someone relied on empty objects not updating, that now no longer makes sense

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This is a tentative fix to show one possible solution, I can clean it up if you think it makes sense

