### PR TITLE
fix: restore chaining and CSS selectors for findComponent

### DIFF
--- a/docs/api/wrapper/findAllComponents.md
+++ b/docs/api/wrapper/findAllComponents.md
@@ -4,7 +4,7 @@ Returns a [`WrapperArray`](../wrapper-array/) of all matching Vue components.
 
 - **Arguments:**
 
-  - `{Component|ref|name} selector`
+  - `selector` Use any valid [selector](../selectors.md)
 
 - **Returns:** `{WrapperArray}`
 
@@ -21,3 +21,7 @@ expect(bar.exists()).toBeTruthy()
 const bars = wrapper.findAllComponents(Bar)
 expect(bars).toHaveLength(1)
 ```
+
+::: warning Usage with CSS selectors
+Using `findAllComponents` with CSS selector is subject to same limitations as [findComponent](api/wrapper/findComponent.md)
+:::

--- a/docs/api/wrapper/findComponent.md
+++ b/docs/api/wrapper/findComponent.md
@@ -4,7 +4,7 @@ Returns `Wrapper` of first matching Vue component.
 
 - **Arguments:**
 
-  - `{Component|ref|name} selector`
+  - `{Component|ref|string} selector`
 
 - **Returns:** `{Wrapper}`
 
@@ -24,3 +24,31 @@ expect(barByName.exists()).toBe(true)
 const barRef = wrapper.findComponent({ ref: 'bar' }) // => finds Bar by `ref`
 expect(barRef.exists()).toBe(true)
 ```
+
+::: warning Usage with CSS selectors
+Using `findAllComponents` with CSS selector might have confusing behavior
+
+Consider this example:
+
+```js
+const ChildComponent = {
+  name: 'Child',
+  template: '<div class="child"></div>'
+}
+
+const RootComponent = {
+  name: 'Root',
+  components: { ChildComponent },
+  template: '<child-component class="root" />'
+}
+
+const wrapper = mount(RootComponent)
+
+const rootByCss = wrapper.findComponent('.root') // => finds Root
+expect(rootByCss.vm.$options.name).toBe('Root')
+const childByCss = wrapper.findComponent('.child')
+expect(childByCss.vm.$options.name).toBe('Root') // => still Root
+```
+
+The reason for such behavior is that `RootComponent` and `ChildComponent` are sharing same DOM node and only first matching component is included for each unique DOM node
+:::

--- a/packages/shared/util.js
+++ b/packages/shared/util.js
@@ -111,3 +111,7 @@ export function warnDeprecated(method: string, fallback: string = '') {
     warn(msg)
   }
 }
+
+export function isVueWrapper(wrapper: Object) {
+  return wrapper.vm || wrapper.isFunctionalComponent
+}

--- a/test/specs/wrapper/find.spec.js
+++ b/test/specs/wrapper/find.spec.js
@@ -194,20 +194,33 @@ describeWithShallowAndMount('find', mountingMethod => {
     expect(wrapper.findComponent(Component).vnode).toBeTruthy()
   })
 
-  it('throws an error if findComponent selector is a CSS selector', () => {
-    const wrapper = mountingMethod(Component)
-    const message =
-      '[vue-test-utils]: findComponent requires a Vue constructor or valid find object. If you are searching for DOM nodes, use `find` instead'
-    const fn = () => wrapper.findComponent('#foo')
-    expect(fn).toThrow(message)
-  })
+  it('findComponent returns top-level component when multiple components are matching', () => {
+    const DeepNestedChild = {
+      name: 'DeepNestedChild',
+      template: '<div>I am deeply nested</div>'
+    }
+    const NestedChild = {
+      name: 'NestedChild',
+      components: { DeepNestedChild },
+      template: '<deep-nested-child class="in-child" />'
+    }
+    const RootComponent = {
+      name: 'RootComponent',
+      components: { NestedChild },
+      template: '<div><nested-child class="in-root"></nested-child></div>'
+    }
 
-  it('throws an error if findComponent is chained off a DOM element', () => {
-    const wrapper = mountingMethod(ComponentWithChild)
-    const message =
-      '[vue-test-utils]: You cannot chain findComponent off a DOM element. It can only be used on Vue Components.'
-    const fn = () => wrapper.find('span').findComponent('#foo')
-    expect(fn).toThrow(message)
+    const wrapper = mountingMethod(RootComponent, { stubs: { NestedChild } })
+
+    expect(wrapper.findComponent('.in-root').vm.$options.name).toEqual(
+      'NestedChild'
+    )
+
+    // someone might expect DeepNestedChild here, but
+    // we always return TOP component matching DOM element
+    expect(wrapper.findComponent('.in-child').vm.$options.name).toEqual(
+      'NestedChild'
+    )
   })
 
   it('allows using findComponent on functional component', () => {

--- a/test/specs/wrapper/setValue.spec.js
+++ b/test/specs/wrapper/setValue.spec.js
@@ -66,7 +66,7 @@ describeWithShallowAndMount('setValue', mountingMethod => {
   })
 
   if (process.env.TEST_ENV !== 'browser') {
-    it.only('sets element of multiselect value', async () => {
+    it('sets element of multiselect value', async () => {
       const wrapper = mountingMethod(ComponentWithInput)
       const select = wrapper.find('select.multiselect')
       await select.setValue(['selectA', 'selectC'])


### PR DESCRIPTION
This PR is basically two features from `vue-test-utils-next`:
- [feat(find): allow chaining find with findComponent](https://github.com/vuejs/vue-test-utils-next/pull/897)
- also it fixes https://github.com/vuejs/vue-test-utils-next/issues/904 (having this consistent across both VTU versions will be in great help for migration

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

