### PR TITLE
feat(test-utils): add types for auto destroy methods

### DIFF
--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -183,4 +183,7 @@ export declare function shallowMount<Props = DefaultProps, PropDefs = PropsDefin
 export declare function createWrapper(node: Vue, options?: WrapperOptions): Wrapper<Vue>
 export declare function createWrapper(node: HTMLElement, options?: WrapperOptions): Wrapper<null>
 
+export declare function enableAutoDestroy(hook: (...args: any[]) => any): void
+export declare function resetAutoDestroyState(hook: (...args: any[]) => any): void
+
 export declare let RouterLinkStub: VueClass<Vue>


### PR DESCRIPTION
Add types for auto destroy methods, the hook type is typed loosely to be agnostic to testing frameworks.
