### PR TITLE
fix: does not pass data provided to mount to wrapper component

### DIFF
--- a/flow/options.flow.js
+++ b/flow/options.flow.js
@@ -3,6 +3,7 @@ declare type Options = {
   attachToDocument?: boolean,
   attachTo?: HTMLElement | string,
   propsData?: Object,
+  data?: Object | Function,
   mocks?: Object,
   methods?: { [key: string]: Function },
   slots?: SlotsObject,
@@ -20,6 +21,7 @@ declare type Options = {
 declare type NormalizedOptions = {
   attachTo?: HTMLElement | string,
   attachToDocument?: boolean,
+  data?: Object | Function,
   propsData?: Object,
   mocks: Object,
   methods: { [key: string]: Function },

--- a/packages/create-instance/create-instance.js
+++ b/packages/create-instance/create-instance.js
@@ -125,7 +125,8 @@ export default function createInstance(
   }
 
   // options  "propsData" can only be used during instance creation with the `new` keyword
-  const { propsData, ...rest } = options // eslint-disable-line
+  // "data" should be set only on component under test to avoid reactivity issues
+  const { propsData, data, ...rest } = options // eslint-disable-line
   const Parent = _Vue.extend({
     ...rest,
     ...parentComponentOptions

--- a/test/specs/mounting-options/data.spec.js
+++ b/test/specs/mounting-options/data.spec.js
@@ -1,0 +1,24 @@
+import { describeWithShallowAndMount } from '~resources/utils'
+
+describeWithShallowAndMount('options.data', mountingMethod => {
+  const TestComponent = {
+    data: () => ({ foo: 1, bar: 2 }),
+    template: '<div />'
+  }
+
+  it('correctly merges component data and data passed to mount', () => {
+    const wrapper = mountingMethod(TestComponent, { data: () => ({ foo: 3 }) })
+
+    expect(wrapper.vm.foo).toBe(3)
+    expect(wrapper.vm.bar).toBe(2)
+  })
+
+  it('does not fail when data is extracted to local variable', () => {
+    const defaultData = { foo: 3 }
+
+    const wrapper = mountingMethod(TestComponent, { data: () => defaultData })
+
+    expect(wrapper.vm.foo).toBe(3)
+    expect(wrapper.vm.bar).toBe(2)
+  })
+})


### PR DESCRIPTION
#1661 [introduced](https://github.com/vuejs/vue-test-utils/pull/1661/files#diff-5d7b4788ebdcd7703b1df7d0bb64f8dd6a843c29459bb4fc134364530368af73R131) copying of passed options to parent wrapper. However it fails in a weird way if you are using `data` option for `mount`/`shallowMount` with external variable.

i.e.
```js 
    const defaultData = { foo: 3 }
    const wrapper = mountingMethod(TestComponent, { data: () => defaultData })
```
In this case `data` function will be invoked two times: 

* one for `Parent` component (wrapper for our `TestComponent`) - at this point `defaultData` will be "poisoned" (will become reactive, and observed by `Parent` component for changes)
* one when `Parent` wrapper will be mounted, causing `TestComponent` instance to mount - at this point Vue will complain 

```
[Vue warn]: Avoid adding reactive properties to a Vue instance or its root $data at runtime - declare it upfront in the data option.
```

because `defaultData` is treated as `$data` for Parent wrapper component already

In general, we do not need setting `data` on parent wrapper, so I just eliminate this propety before copying

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch.
- [-] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

**Other information:**
