### PR TITLE
docs(test-utils): add tip about using `trigger('focus')`

### DIFF
--- a/docs/api/wrapper/trigger.md
+++ b/docs/api/wrapper/trigger.md
@@ -38,6 +38,10 @@ test('trigger demo', async () => {
 })
 ```
 
+::: tip
+When using `trigger('focus')` with [jsdom v16.4.0](https://github.com/jsdom/jsdom/releases/tag/16.4.0) and above you must use the [attachTo](../options.md#attachto) option when mounting the component. This is because a bug fix in [jsdom v16.4.0](https://github.com/jsdom/jsdom/releases/tag/16.4.0) changed `el.focus()` to do nothing on elements that are disconnected from the DOM.
+:::
+
 - **Setting the event target:**
 
 Under the hood, `trigger` creates an `Event` object and dispatches the event on the Wrapper element.


### PR DESCRIPTION
Per https://github.com/vuejs/vue-test-utils/pull/1777#issuecomment-840938988 this PR adds a tip to the documentation about how `attachTo` is needed when using `trigger('focus')` with jsdom v16.4.0 and above

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Docs

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [-] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

https://github.com/vuejs/vue-test-utils/pull/1777#issuecomment-840938988
