### PR TITLE
fix: move exports default condition to last

### DIFF
--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -6,9 +6,9 @@
   "module": "dist/vue-test-utils.esm.js",
   "exports": {
     ".": {
-      "default": "./dist/vue-test-utils.js",
       "require": "./dist/vue-test-utils.js",
-      "import": "./dist/vue-test-utils.esm.js"
+      "import": "./dist/vue-test-utils.esm.js",
+      "default": "./dist/vue-test-utils.js"
     }
   },
   "types": "types/index.d.ts",


### PR DESCRIPTION
Parent issue: https://github.com/vuejs/vue-test-utils/issues/2022
Moved the exports default condition to be last.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
