### PR TITLE
fix #1725: Updates attachToDocument documentation tip

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -336,15 +336,12 @@ wrapper.destroy()
 `attachToDocument` is deprecated and will be removed in future releases. Use [`attachTo`](#attachto) instead. For example, if you need to attach the component to the document.body:
 
 ```js
-const elem = document.createElement('div')
-if (document.body) {
-  document.body.appendChild(elem)
-}
 wrapper = mount(Component, {
-  attachTo: elem
+  attachTo: document.body
 })
 ```
 
+For more information, see [`attachTo`](#attachto)'s tip above.
 :::
 
 Like [`attachTo`](#attachto), but automatically creates a new `div` element for you and inserts it into the body.


### PR DESCRIPTION
Closes #1725

Updates  attachToDocument documentation tip from the div boilerplate from #1584 & #1611 to the new handling from #1578 & #1699

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Documentation update

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**

Updates  attachToDocument documentation tip from the div boilerplate from #1584 & #1611 to the new handling from #1578 & #1699