### PR TITLE
fix #1474: support array class binding and events binding in stubbed functional components

### DIFF
--- a/packages/create-instance/create-component-stubs.js
+++ b/packages/create-instance/create-component-stubs.js
@@ -61,28 +61,6 @@ function getCoreProperties(componentOptions: Component): Object {
   }
 }
 
-function createClassString(staticClass, dynamicClass) {
-  // :class="someComputedObject" can return a string, object or undefined
-  // if it is a string, we don't need to do anything special.
-  let evaluatedDynamicClass = dynamicClass
-
-  // if it is an object, eg { 'foo': true }, we need to evaluate it.
-  // see https://github.com/vuejs/vue-test-utils/issues/1474 for more context.
-  if (typeof dynamicClass === 'object') {
-    evaluatedDynamicClass = Object.keys(dynamicClass).reduce((acc, key) => {
-      if (dynamicClass[key]) {
-        return acc + ' ' + key
-      }
-      return acc
-    }, '')
-  }
-
-  if (staticClass && evaluatedDynamicClass) {
-    return staticClass + ' ' + evaluatedDynamicClass
-  }
-  return staticClass || evaluatedDynamicClass
-}
-
 function resolveOptions(component, _Vue) {
   if (isDynamicComponent(component)) {
     return {}
@@ -134,24 +112,19 @@ export function createStubFromComponent(
     render(h, context) {
       return h(
         tagName,
-        {
-          ref: componentOptions.functional ? context.data.ref : undefined,
-          domProps: componentOptions.functional
-            ? context.data.domProps
-            : undefined,
-          attrs: componentOptions.functional
-            ? {
+        componentOptions.functional
+          ? {
+              ...context.data,
+              attrs: {
                 ...context.props,
-                ...context.data.attrs,
-                class: createClassString(
-                  context.data.staticClass,
-                  context.data.class
-                )
+                ...context.data.attrs
               }
-            : {
+            }
+          : {
+              attrs: {
                 ...this.$props
               }
-        },
+            },
         context
           ? context.children
           : this.$options._renderChildren ||

--- a/test/resources/components/component-with-functional-child.vue
+++ b/test/resources/components/component-with-functional-child.vue
@@ -1,7 +1,8 @@
 <template>
   <functional-component
-    :class="{ bar: a + b === 2, foo: a === 1, qux: a === 2 }"
+    :class="['baz', { bar: a + b === 2, foo: a === 1, qux: a === 2 }]"
     v-text="something"
+    @click="handleFunctionalComponentClick"
   />
 </template>
 
@@ -18,6 +19,12 @@ export default {
       a: 1,
       b: 1,
       something: 'value'
+    }
+  },
+
+  methods: {
+    handleFunctionalComponentClick() {
+      this.something = 'newValue'
     }
   }
 }

--- a/test/specs/shallow-mount.spec.js
+++ b/test/specs/shallow-mount.spec.js
@@ -33,6 +33,7 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'shallowMount', () => {
   it('renders dynamic class of functional child', () => {
     const wrapper = shallowMount(ComponentWithFunctionalChild)
     expect(wrapper.find('functional-component-stub').classes()).toContain(
+      'baz',
       'foo',
       'bar'
     )
@@ -44,6 +45,14 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'shallowMount', () => {
   it('renders v-text content of functional child', () => {
     const wrapper = shallowMount(ComponentWithFunctionalChild)
     expect(wrapper.find('functional-component-stub').text()).toBe('value')
+  })
+
+  it('trigger click must change content of functional child', async () => {
+    const wrapper = shallowMount(ComponentWithFunctionalChild)
+
+    await wrapper.trigger('click')
+
+    expect(wrapper.find('functional-component-stub').text()).toBe('newValue')
   })
 
   it('returns new VueWrapper of Vue localVue if no options are passed', () => {


### PR DESCRIPTION

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR fix array class binding in stubbed functional components, because previous [PR](https://github.com/vuejs/vue-test-utils/pull/1476) add support string and object only.

Also fix events binding in stubbed functional components.

I think, best way provide all context data as the 2nd argument of h, like describe in Vue docs https://vuejs.org/v2/guide/render-function.html#Functional-Components