### PR TITLE
feat: make isVisible more comprehensive (backport from v2) (fix #1456)

### DIFF
--- a/packages/shared/is-visible.js
+++ b/packages/shared/is-visible.js
@@ -5,13 +5,20 @@
  */
 
 function isStyleVisible(element) {
-  const { display, visibility, opacity } = element.style
+  if (!(element instanceof HTMLElement) && !(element instanceof SVGElement)) {
+    return false
+  }
+
+  // Per https://lists.w3.org/Archives/Public/www-style/2018May/0031.html
+  // getComputedStyle should only work with connected elements.
+  const { display, visibility, opacity } = element.isConnected
+    ? getComputedStyle(element)
+    : element.style
   return (
     display !== 'none' &&
     visibility !== 'hidden' &&
     visibility !== 'collapse' &&
-    opacity !== '0' &&
-    opacity !== 0
+    opacity !== '0'
   )
 }
 

--- a/packages/shared/is-visible.js
+++ b/packages/shared/is-visible.js
@@ -18,7 +18,8 @@ function isStyleVisible(element) {
     display !== 'none' &&
     visibility !== 'hidden' &&
     visibility !== 'collapse' &&
-    opacity !== '0'
+    opacity !== '0' &&
+    opacity !== 0
   )
 }
 

--- a/test/specs/wrapper/isVisible.spec.js
+++ b/test/specs/wrapper/isVisible.spec.js
@@ -176,4 +176,19 @@ describeWithShallowAndMount('isVisible', mountingMethod => {
 
     expect(wrapper.find('.child.ready').isVisible()).toEqual(true)
   })
+
+  it('returns false if element has class with opacity: 0', async () => {
+    const style = document.createElement('style')
+    style.type = 'text/css'
+    document.head.appendChild(style)
+    style.sheet.insertRule('.opacity-0 { opacity: 0; }')
+
+    const compiled = compileToFunctions('<div id="my-div" class="opacity-0" />')
+    const wrapper = mountingMethod(compiled, {
+      attachTo: document.body
+    })
+    expect(wrapper.get('#my-div').isVisible()).toBe(false)
+
+    document.head.removeChild(style)
+  })
 })


### PR DESCRIPTION
Enhancement to isVisible to take all styling into account. This is a backport of https://github.com/vuejs/test-utils/pull/454.

One notable change between this and the version in v2 is that it only works on elements that are part of the DOM (part of an attached tree). This is due to getComputedStyle being defined as only working in that scenario, per https://lists.w3.org/Archives/Public/www-style/2018May/0031.html. Chrome and Safari match the spec, but other browsers (including jsdom) allow it to still work. v2 only runs under jsdom while v1 can run under Chrome, which is why I had to narrow it here to only work when the element is part of the DOM. I imagine someday jsdom will implement that behavior as well, in which case v2+ will need to function this way as well.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

CC @lmiller1990 