### PR TITLE
fix(types): Remove argument for `resetAutoDestroyState`

### DIFF
--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -202,6 +202,6 @@ export declare function createWrapper(node: Vue, options?: WrapperOptions): Wrap
 export declare function createWrapper(node: HTMLElement, options?: WrapperOptions): Wrapper<null>
 
 export declare function enableAutoDestroy(hook: (...args: any[]) => any): void
-export declare function resetAutoDestroyState(hook: (...args: any[]) => any): void
+export declare function resetAutoDestroyState(): void
 
 export declare let RouterLinkStub: VueClass<Vue>


### PR DESCRIPTION
`resetAutoDestroyState()` doesn't accept any arguments.

See: https://github.com/vuejs/vue-test-utils/blob/b4201332158ae2ad96611c953a88590c9da94154/packages/test-utils/src/auto-destroy.js#L9

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
