### PR TITLE
feat: export `ErrorWrapper`

### DIFF
--- a/packages/test-utils/src/index.js
+++ b/packages/test-utils/src/index.js
@@ -6,6 +6,7 @@ import RouterLinkStub from './components/RouterLinkStub'
 import createWrapper from './create-wrapper'
 import Wrapper from './wrapper'
 import WrapperArray from './wrapper-array'
+import ErrorWrapper from './error-wrapper'
 import config from './config'
 import { warn } from 'shared/util'
 
@@ -28,5 +29,6 @@ export {
   shallowMount,
   RouterLinkStub,
   Wrapper,
-  WrapperArray
+  WrapperArray,
+  ErrorWrapper
 }


### PR DESCRIPTION
Export `ErrorWrapper` so it can be used when extending VTU.

At GitLab we have an `extendedWrapper` helper that we use to add custom finders and matchers. We are trying to add some [DOM testing library](https://testing-library.com/docs/queries/about) finders to our `extendedWrapper` but one problem we are running into is `ErrorWrapper` is not exported so we have to do something like [this](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/54398/diffs#229989309ef63548f07f6d16cb7e99f9d49e1759_59_89). Ideally we would be able to do `return new ErrorWrapper(query)`.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [-] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
