### PR TITLE
docs(jest): clarify babel configuration

### DIFF
--- a/docs/installation/using-with-jest.md
+++ b/docs/installation/using-with-jest.md
@@ -54,6 +54,14 @@ Then, you need to tell Jest to transform `.js` files using `babel-jest`. You can
 
 Then you need to create babel config using [babel.config.json](https://babeljs.io/docs/en/configuration#babelconfigjson), [.babelrc.json](https://babeljs.io/docs/en/configuration#babelrcjson) or `package.json`:
 
+`babel.config.json or .bablrc.json`
+```json
+{
+  "presets": ["@babel/preset-env"]
+}
+```
+
+`package.json`
 ```json
 {
   "babel": {


### PR DESCRIPTION
I copy pasted the original snippet to my `babel.config.json`.
```json
{
  "babel": {
    "presets": ["@babel/preset-env"]
  }
}
```

I was wondering why I was getting a weird error: `Unknown option: .babel. Check out https://babeljs.io/docs/en/babel-core/#options for more information abou
t options.`

I spent 10 minutes googling `.babel`, until I realized that I'm an idiot and the snippet was only applicable to `package.json`. As someone not yet intimately familiar with babel, I'm hoping this change would help clarify the distinction between `package.json` and `babel.config.json`.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Documentation

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [ ] ~~When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)~~
- [ ] ~~All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup~~
- [ ] ~~New/updated tests are included~~

If adding a **new feature**, the PR's description includes:

- [ ] ~~A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)~~

**Other information:**
This is a documentation update to differentiate `package.json` from `babel.config.json`