### PR TITLE
feat: add abstract property to the core property of the component

### DIFF
--- a/packages/create-instance/create-component-stubs.js
+++ b/packages/create-instance/create-component-stubs.js
@@ -56,7 +56,8 @@ function getCoreProperties(componentOptions: Component): Object {
     style: componentOptions.style,
     normalizedStyle: componentOptions.normalizedStyle,
     nativeOn: componentOptions.nativeOn,
-    functional: componentOptions.functional
+    functional: componentOptions.functional,
+    abstract: componentOptions.abstract
   }
 }
 


### PR DESCRIPTION
Since the Transition component is an abstract component, and we use stub to simulate it. If the abstract property is not copied, and if the Transition component is used inside the tested component, the parent-child relationship of the internal component tree will be incorrect.