### PR TITLE
fix: add typescript 5 compatible types field

### DIFF
--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -6,7 +6,7 @@
   "module": "dist/vue-test-utils.esm.js",
   "exports": {
     ".": {
-      "types": "types/index.d.ts",
+      "types": "./types/index.d.ts",
       "require": "./dist/vue-test-utils.js",
       "import": "./dist/vue-test-utils.esm.js",
       "default": "./dist/vue-test-utils.js"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -6,6 +6,7 @@
   "module": "dist/vue-test-utils.esm.js",
   "exports": {
     ".": {
+      "types": "types/index.d.ts",
       "require": "./dist/vue-test-utils.js",
       "import": "./dist/vue-test-utils.esm.js",
       "default": "./dist/vue-test-utils.js"


### PR DESCRIPTION
Typescript 5 appears to require a "types" entry in each exports entry even though there is a "types" entry at the root of the package.json

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch.
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
