### PR TITLE
fix #2108 Options `provide` should allow symbol keys

### DIFF
--- a/packages/test-utils/types/index.d.ts
+++ b/packages/test-utils/types/index.d.ts
@@ -180,7 +180,7 @@ export interface VueTestUtilsConfigOptions {
   stubs: Record<string, Component | boolean | string>
   mocks: Record<string, any>
   methods: Record<string, Function>
-  provide?: Record<string, any>,
+  provide?: Record<string | symbol, any>,
   showDeprecationWarnings?: boolean
   deprecationWarningHandler?: Function
 }

--- a/packages/test-utils/types/test/mount.ts
+++ b/packages/test-utils/types/test/mount.ts
@@ -99,7 +99,7 @@ config.stubs = {
 }
 config.stubs['quuux'] = true
 config.mocks = {
-  foo: 'bar',
+  foo: 'bar'
 }
 config.mocks['foo'] = {
   bar: 'baz'
@@ -109,8 +109,10 @@ config.methods = {
 }
 config.methods['foo'] = () => true
 config.provide = {
-  foo: {}
+  foo: {},
+  [Symbol('injection key')]: {}
 }
+
 config.provide['foo'] = {
   bar: {}
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue-test-utils/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**

Fixes #2108 
