### PR TITLE
docs: Add warning on docs version

### DIFF
--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -1,26 +1,24 @@
 <template>
-  <div>
-    <ParentLayout>
-      <template #page-top>
-        <div class="warning-wrapper">
-          <div class="custom-block warning vue3-warning">
-            <p>
-              You’re browsing the documentation for Vue Test Utils for Vue v2.x
-              and earlier.
-            </p>
-            <p>
-              To read docs for Vue Test Utils for Vue 3,
-              <a
-                href="https://next.vue-test-utils.vuejs.org/introduction/"
-                v-text="'click here'"
-              />.
-            </p>
-          </div>
+  <ParentLayout>
+    <template #page-top>
+      <div class="warning-wrapper">
+        <div class="custom-block warning vue3-warning">
+          <p>
+            You’re browsing the documentation for Vue Test Utils for Vue v2.x
+            and earlier.
+          </p>
+          <p>
+            To read docs for Vue Test Utils for Vue 3,
+            <a
+              href="https://next.vue-test-utils.vuejs.org/introduction/"
+              v-text="'click here'"
+            />.
+          </p>
         </div>
-      </template>
-      <Content />
-    </ParentLayout>
-  </div>
+      </div>
+    </template>
+    <Content />
+  </ParentLayout>
 </template>
 
 <script>

--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -1,0 +1,57 @@
+<template>
+  <div>
+    <ParentLayout>
+      <template #page-top>
+        <div class="warning-wrapper">
+          <div class="custom-block warning vue3-warning">
+            <p>
+              You’re browsing the documentation for Vue Test Utils for Vue v2.x
+              and earlier.
+            </p>
+            <p>
+              To read docs for Vue Test Utils for Vue 3,
+              <a
+                href="https://next.vue-test-utils.vuejs.org/introduction/"
+                v-text="'click here'"
+              />.
+            </p>
+          </div>
+        </div>
+      </template>
+      <Content />
+    </ParentLayout>
+  </div>
+</template>
+
+<script>
+import ParentLayout from '@parent-theme/layouts/Layout.vue'
+
+export default {
+  name: 'Layout',
+
+  components: {
+    ParentLayout
+  }
+}
+</script>
+
+<style lang="css">
+.warning-wrapper {
+  max-width: 740px;
+  margin: 5rem auto 0;
+}
+
+.custom-block.vue3-warning {
+  padding: 1rem;
+  font-size: 0.9rem;
+}
+
+.custom-block.vue3-warning p {
+  margin: 0;
+}
+
+/* Overrides theme's default margin-top values */
+.theme-default-content:not(.custom) > h1:first-child {
+  margin-top: -4.5rem;
+}
+</style>

--- a/docs/.vuepress/theme/index.js
+++ b/docs/.vuepress/theme/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extend: '@vuepress/theme-default'
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,13 @@
 # Introduction
 
-::: warning
-This doc is for Vue2.x only. If you want to see docs related to 3.x, please move to [here](https://next.vue-test-utils.vuejs.org/introduction/)
-:::
-
 Vue Test Utils is the official unit testing utility library for Vue.js.
+
+This is the documentation for Vue Test Utils v1, which targets Vue 2 and earlier.
+
+In short:
+
+- [Vue Test Utils 1](https://github.com/vuejs/vue-test-utils/) targets [Vue 2](https://github.com/vuejs/vue/).
+- [Vue Test Utils 2](https://github.com/vuejs/vue-test-utils-next/) targets [Vue 3](https://github.com/vuejs/vue-next/).
 
 <div class="vueschool"><a href="https://vueschool.io/courses/learn-how-to-test-vuejs-components?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how to use Vue Test Utils to test Vue.js Components with Vue School">Learn how to test Vue.js components with Vue School</a></div>
 


### PR DESCRIPTION
A couple of users let me know they spent some time on VTU docs even though they were using Vue 3. I think signaling everywhere that these are docs for Vue 2 might be helpful.

disclaimer: I didn't spend much time on the actual layout, I simply kept it simple. Any suggestion is welcome ;)


![imatge](https://user-images.githubusercontent.com/9197791/108678700-bc497780-74eb-11eb-864c-1929d0f12dbb.png)
