### PR TITLE
fix(trigger('focus')) added natural to jsdom behavior

### DIFF
--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -31,7 +31,7 @@ export default class Wrapper implements BaseWrapper {
   +vm: Component | void
   _emitted: { [name: string]: Array<Array<any>> }
   _emittedByOrder: Array<{ name: string, args: Array<any> }>
-  +element: Element
+  +element: Element | HTMLInputElement
   +options: WrapperOptions
   isFunctionalComponent: boolean
   rootNode: VNode | Element
@@ -831,8 +831,8 @@ export default class Wrapper implements BaseWrapper {
 
   /**
    * Simulates event triggering
-   * @param type
-   * @param options
+   * @param type {string}
+   * @param [options] {Object}
    * @returns {*}
    * @private
    */

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -830,6 +830,31 @@ export default class Wrapper implements BaseWrapper {
   }
 
   /**
+   * Simulates event triggering
+   * @param type
+   * @param options
+   * @returns {*}
+   * @private
+   */
+  __simulateTrigger(type, options) {
+    const regularEventTrigger = (type, options) => {
+      const event = createDOMEvent(type, options)
+      return this.element.dispatchEvent(event)
+    }
+
+    const focusEventTrigger = (type, options) => this.element.focus(options)
+
+    const triggerProcedureMap = {
+      focus: focusEventTrigger,
+      __default: regularEventTrigger
+    }
+
+    const triggerFn = triggerProcedureMap[type] || triggerProcedureMap.__default
+
+    return triggerFn(type, options)
+  }
+
+  /**
    * Dispatches a DOM event on wrapper
    */
   trigger(type: string, options: Object = {}): Promise<void> {
@@ -869,8 +894,7 @@ export default class Wrapper implements BaseWrapper {
       return nextTick()
     }
 
-    const event = createDOMEvent(type, options)
-    this.element.dispatchEvent(event)
+    this.__simulateTrigger(type, options)
     return nextTick()
   }
 }

--- a/packages/test-utils/src/wrapper.js
+++ b/packages/test-utils/src/wrapper.js
@@ -31,7 +31,7 @@ export default class Wrapper implements BaseWrapper {
   +vm: Component | void
   _emitted: { [name: string]: Array<Array<any>> }
   _emittedByOrder: Array<{ name: string, args: Array<any> }>
-  +element: Element | HTMLInputElement
+  +element: Element
   +options: WrapperOptions
   isFunctionalComponent: boolean
   rootNode: VNode | Element
@@ -831,18 +831,20 @@ export default class Wrapper implements BaseWrapper {
 
   /**
    * Simulates event triggering
-   * @param type {string}
-   * @param [options] {Object}
-   * @returns {*}
-   * @private
    */
-  __simulateTrigger(type, options) {
+  __simulateTrigger(type: string, options?: Object): void {
     const regularEventTrigger = (type, options) => {
       const event = createDOMEvent(type, options)
       return this.element.dispatchEvent(event)
     }
 
-    const focusEventTrigger = (type, options) => this.element.focus(options)
+    const focusEventTrigger = (type, options) => {
+      if (this.element instanceof HTMLElement) {
+        return this.element.focus()
+      }
+
+      regularEventTrigger(type, options)
+    }
 
     const triggerProcedureMap = {
       focus: focusEventTrigger,

--- a/test/resources/components/component-with-multiple-inputs.vue
+++ b/test/resources/components/component-with-multiple-inputs.vue
@@ -1,0 +1,57 @@
+<template>
+  <div>
+    <input
+      v-for="index of 5"
+      @focus="onFocus(index)"
+      :id="index"
+      :data-test-position="index"
+      :ref="refNameByIndex(index)"
+      :key="index"
+      type="text"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'component-with-multiple-inputs',
+  data: () => ({ activeInputIndex: null }),
+  computed: {
+    inputRefAtIndex() {
+      return index => this.$refs[this.refNameByIndex(index)]
+    }
+  },
+
+  methods: {
+    refNameByIndex(index) {
+      return `input${index}`
+    },
+
+    returnToLastSelectedInput() {
+      return this.focusInput(this.inputRefAtIndex(this.activeInputIndex))
+    },
+
+    onFocus(index) {
+      const isOdd = Boolean(index % 2)
+      if (isOdd) {
+        return this.returnToLastSelectedInput()
+      }
+      this.activeInputIndex = index
+    },
+
+    focusInput(inputRef) {
+      if (!inputRef) {
+        return
+      }
+      const [input] = inputRef
+      input.focus()
+    }
+  },
+
+  mounted() {
+    this.focusInput(this.focusInput(this.inputRefAtIndex(2)))
+  }
+}
+</script>
+
+<style scoped></style>

--- a/test/specs/wrapper-array/trigger.spec.js
+++ b/test/specs/wrapper-array/trigger.spec.js
@@ -1,6 +1,10 @@
 import { compileToFunctions } from 'vue-template-compiler'
 import ComponentWithEvents from '~resources/components/component-with-events.vue'
+import ComponentWithMultipleInputs from '~resources/components/component-with-multiple-inputs.vue'
 import { describeWithShallowAndMount } from '~resources/utils'
+
+const assertElementIsFocused = element =>
+  expect(document.activeElement.id).toEqual(element.id)
 
 describeWithShallowAndMount('trigger', mountingMethod => {
   it('causes click handler to fire when wrapper.trigger("click") is called on a Component', async () => {
@@ -32,6 +36,26 @@ describeWithShallowAndMount('trigger', mountingMethod => {
     await wrapper.findAll('.keydown-enter').trigger('keydown.enter')
 
     expect(keydownHandler).toHaveBeenCalled()
+  })
+
+  it('should really focus element when trigger focus was called', async () => {
+    const wrapper = mountingMethod(ComponentWithMultipleInputs, {
+      attachTo: document.body
+    })
+
+    assertElementIsFocused(wrapper.get('[data-test-position="2"]').element)
+
+    await wrapper.get('[data-test-position="4"]').trigger('focus')
+
+    assertElementIsFocused(wrapper.get('[data-test-position="4"]').element)
+
+    await wrapper.get('[data-test-position="3"]').trigger('focus')
+
+    assertElementIsFocused(wrapper.get('[data-test-position="4"]').element)
+
+    await wrapper.get('[data-test-position="2"]').trigger('focus')
+
+    assertElementIsFocused(wrapper.get('[data-test-position="2"]').element)
   })
 
   it('throws an error if type is not a string', () => {


### PR DESCRIPTION
When I have a component that manipulates the focus of multiple inputs, I expect that `wrapper.trigger('focus')` would really focus an input, but actually, it does not.

This PR introduces a way of triggering some kind of events more closely to their natural behavior.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch.
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Added a test case and a fix for wrapper.trigger.