### PR TITLE
Fix VTU don't return key property to event when use trigger.('eventName.key')

### DIFF
--- a/packages/test-utils/src/create-dom-event.js
+++ b/packages/test-utils/src/create-dom-event.js
@@ -27,6 +27,7 @@ const modifiers = {
 function getOptions(eventParams) {
   const { modifier, meta, options } = eventParams
   const keyCode = modifiers[modifier] || options.keyCode || options.code
+  const key = modifier
 
   return {
     ...options, // What the user passed in as the second argument to #trigger
@@ -36,6 +37,7 @@ function getOptions(eventParams) {
 
     // Any derived options should go here
     keyCode,
+    key,
     code: keyCode
   }
 }

--- a/packages/test-utils/src/create-dom-event.js
+++ b/packages/test-utils/src/create-dom-event.js
@@ -118,7 +118,6 @@ export default function createDOMEvent(type, options) {
       propertyDescriptor && propertyDescriptor.setter === undefined
     )
     if (canSetProperty) {
-      console.log('canSetProperty')
       event[key] = options[key]
     }
   })

--- a/packages/test-utils/src/create-dom-event.js
+++ b/packages/test-utils/src/create-dom-event.js
@@ -24,10 +24,35 @@ const modifiers = {
   pagedown: 34
 }
 
+// get from https://github.com/ashubham/w3c-keys/blob/master/index.ts
+const w3cKeys = {
+  enter: 'Enter',
+  tab: 'Tab',
+  delete: 'Delete',
+  esc: 'Esc',
+  escape: 'Escape',
+  space: ' ',
+  up: 'Up',
+  left: 'Left',
+  right: 'Right',
+  down: 'Down',
+  end: 'End',
+  home: 'Home',
+  backspace: 'Backspace',
+  insert: 'Insert',
+  pageup: 'PageUp',
+  pagedown: 'PageDown'
+}
+
+const codeToKeyNameMap = Object.entries(modifiers).reduce(
+  (acc, [key, value]) => Object.assign(acc, { [value]: w3cKeys[key] }),
+  {}
+)
+
 function getOptions(eventParams) {
   const { modifier, meta, options } = eventParams
   const keyCode = modifiers[modifier] || options.keyCode || options.code
-  const key = modifier
+  const key = codeToKeyNameMap[keyCode]
 
   return {
     ...options, // What the user passed in as the second argument to #trigger
@@ -37,8 +62,8 @@ function getOptions(eventParams) {
 
     // Any derived options should go here
     keyCode,
-    key,
-    code: keyCode
+    code: keyCode,
+    key
   }
 }
 
@@ -93,6 +118,7 @@ export default function createDOMEvent(type, options) {
       propertyDescriptor && propertyDescriptor.setter === undefined
     )
     if (canSetProperty) {
+      console.log('canSetProperty')
       event[key] = options[key]
     }
   })

--- a/test/specs/wrapper/trigger.spec.js
+++ b/test/specs/wrapper/trigger.spec.js
@@ -77,7 +77,7 @@ describeWithShallowAndMount('trigger', mountingMethod => {
     expect(keydownHandler).toHaveBeenCalled()
   })
 
