### PR TITLE
fix #1824: trigger keyboard event regression

### DIFF
--- a/packages/test-utils/src/create-dom-event.js
+++ b/packages/test-utils/src/create-dom-event.js
@@ -63,7 +63,7 @@ function getOptions(eventParams) {
     // Any derived options should go here
     keyCode,
     code: keyCode,
-    key
+    key: key || options.key
   }
 }
 

--- a/test/specs/wrapper/trigger.spec.js
+++ b/test/specs/wrapper/trigger.spec.js
@@ -67,6 +67,21 @@ describeWithShallowAndMount('trigger', mountingMethod => {
     })
   })
 
+  describe('causes keydown handler to fire with the appropriate key when wrapper.trigger("keydown", { key: "k" }) is fired on a Component', async () => {
+    const keydownHandler = jest.fn()
+    const wrapper = mountingMethod(ComponentWithEvents, {
+      propsData: { keydownHandler }
+    })
+
+    await wrapper.find('.keydown').trigger('keydown', { key: 'k' })
+
+    const keyboardEvent = keydownHandler.mock.calls[0][0]
+
+    it('contains the key', () => {
+      expect(keyboardEvent.key).toEqual('k')
+    })
+  })
+
   it('causes keydown handler to fire when wrapper.trigger("keydown.enter") is fired on a Component', async () => {
     const keydownHandler = jest.fn()
     const wrapper = mountingMethod(ComponentWithEvents, {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch.
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

**Other information:**

PR https://github.com/vuejs/vue-test-utils/pull/1808 introduced a regression where it was overriding the key with a possibly empty string. This broke the functionally of passing down a key to the trigger event. As pointed out in https://github.com/vuejs/vue-test-utils/issues/1824, also added a test to this specific use case.
