### PR TITLE
fix #1845: add functional component check in component name match

### DIFF
--- a/packages/test-utils/src/matches.js
+++ b/packages/test-utils/src/matches.js
@@ -3,16 +3,20 @@ import {
   COMPONENT_SELECTOR,
   FUNCTIONAL_OPTIONS
 } from 'shared/consts'
-import { isConstructor } from 'shared/validators'
+import { isConstructor, isFunctionalComponent } from 'shared/validators'
 import { capitalize, camelize } from 'shared/util'
 
 function vmMatchesName(vm, name) {
   // We want to mirror how Vue resolves component names in SFCs:
   // For example, <test-component />, <TestComponent /> and `<testComponent />
   // all resolve to the same component
-  const componentName = vm.name || (vm.$options && vm.$options.name) || ''
+  const componentName = isFunctionalComponent(vm)
+    ? vm.name
+    : vm.$options && vm.$options.name
+
   return (
     !!name &&
+    !!componentName &&
     (componentName === name ||
       // testComponent -> TestComponent
       componentName === capitalize(name) ||

--- a/test/resources/components/component-with-name-prop.vue
+++ b/test/resources/components/component-with-name-prop.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>
+    <p class="prop-name">{{ name }}</p>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'component-with-name-prop',
+  props: ['name']
+}
+</script>

--- a/test/specs/wrapper/find.spec.js
+++ b/test/specs/wrapper/find.spec.js
@@ -3,6 +3,7 @@ import { createLocalVue, shallowMount } from 'packages/test-utils/src'
 import Vue from 'vue'
 import VueRouter from 'vue-router'
 import ComponentWithChild from '~resources/components/component-with-child.vue'
+import ComponentWithNameProp from '~resources/components/component-with-name-prop.vue'
 import ComponentWithoutName from '~resources/components/component-without-name.vue'
 import ComponentWithSlots from '~resources/components/component-with-slots.vue'
 import ComponentWithVFor from '~resources/components/component-with-v-for.vue'
@@ -554,6 +555,15 @@ describeWithShallowAndMount('find', mountingMethod => {
     }
     const wrapper = mountingMethod(component)
     expect(wrapper.find({ name: 'CamelCase' }).name()).toEqual('camel-case')
+  })
+
+  it('returns a Wrapper matching a component name if Component has a name prop', () => {
+    const wrapper = mountingMethod(ComponentWithNameProp, {
+      propsData: { name: 'prop1' }
+    })
+    expect(
+      wrapper.findComponent({ name: 'component-with-name-prop' }).vnode
+    ).toBeTruthy()
   })
 
   it('returns Wrapper of Vue Component matching the ref in options object', () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

The following PR introduced a bug for finding components that contain a name prop themselves: https://github.com/vuejs/vue-test-utils/commit/3cd81d0593f56034b96f368d8ab066a855e0b204#diff-80ab213bfb0eeafc02c6f0005a492f52eab27ef052d46ed9e17c5df0da4eefe1

This PR fixes that behaviour by only using `vm.name` if the component is functional

This should fix the following issues:
Resolves #1820
Resolves #1845
Resolves #1854

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
