### PR TITLE
Update contains.md

### DIFF
--- a/docs/api/wrapper-array/contains.md
+++ b/docs/api/wrapper-array/contains.md
@@ -1,4 +1,4 @@
-### contains
+## contains
 
 Assert every wrapper in `WrapperArray` contains selector.
 


### PR DESCRIPTION
Hello, it seems that all the other methods of wrapper-array are h2s while `contains` is an h3 and therefore doesn't show up in the sidebar menu.
Example: https://vue-test-utils.vuejs.org/api/wrapper-array/#exists
Afterwards the deprecation message from wrapper.contains could be added here as well in a subsequent pr.

Cheers

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
