### PR TITLE
fix: make scoped slots rendering consistent for stubs

### DIFF
--- a/packages/create-instance/create-component-stubs.js
+++ b/packages/create-instance/create-component-stubs.js
@@ -77,16 +77,8 @@ function getScopedSlotRenderFunctions(ctx: any): Array<string> {
   // In Vue 2.6+ a new v-slot syntax was introduced
   // scopedSlots are now saved in parent._vnode.data.scopedSlots
   // We filter out _normalized, $stable and $key keys
-  if (
-    ctx &&
-    ctx.$options &&
-    ctx.$options.parent &&
-    ctx.$options.parent._vnode &&
-    ctx.$options.parent._vnode.data &&
-    ctx.$options.parent._vnode.data.scopedSlots
-  ) {
-    const slotKeys: Array<string> = ctx.$options.parent._vnode.data.scopedSlots
-    return keys(slotKeys).filter(
+  if (ctx.$vnode.data.scopedSlots) {
+    return keys(ctx.$vnode.data.scopedSlots).filter(
       x => x !== '_normalized' && x !== '$stable' && x !== '$key'
     )
   }
@@ -130,9 +122,15 @@ export function createStubFromComponent(
         context
           ? context.children
           : this.$options._renderChildren ||
-              getScopedSlotRenderFunctions(this).map(x =>
-                this.$options.parent._vnode.data.scopedSlots[x]({})
-              )
+              getScopedSlotRenderFunctions(this)
+                .map(x => {
+                  let result = null
+                  try {
+                    result = this.$vnode.data.scopedSlots[x]({})
+                  } catch (e) {}
+                  return result
+                })
+                .filter(Boolean)
       )
     }
   }

--- a/test/specs/shallow-mount.spec.js
+++ b/test/specs/shallow-mount.spec.js
@@ -164,6 +164,38 @@ describeRunIf(process.env.TEST_ENV !== 'node', 'shallowMount', () => {
     )
   })
 
+  it('renders named slots with v-slot syntax when they are wrapped', () => {
+    const localVue = createLocalVue()
+    localVue.component('Foo', {
+      template: '<div><slot name="newSyntax" /></div>'
+    })
+    const TestComponent = {
+      template: `
+        <div>
+          <Foo>
+            <template v-slot:newSyntax>
+              <p class="new-example">text</p>
+            </template>
+          </Foo>
+        </div>
+      `
+    }
+    const wrapper = shallowMount(TestComponent, {
+      localVue
+    })
+    expect(wrapper.find({ name: 'Foo' }).exists()).toEqual(true)
+    expect(wrapper.find('.new-example').exists()).toEqual(true)
+    expect(wrapper.html()).toEqual(
+      [
+        '<div>',
+        '  <foo-stub>',
+        '    <p class="new-example">text</p>',
+        '  </foo-stub>',
+        '</div>'
+      ].join('\n')
+    )
+  })
+
   it('renders named slots when they are located inside component with v-if', () => {
     const localVue = createLocalVue()
     localVue.component('Foo', {


### PR DESCRIPTION
This MR fixes extremely weird stubbing behavior. Currently scoped slot stubs will be rendered **only** for components, which are located at root level of other component. Basically:

```html
<some-cmp>foo</some-cmp>
```
will have scoped slots rendered on stub, while

```html
<div><some-cmp>foo</some-cmp>
````

will have only default slot rendered. 
This is caused because slot lookup was performed on **parent** instead of instance itself

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

This is definitely a breaking change: now we try to render more scoped slots than before. Basically, that means that some tests which rely that slots were not previously rendered will fail. However, I see this definitely a better thing than current confusing approach

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
