### PR TITLE
docs: Fix urls to test-utils v2

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -59,8 +59,8 @@ module.exports = {
             link: '/guides/',
             items: [
               {
-                text: '2.x-beta',
-                link: 'https://next.vue-test-utils.vuejs.org/guide/'
+                text: 'v2 (Vue.js 3)',
+                link: 'https://test-utils.vuejs.org/'
               }
             ]
           },
@@ -94,8 +94,8 @@ module.exports = {
             link: '/zh/guides/',
             items: [
               {
-                text: '2.x-beta',
-                link: 'https://next.vue-test-utils.vuejs.org/guide/'
+                text: 'v2 (Vue.js 3)',
+                link: 'https://test-utils.vuejs.org/'
               }
             ]
           }
@@ -125,8 +125,8 @@ module.exports = {
             link: '/ja/guides/',
             items: [
               {
-                text: '2.x-beta',
-                link: 'https://next.vue-test-utils.vuejs.org/guide/'
+                text: 'v2 (Vue.js 3)',
+                link: 'https://test-utils.vuejs.org/'
               }
             ]
           }
@@ -156,8 +156,8 @@ module.exports = {
             link: '/ru/guides/',
             items: [
               {
-                text: '2.x-beta',
-                link: 'https://next.vue-test-utils.vuejs.org/guide/'
+                text: 'v2 (Vue.js 3)',
+                link: 'https://test-utils.vuejs.org/'
               }
             ]
           }
@@ -187,9 +187,8 @@ module.exports = {
             link: '/fr/guides/',
             items: [
               {
-                text: '2.x-beta',
-                link:
-                  'https://vuejs.github.io/vue-test-utils-next-docs/guide/introduction.html'
+                text: 'v2 (Vue.js 3)',
+                link: 'https://test-utils.vuejs.org/'
               }
             ]
           }

--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -10,7 +10,7 @@
           <p>
             To read docs for Vue Test Utils for Vue 3,
             <a
-              href="https://next.vue-test-utils.vuejs.org/guide/"
+              href="https://test-utils.vuejs.org/"
               v-text="'click here'"
             />.
           </p>

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ This is the documentation for Vue Test Utils v1, which targets Vue 2 and earlier
 In short:
 
 - [Vue Test Utils 1](https://github.com/vuejs/vue-test-utils/) targets [Vue 2](https://github.com/vuejs/vue/).
-- [Vue Test Utils 2](https://github.com/vuejs/vue-test-utils-next/) targets [Vue 3](https://github.com/vuejs/vue-next/).
+- [Vue Test Utils 2](https://github.com/vuejs/test-utils) targets [Vue 3](https://github.com/vuejs/core).
 
 <div class="vueschool"><a href="https://vueschool.io/courses/learn-how-to-test-vuejs-components?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how to use Vue Test Utils to test Vue.js Components with Vue School">Learn how to test Vue.js components with Vue School</a></div>
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -7,7 +7,7 @@ Voici la documentation de Vue Test Utils v1, qui vise Vue 2 et les versions ant√
 En bref :
 
 - [Vue Test Utils 1](https://github.com/vuejs/vue-test-utils/) ciblant [Vue 2](https://github.com/vuejs/vue/).
-- [Vue Test Utils 2](https://github.com/vuejs/vue-test-utils-next/) ciblant [Vue 3](https://github.com/vuejs/vue-next/).
+- [Vue Test Utils 2](https://github.com/vuejs/test-utils) ciblant [Vue 3](https://github.com/vuejs/core).
 
   <div class="vueschool"><a href="https://vueschool.io/courses/learn-how-to-test-vuejs-components?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how to use Vue Test Utils to test Vue.js Components with Vue School">Apprenez comment tester les composants de Vue.js avec Vue School</a></div>
 

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -1,7 +1,7 @@
 # 介绍
 
 ::: warning
-本文档基于 Vue2.x，新版本文档请移步至[这里](https://next.vue-test-utils.vuejs.org/guide/)
+本文档基于 Vue2.x，新版本文档请移步至[这里](https://test-utils.vuejs.org/)
 :::
 
 Vue Test Utils 是 Vue.js 官方的单元测试实用工具库。


### PR DESCRIPTION
Fix wrong urls to test-utils v2 docs

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe: Docs

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
