### PR TITLE
docs(name): Add link to deprecation explanation

### DIFF
--- a/docs/api/wrapper/name.md
+++ b/docs/api/wrapper/name.md
@@ -1,7 +1,7 @@
 ## name
 
 ::: warning Deprecation warning
-`name` is deprecated and will be removed in future releases. See https://vue-test-utils.vuejs.org/upgrading-to-v1/#name
+`name` is deprecated and will be removed in future releases. See [vue-test-utils.vuejs.org/upgrading-to-v1/#name](https://vue-test-utils.vuejs.org/upgrading-to-v1/#name)
 :::
 
 Returns component name if `Wrapper` contains a Vue instance, or the tag name of `Wrapper` DOM node if `Wrapper` does not contain a Vue instance.

--- a/docs/api/wrapper/name.md
+++ b/docs/api/wrapper/name.md
@@ -1,7 +1,7 @@
 ## name
 
 ::: warning Deprecation warning
-`name` is deprecated and will be removed in future releases.
+`name` is deprecated and will be removed in future releases. See https://vue-test-utils.vuejs.org/upgrading-to-v1/#name
 :::
 
 Returns component name if `Wrapper` contains a Vue instance, or the tag name of `Wrapper` DOM node if `Wrapper` does not contain a Vue instance.


### PR DESCRIPTION
Closes #1745 

Add reference to doc to explain to users why `name` is deprecated and what they should do next!

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Doc update

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Just updating docs so new users don't abandon this project. This should also address https://github.com/vuejs/vue-test-utils/issues/1745