### PR TITLE
[Doc] Typo in findAllComponents page

### DIFF
--- a/docs/api/wrapper/findAllComponents.md
+++ b/docs/api/wrapper/findAllComponents.md
@@ -19,5 +19,5 @@ const wrapper = mount(Foo)
 const bar = wrapper.findAllComponents(Bar).at(0)
 expect(bar.exists()).toBeTruthy()
 const bars = wrapper.findAllComponents(Bar)
-expect(bar).toHaveLength(1)
+expect(bars).toHaveLength(1)
 ```


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

It seems that there is a typo on what is checked for the findAllComponents example : since we findAllComponents bar, the .toHaveLength() seems to have been meant for the "bars" variable instead of the "bar" variable.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Documentation

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
