### PR TITLE
feat: add generic for wrapper.find() and wrapper.get()

### DIFF
--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -96,7 +96,7 @@ export interface Wrapper<V extends Vue | null, el extends Element = Element> ext
   find<R extends Vue> (selector: VueClass<R>): Wrapper<R>
   find<R extends Vue> (selector: ComponentOptions<R>): Wrapper<R>
   find<Props = DefaultProps, PropDefs = PropsDefinition<Props>>(selector: FunctionalComponentOptions<Props, PropDefs>): Wrapper<Vue>
-  find<el extends Element>(selector: string): Wrapper<Vue>
+  find<el extends Element>(selector: string): Wrapper<Vue, el>
   find (selector: RefSelector): Wrapper<Vue>
   find (selector: NameSelector): Wrapper<Vue>
 

--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -75,7 +75,7 @@ interface BaseWrapper {
   selector: Selector | void
 }
 
-export interface Wrapper<V extends Vue | null, el extends HTMLElement = HTMLElement> extends BaseWrapper {
+export interface Wrapper<V extends Vue | null, el extends Element = Element> extends BaseWrapper {
   readonly vm: V
   readonly element: el
   readonly options: WrapperOptions
@@ -83,7 +83,7 @@ export interface Wrapper<V extends Vue | null, el extends HTMLElement = HTMLElem
   get<R extends Vue> (selector: VueClass<R>): Wrapper<R>
   get<R extends Vue> (selector: ComponentOptions<R>): Wrapper<R>
   get<Props = DefaultProps, PropDefs = PropsDefinition<Props>>(selector: FunctionalComponentOptions<Props, PropDefs>): Wrapper<Vue>
-  get<el extends HTMLElement>(selector: string): Wrapper<Vue, el>
+  get<el extends Element>(selector: string): Wrapper<Vue, el>
   get (selector: RefSelector): Wrapper<Vue>
   get (selector: NameSelector): Wrapper<Vue>
 
@@ -96,7 +96,7 @@ export interface Wrapper<V extends Vue | null, el extends HTMLElement = HTMLElem
   find<R extends Vue> (selector: VueClass<R>): Wrapper<R>
   find<R extends Vue> (selector: ComponentOptions<R>): Wrapper<R>
   find<Props = DefaultProps, PropDefs = PropsDefinition<Props>>(selector: FunctionalComponentOptions<Props, PropDefs>): Wrapper<Vue>
-  find<el extends HTMLElement>(selector: string): Wrapper<Vue>
+  find<el extends Element>(selector: string): Wrapper<Vue>
   find (selector: RefSelector): Wrapper<Vue>
   find (selector: NameSelector): Wrapper<Vue>
 

--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -75,15 +75,15 @@ interface BaseWrapper {
   selector: Selector | void
 }
 
-export interface Wrapper<V extends Vue | null> extends BaseWrapper {
+export interface Wrapper<V extends Vue | null, el extends HTMLElement = HTMLElement> extends BaseWrapper {
   readonly vm: V
-  readonly element: HTMLElement
+  readonly element: el
   readonly options: WrapperOptions
 
   get<R extends Vue> (selector: VueClass<R>): Wrapper<R>
   get<R extends Vue> (selector: ComponentOptions<R>): Wrapper<R>
   get<Props = DefaultProps, PropDefs = PropsDefinition<Props>>(selector: FunctionalComponentOptions<Props, PropDefs>): Wrapper<Vue>
-  get (selector: string): Wrapper<Vue>
+  get<el extends HTMLElement>(selector: string): Wrapper<Vue, el>
   get (selector: RefSelector): Wrapper<Vue>
   get (selector: NameSelector): Wrapper<Vue>
 
@@ -96,7 +96,7 @@ export interface Wrapper<V extends Vue | null> extends BaseWrapper {
   find<R extends Vue> (selector: VueClass<R>): Wrapper<R>
   find<R extends Vue> (selector: ComponentOptions<R>): Wrapper<R>
   find<Props = DefaultProps, PropDefs = PropsDefinition<Props>>(selector: FunctionalComponentOptions<Props, PropDefs>): Wrapper<Vue>
-  find (selector: string): Wrapper<Vue>
+  find<el extends HTMLElement>(selector: string): Wrapper<Vue>
   find (selector: RefSelector): Wrapper<Vue>
   find (selector: NameSelector): Wrapper<Vue>
 

--- a/packages/test-utils/types/test/wrapper.ts
+++ b/packages/test-utils/types/test/wrapper.ts
@@ -68,6 +68,8 @@ selector = found.selector
 found = wrapper.find({ name: 'my-button' })
 selector = found.selector
 
+wrapper.find<HTMLInputElement>('input').element.value
+
 let array = wrapper.findAll('.bar')
 selector = array.selector
 array = wrapper.findAll(normalOptions)

--- a/packages/test-utils/types/test/wrapper.ts
+++ b/packages/test-utils/types/test/wrapper.ts
@@ -51,7 +51,7 @@ wrapper.findComponent(ClassComponent)
 wrapper.vm.foo
 wrapper.vm.$emit('event', 'arg')
 
-let el: HTMLElement = wrapper.element
+let el: Element = wrapper.element
 
 let selector: Selector | void
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ x] It's submitted to the `dev` branch.
- [x ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x ] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

fix: #1870 

This feature will allow to target already the need type of the Element e.g. SVGElement, HTMLElement or other

Example: 
```js
const input = wrapper.find<HTMLInputElement>('input')
console.log(input.element.value)
```