### PR TITLE
fix: update exports and use cjs as default

### DIFF
--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -6,11 +6,9 @@
   "module": "dist/vue-test-utils.esm.js",
   "exports": {
     ".": {
-      "import": {
-        "node": "./dist/vue-test-utils.js",
-        "require": "./dist/vue-test-utils.js",
-        "default": "./dist/vue-test-utils.esm.js"
-      }
+      "default": "./dist/vue-test-utils.js",
+      "require": "./dist/vue-test-utils.js",
+      "import": "./dist/vue-test-utils.esm.js"
     }
   },
   "types": "types/index.d.ts",


### PR DESCRIPTION
Revert breaking change in https://github.com/vuejs/vue-test-utils/pull/1990 where ESM was made the default, breaking CJS.