-  it('convert a registered key name to a key code key', async () => {
+  it('convert a registered key name to a key code and key', async () => {
     const modifiers = {
       enter: 13,
       esc: 27,

--- a/test/specs/wrapper/trigger.spec.js
+++ b/test/specs/wrapper/trigger.spec.js
@@ -43,23 +43,27 @@ describeWithShallowAndMount('trigger', mountingMethod => {
     expect(keydownHandler).toHaveBeenCalled()
   })
 
-  describe('causes keydown handler to fire with the appropriate keyCode when wrapper.trigger("keydown", { keyCode: 65 }) is fired on a Component', async () => {
+  describe('causes keydown handler to fire with the appropriate keyCode when wrapper.trigger("keydown", { keyCode: 46 }) is fired on a Component', async () => {
     const keydownHandler = jest.fn()
     const wrapper = mountingMethod(ComponentWithEvents, {
       propsData: { keydownHandler }
     })
 
-    await wrapper.find('.keydown').trigger('keydown', { keyCode: 65 })
+    await wrapper.find('.keydown').trigger('keydown', { keyCode: 46 })
 
     const keyboardEvent = keydownHandler.mock.calls[0][0]
 
     // Unfortunately, JSDom will give different types than PhantomJS for keyCodes (string vs number), so we have to use parseInt to normalize the types.
     it('contains the keyCode', () => {
-      expect(parseInt(keyboardEvent.keyCode, 10)).toEqual(65)
+      expect(parseInt(keyboardEvent.keyCode, 10)).toEqual(46)
+    })
+
+    it('contains the key', () => {
+      expect(keyboardEvent.key).toEqual('Delete')
     })
 
     itDoNotRunIf(isRunningChrome, 'contains the code', () => {
-      expect(parseInt(keyboardEvent.code, 10)).toEqual(65)
+      expect(parseInt(keyboardEvent.code, 10)).toEqual(46)
     })
   })
 
@@ -73,7 +77,7 @@ describeWithShallowAndMount('trigger', mountingMethod => {
     expect(keydownHandler).toHaveBeenCalled()
   })
 
-  it.skip('convert a registered key name to a key code', async () => {
+  it('convert a registered key name to a key code key', async () => {
     const modifiers = {
       enter: 13,
       esc: 27,
@@ -91,14 +95,47 @@ describeWithShallowAndMount('trigger', mountingMethod => {
       pageup: 33,
       pagedown: 34
     }
+
+    // get from https://github.com/ashubham/w3c-keys/blob/master/index.ts
+    const w3cKeys = {
+      enter: 'Enter',
+      tab: 'Tab',
+      delete: 'Delete',
+      esc: 'Esc',
+      escape: 'Escape',
+      space: ' ',
+      up: 'Up',
+      left: 'Left',
+      right: 'Right',
+      down: 'Down',
+      end: 'End',
+      home: 'Home',
+      backspace: 'Backspace',
+      insert: 'Insert',
+      pageup: 'PageUp',
+      pagedown: 'PageDown'
+    }
+
+    const codeToKeyNameMap = Object.entries(modifiers).reduce(
+      (acc, [key, value]) => Object.assign(acc, { [value]: w3cKeys[key] }),
+      {}
+    )
+
+    const modifiersArray = Object.entries(modifiers)
+
     const keyupHandler = jest.fn()
     const wrapper = mountingMethod(ComponentWithEvents, {
       propsData: { keyupHandler }
     })
-    for (const keyName in modifiers) {
-      const keyCode = modifiers[keyName]
+
+    for (let index = 0; index < modifiersArray.length; index++) {
+      const [keyName, keyCode] = modifiersArray[index]
       await wrapper.find('.keydown').trigger(`keyup.${keyName}`)
-      expect(keyupHandler.mock.calls[0][0].keyCode).toEqual(keyCode)
+
+      expect(keyupHandler.mock.calls[index][0].keyCode).toEqual(keyCode)
+      expect(keyupHandler.mock.calls[index][0].key).toEqual(
+        codeToKeyNameMap[keyCode]
+      )
     }
   })
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Other, please describe: fix test `convert a registered key name to a key code` in `test/specs/wrapper/trigger.spec.js`

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**
If in our code exist check like this:
```
import { Key } from 'w3c-keys'
...
handleOnKeyDown(e: KeyboardEvent) {
	const tab = e.key === Key.Tab
	const escape = e.key === Key.Escape

	if (tab || escape) {
		...doSmth
	}
}
```

we can't test it by fire event like this
```
await input.trigger('keydown.tab')
```

Because VTU don't return `key` property in event when triggered by `eventName.keyName`.

Of course we can test it like this )
```
await input.trigger('keydown', {
	key: 'Tab',
})
```