### PR TITLE
Fix #1760: do not console.error handled exceptions

### DIFF
--- a/packages/test-utils/src/error.js
+++ b/packages/test-utils/src/error.js
@@ -22,13 +22,14 @@ function errorHandler(errorOrString, vm, info) {
     vm._error = error
   }
 
+  if (!instancedErrorHandlers.length) {
+    throw error
+  }
   // should be one error handler, as only once can be registered with local vue
   // regardless, if more exist (for whatever reason), invoke the other user defined error handlers
   instancedErrorHandlers.forEach(instancedErrorHandler => {
     instancedErrorHandler(error, vm, info)
   })
-
-  throw error
 }
 
 export function throwIfInstancesThrew(vm) {


### PR DESCRIPTION
When an exception is handled in an `errorHandler` function, do not re-raise it.

fix #1760

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
