### PR TITLE
fix(test-utils): verify object not null for typeof

### DIFF
--- a/packages/server-test-utils/dist/vue-server-test-utils.js
+++ b/packages/server-test-utils/dist/vue-server-test-utils.js
@@ -1806,7 +1806,7 @@ function isDynamicComponent(c) {
 }
 
 function isComponentOptions(c) {
-  return typeof c === 'object' && (c.template || c.render)
+  return c !== null && typeof c === 'object' && (c.template || c.render)
 }
 
 function isFunctionalComponent(c) {

--- a/packages/shared/validators.js
+++ b/packages/shared/validators.js
@@ -89,7 +89,7 @@ export function isDynamicComponent(c: any) {
 }
 
 export function isComponentOptions(c: any) {
-  return typeof c === 'object' && (c.template || c.render)
+  return c !== null && typeof c === 'object' && (c.template || c.render)
 }
 
 export function isFunctionalComponent(c: any) {

--- a/packages/test-utils/dist/vue-test-utils.iife.js
+++ b/packages/test-utils/dist/vue-test-utils.iife.js
@@ -1953,7 +1953,7 @@ var VueTestUtils = (function (exports, Vue, vueTemplateCompiler) {
   }
 
   function isComponentOptions(c) {
-    return typeof c === 'object' && (c.template || c.render)
+    return c !== null && typeof c === 'object' && (c.template || c.render)
   }
 
   function isFunctionalComponent(c) {

--- a/packages/test-utils/dist/vue-test-utils.js
+++ b/packages/test-utils/dist/vue-test-utils.js
@@ -1957,7 +1957,7 @@ function isDynamicComponent(c) {
 }
 
 function isComponentOptions(c) {
-  return typeof c === 'object' && (c.template || c.render)
+  return c !== null && typeof c === 'object' && (c.template || c.render)
 }
 
 function isFunctionalComponent(c) {

--- a/packages/test-utils/dist/vue-test-utils.umd.js
+++ b/packages/test-utils/dist/vue-test-utils.umd.js
@@ -1956,7 +1956,7 @@
   }
 
   function isComponentOptions(c) {
-    return typeof c === 'object' && (c.template || c.render)
+    return c !== null && typeof c === 'object' && (c.template || c.render)
   }
 
   function isFunctionalComponent(c) {


### PR DESCRIPTION
Using vue-test-utils may cause several messages of the sort
```
[Vue warn]: Error in render: "TypeError: Cannot read property 'template' of null"
```

Such messages stemmed from the `isComponentOptions` method call. It
seems it received a null object and `typeof null` is object, so this
error propagates to users of the library.

This patch does not look for the reason a null object was sent in the
first place, but it avoids the error propagation.

close #1805