### PR TITLE
Updated router link stub to match actual router-link interface

### DIFF
--- a/docs/api/components/RouterLinkStub.md
+++ b/docs/api/components/RouterLinkStub.md
@@ -16,5 +16,5 @@ const wrapper = mount(Component, {
     RouterLink: RouterLinkStub
   }
 })
-expect(wrapper.find(RouterLinkStub).props().to).toBe('/some/path')
+expect(wrapper.findComponent(RouterLinkStub).props().to).toBe('/some/path')
 ```

--- a/docs/ja/api/components/RouterLinkStub.md
+++ b/docs/ja/api/components/RouterLinkStub.md
@@ -16,5 +16,5 @@ const wrapper = mount(Component, {
     RouterLink: RouterLinkStub
   }
 })
-expect(wrapper.find(RouterLinkStub).props().to).toBe('/some/path')
+expect(wrapper.findComponent(RouterLinkStub).props().to).toBe('/some/path')
 ```

--- a/docs/ru/api/components/RouterLinkStub.md
+++ b/docs/ru/api/components/RouterLinkStub.md
@@ -16,5 +16,5 @@ const wrapper = mount(Component, {
     RouterLink: RouterLinkStub
   }
 })
-expect(wrapper.find(RouterLinkStub).props().to).toBe('/some/path')
+expect(wrapper.findComponent(RouterLinkStub).props().to).toBe('/some/path')
 ```

--- a/docs/zh/api/components/RouterLinkStub.md
+++ b/docs/zh/api/components/RouterLinkStub.md
@@ -16,5 +16,5 @@ const wrapper = mount(Component, {
     RouterLink: RouterLinkStub
   }
 })
-expect(wrapper.find(RouterLinkStub).props().to).toBe('/some/path')
+expect(wrapper.findComponent(RouterLinkStub).props().to).toBe('/some/path')
 ```

--- a/packages/test-utils/src/components/RouterLinkStub.js
+++ b/packages/test-utils/src/components/RouterLinkStub.js
@@ -14,6 +14,7 @@ export default {
       default: 'a'
     },
     exact: Boolean,
+    exactPath: Boolean,
     append: Boolean,
     replace: Boolean,
     activeClass: String,

--- a/packages/test-utils/src/components/RouterLinkStub.js
+++ b/packages/test-utils/src/components/RouterLinkStub.js
@@ -19,6 +19,7 @@ export default {
     replace: Boolean,
     activeClass: String,
     exactActiveClass: String,
+    exactPathActiveClass: String,
     event: {
       type: eventTypes,
       default: 'click'

--- a/test/specs/components/RouterLink.spec.js
+++ b/test/specs/components/RouterLink.spec.js
@@ -12,6 +12,7 @@ describeWithShallowAndMount('RouterLinkStub', mountingMethod => {
             activeClass="activeClass1"
             exactActiveClass="exactActiveClass1"
             event="event1"
+            exact-path-active-class="exact-path-active-class"
             exact
             exact-path
             append
@@ -35,6 +36,9 @@ describeWithShallowAndMount('RouterLinkStub', mountingMethod => {
     expect(routerLink.props().replace).toEqual(true)
     expect(routerLink.props().activeClass).toEqual('activeClass1')
     expect(routerLink.props().exactActiveClass).toEqual('exactActiveClass1')
+    expect(routerLink.props().exactPathActiveClass).toEqual(
+      'exact-path-active-class'
+    )
     expect(routerLink.props().event).toEqual('event1')
   })
 

--- a/test/specs/components/RouterLink.spec.js
+++ b/test/specs/components/RouterLink.spec.js
@@ -13,6 +13,7 @@ describeWithShallowAndMount('RouterLinkStub', mountingMethod => {
             exactActiveClass="exactActiveClass1"
             event="event1"
             exact
+            exact-path
             append
             replace
           />
@@ -25,10 +26,11 @@ describeWithShallowAndMount('RouterLinkStub', mountingMethod => {
       }
     })
 
-    const routerLink = wrapper.find(RouterLinkStub)
+    const routerLink = wrapper.getComponent(RouterLinkStub)
     expect(routerLink.props().to).toEqual('to1')
     expect(routerLink.props().tag).toEqual('a')
     expect(routerLink.props().exact).toEqual(true)
+    expect(routerLink.props().exactPath).toEqual(true)
     expect(routerLink.props().append).toEqual(true)
     expect(routerLink.props().replace).toEqual(true)
     expect(routerLink.props().activeClass).toEqual('activeClass1')
@@ -49,6 +51,6 @@ describeWithShallowAndMount('RouterLinkStub', mountingMethod => {
         RouterLink: RouterLinkStub
       }
     })
-    expect(wrapper.find(RouterLinkStub).text()).toEqual('some text')
+    expect(wrapper.getComponent(RouterLinkStub).text()).toEqual('some text')
   })
 })


### PR DESCRIPTION
Added properties related to `exact-path` that's present in actual router link https://router.vuejs.org/api/#exact-path

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch.
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [X] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**