### PR TITLE
docs(guides): format headline for `Using with Vuex`

### DIFF
--- a/docs/guides/using-with-vuex.md
+++ b/docs/guides/using-with-vuex.md
@@ -1,10 +1,8 @@
-# Using with Vuex
+## Using with Vuex
 
 In this guide, we'll see how to test Vuex in components with Vue Test Utils, and how to approach testing a Vuex store.
 
 <div class="vueschool"><a href="https://vueschool.io/lessons/how-to-test-vuejs-component-with-vuex-store?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how to test that a Vuex Store is injected into a component with a free video lesson on Vue School">Learn how to test that a Vuex Store is injected into a component with Vue School</a></div>
-
-## Testing Vuex in components
 
 ### Mocking Actions
 


### PR DESCRIPTION
Format headline "Using with Vuex" as h2 to list it within the sidebar navigation in a wording like "Using with TypeScript" and "Using with Vue Router" for better readability

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Formatting the docs about "Using with Vuex"

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup

