### PR TITLE
fix: stubs components inlined in render function

### DIFF
--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -9,10 +9,7 @@
           </p>
           <p>
             To read docs for Vue Test Utils for Vue 3,
-            <a
-              href="https://test-utils.vuejs.org/"
-              v-text="'click here'"
-            />.
+            <a href="https://test-utils.vuejs.org/" v-text="'click here'" />.
           </p>
         </div>
       </div>

--- a/packages/create-instance/create-component-stubs.js
+++ b/packages/create-instance/create-component-stubs.js
@@ -43,10 +43,10 @@ function resolveComponent(obj: Object, component: string): Object {
   )
 }
 
-function getCoreProperties(componentOptions: Component): Object {
+function getCoreProperties(componentOptions: Component, name?: string): Object {
   return {
     attrs: componentOptions.attrs,
-    name: componentOptions.name,
+    name: componentOptions.name || name,
     model: componentOptions.model,
     props: componentOptions.props,
     on: componentOptions.on,
@@ -108,7 +108,7 @@ export function createStubFromComponent(
   }
 
   return {
-    ...getCoreProperties(componentOptions),
+    ...getCoreProperties(componentOptions, name),
     $_vueTestUtils_original: originalComponent,
     $_doNotStubChildren: true,
     render(h, context) {

--- a/packages/create-instance/patch-create-element.js
+++ b/packages/create-instance/patch-create-element.js
@@ -68,8 +68,16 @@ export function patchCreateElement(_Vue, stubs, stubAllComponents) {
       }
 
       if (isConstructor(el) || isComponentOptions(el)) {
+        const componentOptions = isConstructor(el) ? el.options : el
+        const elName = componentOptions.name
+
+        const stubbedComponent = resolveComponent(elName, stubs)
+        if (stubbedComponent) {
+          return originalCreateElement(stubbedComponent, ...args)
+        }
+
         if (stubAllComponents) {
-          const stub = createStubFromComponent(el, el.name || 'anonymous', _Vue)
+          const stub = createStubFromComponent(el, elName || 'anonymous', _Vue)
           return originalCreateElement(stub, ...args)
         }
         const Constructor = shouldExtend(el, _Vue) ? extend(el, _Vue) : el

--- a/test/specs/mounting-options/stubs.spec.js
+++ b/test/specs/mounting-options/stubs.spec.js
@@ -704,4 +704,90 @@ describeWithShallowAndMount('options.stub', mountingMethod => {
         `</div>`
     )
   })
+
+  it('stubs component inlined in render function with custom stub', () => {
+    let childComponentCreated = false
+    let childComponent2Created = false
+    const ChildComponent = Vue.extend({
+      name: 'child-component',
+      template: '<div />',
+      created() {
+        childComponentCreated = true
+      }
+    })
+    const ChildComponent2 = {
+      name: 'child-component-2',
+      template: '<div />',
+      created() {
+        childComponent2Created = true
+      }
+    }
+
+    const ParentComponent = {
+      name: 'parent-component',
+      render(h) {
+        return h('div', [h(ChildComponent), h(ChildComponent2)])
+      }
+    }
+
+    const wrapper = mountingMethod(ParentComponent, {
+      stubs: {
+        ChildComponent: {
+          name: 'child-component',
+          template: '<div class="stub" />'
+        },
+        ChildComponent2: {
+          name: 'child-component-2',
+          template: '<div class="stub-2" />'
+        }
+      }
+    })
+
+    expect(childComponentCreated).toBe(false)
+    expect(childComponent2Created).toBe(false)
+
+    expect(wrapper.find('.stub').exists()).toBe(true)
+    expect(wrapper.find('.stub-2').exists()).toBe(true)
+    expect(wrapper.find(ChildComponent).exists()).toBe(true)
+    expect(wrapper.find(ChildComponent2).exists()).toBe(true)
+  })
+
+  it('stubs component inlined in render function with default stub', () => {
+    let childComponentCreated = false
+    let childComponent2Created = false
+    const ChildComponent = Vue.extend({
+      name: 'child-component',
+      template: '<div />',
+      created() {
+        childComponentCreated = true
+      }
+    })
+    const ChildComponent2 = {
+      name: 'child-component-2',
+      template: '<div />',
+      created() {
+        childComponent2Created = true
+      }
+    }
+
+    const ParentComponent = {
+      name: 'parent-component',
+      render(h) {
+        return h('div', [h(ChildComponent), h(ChildComponent2)])
+      }
+    }
+
+    const wrapper = mountingMethod(ParentComponent, {
+      stubs: {
+        ChildComponent: true,
+        ChildComponent2: true
+      }
+    })
+
+    expect(childComponentCreated).toBe(false)
+    expect(childComponent2Created).toBe(false)
+
+    expect(wrapper.find(ChildComponent).exists()).toBe(true)
+    expect(wrapper.find(ChildComponent2).exists()).toBe(true)
+  })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

You can see use case for this fix in tests - we need a way to stub components inlined in render function (currently it works only if a component registered in `components` section and its name provided in render function)

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included
