### PR TITLE
docs: update deprecation warning for find method in Japanese translation

### DIFF
--- a/docs/ja/api/wrapper/find.md
+++ b/docs/ja/api/wrapper/find.md
@@ -1,7 +1,8 @@
 ## find(selector)
 
 ::: warning Deprecation warning
-コンポーネントの検索に `find` を使用することは非推奨となり、削除される予定です。代わりに `findComponent` を使用してください。
+コンポーネントの検索に `find` を使用することは非推奨となり、削除される予定です。代わりに [`findComponent`](./findComponent.md) を使用してください。
+コンポーネントではなく有効な [selector](../selectors.md) を引数にする場合は、引き続き `find` でコンポーネントを検索できます。
 :::
 
 最初の DOM ノードの Wrapper、またはセレクタで一致した Vue コンポーネントを返します。

--- a/docs/ja/api/wrapper/findAll.md
+++ b/docs/ja/api/wrapper/findAll.md
@@ -2,6 +2,7 @@
 
 ::: warning Deprecation warning
 `findAll` を使用してコンポーネントを検索することは非推奨となり、削除される予定です。代わりに `findAllComponents` を使用してください。
+コンポーネントではなく有効な [selector](../selectors.md) を引数にする場合は、今後も `findAll` でコンポーネントを検索できます。
 :::
 
 [`WrapperArray`](../wrapper-array/)を返します。


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

In the Japanese translation for `find` and `findAll`, deprecation warnings do not mention that we can still use these methods when we pass selectors.

Below is the English version of the corresponding documentation.

https://github.com/vuejs/vue-test-utils/blob/dev/docs/api/wrapper/find.md
https://github.com/vuejs/vue-test-utils/blob/dev/docs/api/wrapper/findAll.md

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
