### PR TITLE
[WIP] fix #1839: props comparison regression

### DIFF
--- a/test/specs/wrapper/props.spec.js
+++ b/test/specs/wrapper/props.spec.js
@@ -112,7 +112,7 @@ describeWithShallowAndMount('props', mountingMethod => {
     const TestComponent = {
       template: `
           <div>
-            {{ array }}
+            {{ keys }}
           </div>'
         `,
       props: {

--- a/test/specs/wrapper/props.spec.js
+++ b/test/specs/wrapper/props.spec.js
@@ -113,7 +113,7 @@ describeWithShallowAndMount('props', mountingMethod => {
       template: `
           <div>
             {{ keys }}
-          </div>'
+          </div>
         `,
       props: {
         keys: {

--- a/test/specs/wrapper/props.spec.js
+++ b/test/specs/wrapper/props.spec.js
@@ -5,6 +5,7 @@ import {
   functionalSFCsSupported
 } from '~resources/utils'
 import { itSkipIf } from 'conditional-specs'
+import { deepStrictEqual } from 'assert'
 
 describeWithShallowAndMount('props', mountingMethod => {
   it('returns true if wrapper has prop', () => {
@@ -105,5 +106,73 @@ describeWithShallowAndMount('props', mountingMethod => {
       propsData: { prop1, prop2 }
     })
     expect(wrapper.props('propNotHere')).toEqual(undefined)
+  })
+
+  it('returns true on the props comparison', () => {
+    const TestComponent = {
+      template: `
+          <div>
+            {{ array }}
+          </div>'
+        `,
+      props: {
+        keys: {
+          type: Array,
+          required: true
+        }
+      },
+      name: 'test-component'
+    }
+    const wrapper = mountingMethod(TestComponent, {
+      propsData: { keys: ['Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P'] }
+    })
+    expect(wrapper.props('keys')).toEqual([
+      'Q',
+      'W',
+      'E',
+      'R',
+      'T',
+      'Y',
+      'U',
+      'I',
+      'O',
+      'P'
+    ])
+    expect(wrapper.vm.$props.keys).toEqual([
+      'Q',
+      'W',
+      'E',
+      'R',
+      'T',
+      'Y',
+      'U',
+      'I',
+      'O',
+      'P'
+    ])
+    deepStrictEqual(wrapper.props('keys'), [
+      'Q',
+      'W',
+      'E',
+      'R',
+      'T',
+      'Y',
+      'U',
+      'I',
+      'O',
+      'P'
+    ])
+    deepStrictEqual(wrapper.vm.$props.keys, [
+      'Q',
+      'W',
+      'E',
+      'R',
+      'T',
+      'Y',
+      'U',
+      'I',
+      'O',
+      'P'
+    ])
   })
 })


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch.
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**

As mentioned in the issue https://github.com/vuejs/vue-test-utils/issues/1839, when using the `assert` library, the props comparison that previously worked in 1.1.2 stopped working in 1.1.3. The tests added in this PR fail, however if adding them to the version 1.1.2, they work.

Tests made:
1. Run `yarn run test:unit` -> FAIL
2. Checkout to v.1.1.3 (porting the tests) and run `yarn run test:unit` -> FAIL
3. Checkout to v.1.1.2 (porting the tests) and run `yarn run test:unit` -> SUCCESS

I still don't know what caused this behaviour, but its not something related to `assert` since I maintained the same node version and dependencies installed.
